### PR TITLE
130635935(sub-task) Implement filter with automation status

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -24,6 +24,8 @@
   },
   "rules": {
     "react/prefer-stateless-function": 0,
-    "react/forbid-prop-types": 0
+    "react/forbid-prop-types": 0,
+    "jsx-a11y/click-events-have-key-events": 0,
+    "jsx-a11y/no-static-element-interactions": 0
   }
 }

--- a/src/components/Filter/index.jsx
+++ b/src/components/Filter/index.jsx
@@ -1,0 +1,78 @@
+import React, { PureComponent } from 'react';
+import classNames from 'classnames';
+import PropTypes from 'proptypes';
+import './styles.scss';
+
+class Filter extends PureComponent {
+  state = {
+    filterOptionsIsVisible: false,
+    selectedFilters: [],
+  }
+
+  toggleVisibility = () => {
+    const { filterOptionsIsVisible } = this.state;
+    this.setState({ filterOptionsIsVisible: !filterOptionsIsVisible });
+  }
+
+  selectFilter = (event) => {
+    const { selectedFilters } = this.state;
+    const { handleFilterChange } = this.props;
+    const filter = event.target.value;
+    if (selectedFilters.includes(filter)) {
+      const selectedFiltersToMutate = [...selectedFilters];
+      selectedFiltersToMutate.splice(selectedFilters.indexOf(filter), 1);
+      this.setState({
+        selectedFilters: selectedFiltersToMutate,
+      });
+      handleFilterChange(filter, 'remove_filter');
+    } else {
+      this.setState({
+        selectedFilters: [...selectedFilters, event.target.value],
+      });
+      handleFilterChange(filter, 'add_filter');
+    }
+  }
+
+  renderFilterOptions() {
+    const { options } = this.props;
+    const { filterOptionsIsVisible } = this.state;
+    return (
+      <ul
+        className={classNames('filter-options', { 'filter-options-isvisible': filterOptionsIsVisible })}
+      >
+        {
+          options.map(option => (
+            <li key={option.id}>
+              <input type="checkbox" value={option.value} onChange={this.selectFilter} />
+              <span>{option.text}</span>
+            </li>
+          ))
+        }
+      </ul>
+    );
+  }
+
+  render() {
+    const { title } = this.props;
+    const { filterOptionsIsVisible } = this.state;
+    return (
+      <div className="filter">
+        <div className="filter-title" onClick={this.toggleVisibility}>
+          <span className="title">{title}</span>
+          <i
+            className={classNames('fa fa-angle-down', { 'rotate-180': filterOptionsIsVisible })}
+          />
+        </div>
+        {this.renderFilterOptions()}
+      </div>
+    );
+  }
+}
+
+Filter.propTypes = {
+  title: PropTypes.string.isRequired,
+  options: PropTypes.array.isRequired,
+  handleFilterChange: PropTypes.func.isRequired,
+};
+
+export default Filter;

--- a/src/components/Filter/styles.scss
+++ b/src/components/Filter/styles.scss
@@ -1,0 +1,48 @@
+.filter {
+  position: relative;
+  display: inline-block;
+  font-size: 14px;
+  text-transform: capitalize;
+  .filter-title {
+    padding: 8px 15px 8px 15px;
+    border: 1px solid grey;
+    text-align: center;
+    color: #4d4d4d;
+    cursor: pointer;
+    &:hover {
+      color: black;
+    }
+    i {
+      margin-left: 10px;
+      font-size: 20px;
+      transition: all 0.3s;
+      &.rotate-180 {
+        transform: rotate(180deg);
+      }
+    }
+  }
+
+  .filter-options {
+    opacity: 0;
+    display: block;
+    position: absolute;
+    width: 100%;
+    border-radius: 3px;
+    background-color: white;
+    box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
+    li {
+      border-bottom: 1px solid #d9d9d9;
+      padding: 5px;
+      input[type=checkbox] {
+        margin-right: 10px;
+      }
+    }
+    li:last-child {
+      border-bottom: none;
+    }
+    transition: all 0.3s;
+    &.filter-options-isvisible {
+      opacity: 1;
+    }
+  }
+}

--- a/src/components/ReportPage/styles.scss
+++ b/src/components/ReportPage/styles.scss
@@ -1,6 +1,5 @@
 #report-page {
   padding: 0 30px 0 30px;
-  font-family: 'Open Sans', sans-serif;
   .table-header table {
     margin-top: 15px;
     thead tr {
@@ -55,6 +54,19 @@
     }
     .numbering {
       width: 40px;
+    }
+  }
+  .filter-box {
+    height: 15vh;
+    margin-top: 15px;
+    padding: 15px;
+    box-shadow: rgba(0, 0, 0, 0.12) 0px 1px 3px, rgba(0, 0, 0, 0.12) 0px 1px 2px;
+    background-color: rgb(248, 249, 251);
+
+    p {
+      font-size: 18px;
+      margin-bottom: 5px;
+      line-height: 45px;
     }
   }
 }

--- a/src/components/constants.js
+++ b/src/components/constants.js
@@ -1,0 +1,26 @@
+export const SUCCESSFUL_AUTOMATIONS = 'SUCCESSFUL_AUTOMATIONS';
+export const FAILED_AUTOMATIONS = 'FAILED_AUTOMATIONS';
+export const SUCCESSFUL_SLACK_AUTOMATIONS = 'SUCCESSFUL_SLACK_AUTOMATIONS';
+export const SUCCESSFUL_EMAIL_AUTOMATIONS = 'SUCCESSFUL_EMAIL_AUTOMATIONS';
+export const SUCCESSFUL_FRECKLE_AUTOMATIONS = 'SUCCESSFUL_FRECKLE_AUTOMATIONS';
+export const FAILED_SLACK_AUTOMATIONS = 'FAILED_SLACK_AUTOMATIONS';
+export const FAILED_EMAIL_AUTOMATIONS = 'FAILED_EMAIL_AUTOMATIONS';
+export const FAILED_FRECKLE_AUTOMATIONS = 'FAILED_FRECKLE_AUTOMATIONS';
+
+
+export const filters = [
+  {
+    id: 1,
+    title: 'Automation Status',
+    options: [
+      { id: 1, text: 'Failed Automations', value: FAILED_AUTOMATIONS },
+      { id: 2, text: 'Successful Automations', value: SUCCESSFUL_AUTOMATIONS },
+      { id: 3, text: 'Failed Slack Automations', value: FAILED_SLACK_AUTOMATIONS },
+      { id: 4, text: 'Failed Email Automation', value: FAILED_EMAIL_AUTOMATIONS },
+      { id: 5, text: 'Failed Freckle Automation', value: FAILED_FRECKLE_AUTOMATIONS },
+      { id: 6, text: 'Successful Slack Automations', value: SUCCESSFUL_SLACK_AUTOMATIONS },
+      { id: 7, text: 'Successful Email Automation', value: SUCCESSFUL_EMAIL_AUTOMATIONS },
+      { id: 8, text: 'Successful Freckle Automation', value: SUCCESSFUL_FRECKLE_AUTOMATIONS },
+    ],
+  },
+];

--- a/src/index.css
+++ b/src/index.css
@@ -199,3 +199,10 @@ table .report_table, th, td {
     color: white;
 }
 
+.contaienr {
+    padding: 0 30px 0 30px;
+}
+
+* {
+    font-family: 'Open Sans', sans-serif;
+}

--- a/src/mocks/mockReport.js
+++ b/src/mocks/mockReport.js
@@ -21,10 +21,10 @@ export default [
     partnerName: 'ESA',
     type: 'Onboarding',
     slackAutomation: {
-      success: true,
+      success: false,
     },
     freckleAutomation: {
-      success: false,
+      success: true,
     },
     emailAutomation: {
       success: true,
@@ -40,10 +40,10 @@ export default [
       success: true,
     },
     freckleAutomation: {
-      success: false,
+      success: true,
     },
     emailAutomation: {
-      success: true,
+      success: false,
     },
     date: '2017-09-29 01:22',
   },
@@ -56,7 +56,7 @@ export default [
       success: true,
     },
     freckleAutomation: {
-      success: false,
+      success: true,
     },
     emailAutomation: {
       success: true,
@@ -69,13 +69,13 @@ export default [
     partnerName: 'ESA',
     type: 'Onboarding',
     slackAutomation: {
-      success: true,
+      success: false,
     },
     freckleAutomation: {
       success: false,
     },
     emailAutomation: {
-      success: true,
+      success: false,
     },
     date: '2017-09-29 01:22',
   },
@@ -120,7 +120,7 @@ export default [
       success: true,
     },
     freckleAutomation: {
-      success: false,
+      success: true,
     },
     emailAutomation: {
       success: true,
@@ -133,13 +133,13 @@ export default [
     partnerName: 'ESA',
     type: 'Onboarding',
     slackAutomation: {
-      success: true,
+      success: false,
     },
     freckleAutomation: {
       success: false,
     },
     emailAutomation: {
-      success: true,
+      success: false,
     },
     date: '2017-09-29 01:22',
   },
@@ -168,10 +168,10 @@ export default [
       success: true,
     },
     freckleAutomation: {
-      success: false,
+      success: true,
     },
     emailAutomation: {
-      success: true,
+      success: false,
     },
     date: '2017-09-29 01:22',
   },
@@ -277,7 +277,7 @@ export default [
     partnerName: 'ESA',
     type: 'Onboarding',
     slackAutomation: {
-      success: true,
+      success: false,
     },
     freckleAutomation: {
       success: false,


### PR DESCRIPTION
#### What does this PR do?
- adds a reusable filter component
- use the filter component in the report page
- add a `constants.js` file to hold the filter types configuration
- alter the status of some of the automation in `mockReport.js`
#### Description of Task to be completed?
User should be able to filter automation reports with *automation status*
#### How should this be manually tested?

- Clone and set up the project using the instruction in the README.
- Use `$ git checkout ft-filter-report-with-status` to check out the branch containing the changes of this pull request
- Use `$ npm start` to start the application
- Visit `http://localhost:3000/` to see the report page.
- You should see the filter and also be able to interact with the different filter options

#### Any background context you want to provide?
- I ensured to make the filter component reusable so as to ease other filter implementation.
 
#### What are the relevant pivotal tracker stories?
#130635935
#### Screenshots (if appropriate)
![screen shot 2018-09-21 at 4 46 40 pm 2](https://user-images.githubusercontent.com/26048536/45891791-61614280-bdbe-11e8-90e4-dd478cb629c8.png)
<img width="1440" alt="screen shot 2018-09-21 at 4 46 40 pm" src="https://user-images.githubusercontent.com/26048536/45891817-6aeaaa80-bdbe-11e8-99ab-7f107f9d9420.png">

