### PR TITLE
feat(Automation details): Service automation details modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "babel-preset-react-app": "^3.1.1",
     "babel-runtime": "6.26.0",
     "bootstrap": "^4.1.2",
+    "jquery": "^1.9.1",
     "case-sensitive-paths-webpack-plugin": "2.1.1",
     "chalk": "1.1.3",
     "classnames": "^2.2.6",

--- a/src/__tests__/components/AutomationDetails.test.jsx
+++ b/src/__tests__/components/AutomationDetails.test.jsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import AutomationDetails from '../../components/AutomationDetails';
+import ReportPage from '../../components/ReportPage';
+
+const props = {
+  history: {},
+  currentUser: {
+    additionalUserInfo: { profile: { name: 'Kelvin', picture: 'ddff' } },
+  },
+  isModalOpen: false,
+  closeModal: jest.fn(),
+  modalType: 'slack',
+  modalContent: {
+    id: 1,
+    fellowName: 'Tunmise',
+    partnerName: 'Andela',
+    type: 'Onboarding',
+    slackAutomation: {
+      success: true,
+      slackChannels: [
+        {
+          slackChannel: 'andela-int',
+          type: 'Addition',
+          success: true,
+        },
+        {
+          slackChannel: 'andela',
+          type: 'Removal',
+          success: true,
+        },
+      ],
+    },
+    freckleAutomation: {
+      success: false,
+    },
+    emailAutomation: {
+      success: true,
+      email: [{
+        id: 1,
+        emailTo: 'Tunmise.ogunniyi@andela.com',
+        subject: 'Onboarding',
+        success: true,
+      },
+      {
+        id: 2,
+        emailTo: 'Tunmise.ogunniyi@andela.com',
+        subject: 'Onboarding',
+        success: true,
+      },
+      ],
+    },
+    date: '2017-09-29 01:22',
+  },
+};
+
+const getComponent = () => shallow(<AutomationDetails {...props} />);
+
+describe('Automation details', () => {
+  it('should render slack details', () => {
+    expect(getComponent()).toMatchSnapshot();
+  });
+
+  it('should render email details', () => {
+    const component = getComponent();
+    component.setProps({
+      modalType: 'email',
+    });
+    expect(getComponent()).toMatchSnapshot();
+    expect(component.find('.table-body-details')).toBeTruthy();
+  });
+
+  it('should render freckle details', () => {
+    const component = getComponent();
+    component.setProps({
+      modalType: 'freckle',
+    });
+    expect(getComponent()).toMatchSnapshot();
+  });
+});
+
+describe('Automation details methods', () => {
+  it('should call the method closeModal', () => {
+    const component = mount(<ReportPage {...props} />);
+    const componentInstance = component.instance();
+    const spy = jest.spyOn(componentInstance, 'closeModal');
+    component.find('.fa.fa-info-circle.success').at(0).simulate('click');
+    component.find('.fas.fa-times').at(0).simulate('click');
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/__tests__/components/ReportPage.test.jsx
+++ b/src/__tests__/components/ReportPage.test.jsx
@@ -15,6 +15,16 @@ const sampleReports = [
     type: 'Onboarding',
     slackAutomation: {
       success: false,
+      slackChannels: [
+        {
+          slackChannel: 'andela-int',
+          type: 'Addition',
+        },
+        {
+          slackChannel: 'andela',
+          type: 'Removal',
+        },
+      ],
     },
     freckleAutomation: {
       success: false,
@@ -406,6 +416,26 @@ describe('<ReportPage />', () => {
       global.open = jest.fn();
       redirectToAIS.simulate('click');
       expect(global.open).toHaveBeenCalled();
+    });
+    it('should render a slack modal when the slack status icons are clicked', () => {
+      const component = getComponent();
+      component.setState({ reportData: sampleReports });
+      component.find('.fa.fa-info-circle.success').at(0).simulate('click');
+      expect(component.state('type')).toEqual('slack');
+    });
+
+    it('should render an email modal when the email status icons are clicked', () => {
+      const component = getComponent();
+      component.setState({ reportData: sampleReports });
+      component.find('.fa.fa-info-circle.success').at(1).simulate('click');
+      expect(component.state('type')).toEqual('email');
+    });
+
+    it('should render a freckle modal when the freckle status icons are clicked', () => {
+      const component = getComponent();
+      component.setState({ reportData: sampleReports });
+      component.find('.fa.fa-info-circle.success').at(2).simulate('click');
+      expect(component.state('type')).toEqual('freckle');
     });
   });
 });

--- a/src/components/AutomationDetails/index.jsx
+++ b/src/components/AutomationDetails/index.jsx
@@ -1,0 +1,120 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'proptypes';
+import './styles.scss';
+
+class AutomationDetails extends PureComponent {
+  renderAutomation = (status) => {
+    if (status) {
+      return <h4 className="modal-values">Success</h4>;
+    }
+    return <h4 className="modal-values">Failed</h4>;
+  }
+
+  renderModalDetails = (modalType, modalContent) => (
+    <div>
+      <h1 className="modal-title">
+        {modalType}
+        {' '}
+        Automation Details
+      </h1>
+      <div className="line">
+        <span className="long" />
+        <span className="short" />
+      </div>
+      {this.renderCommonDetails(modalContent, modalType)}
+      { (modalType === 'email' || modalType === 'slack') && this.renderModalTable(modalContent, modalType)}
+    </div>
+  );
+
+  renderCommonDetails = (modalContent, modalType) => (
+    <div className="flex-container">
+      <div className="modal-data">
+        <h2 className="modal-labels"> Developer Name:</h2>
+        <h4 className="modal-labels"> Partner Name:</h4>
+        <h4 className="modal-labels"> Date:</h4>
+        <h4 className="modal-labels"> Status:</h4>
+      </div>
+      <div className="modal-data">
+        <h4 className="modal-values">{modalContent.fellowName}</h4>
+        <h4 className="modal-values">{modalContent.partnerName}</h4>
+        <h4 className="modal-values">{modalContent.date}</h4>
+        {modalType === 'slack' && this.renderAutomation(modalContent.slackAutomation.success)}
+        {modalType === 'email' && this.renderAutomation(modalContent.emailAutomation.success)}
+        {modalType === 'freckle' && this.renderAutomation(modalContent.freckleAutomation.success)}
+      </div>
+    </div>
+  );
+
+  renderModalTable = (modalContent, modalType) => {
+    const contents = modalType === 'email' ? modalContent.emailAutomation.email : modalContent.slackAutomation.slackChannels;
+    return (
+      <div className="table-header-details">
+        <table className="details-table">
+          <thead>
+            <tr>
+              {modalType === 'email' ? <th>Sent to</th> : <th>Channel</th>}
+              {modalType === 'email' ? <th>Subject</th> : <th>Auto Type</th>}
+              <th>Status</th>
+            </tr>
+          </thead>
+        </table>
+        {contents.map(content => (
+          <div key={modalType === 'email' ? content.id : content.slackChannel} className="table-body-details">
+            <table className="details-table">
+              <tbody>
+                <tr>
+                  {this.renderTableData(content, modalType)}
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  renderTableData = (content, modalType) => {
+    let automationMedia = content.slackChannel;
+    let automationTitle = content.type;
+    if (modalType === 'email') {
+      automationMedia = content.emailTo;
+      automationTitle = content.subject;
+    }
+    return (
+      <React.Fragment>
+        <td>{automationMedia}</td>
+        <td>{automationTitle}</td>
+        {content.success ? <td>Success</td> : <td>Failed</td>}
+      </React.Fragment>
+    );
+  }
+
+  render() {
+    const {
+      isModalOpen,
+      closeModal,
+      modalContent,
+      modalType,
+    } = this.props;
+    const modalClass = isModalOpen ? 'modal-open' : 'modal-closed';
+    return (
+      <div className={modalClass}>
+        <div className="modal-overlay" onClick={closeModal} />
+        <div className={`modal-body ${modalType}`}>
+          <i className="fas fa-times" onClick={closeModal} />
+          {this.renderModalDetails(modalType, modalContent)}
+        </div>
+      </div>
+    );
+  }
+}
+
+AutomationDetails.propTypes = {
+  isModalOpen: PropTypes.bool.isRequired,
+  closeModal: PropTypes.func.isRequired,
+  modalContent: PropTypes.object.isRequired,
+  modalType: PropTypes.string.isRequired,
+
+};
+
+export default AutomationDetails;

--- a/src/components/AutomationDetails/styles.scss
+++ b/src/components/AutomationDetails/styles.scss
@@ -1,0 +1,127 @@
+.fas.fa-times{
+    padding-left: 95%;
+}
+
+.modal-open{
+    display: block;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    overflow: auto;
+    z-index: 1;
+}
+
+.modal-closed{
+    display: none;
+}
+
+.modal-overlay{
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0,0,0,0.7);
+}
+
+.modal-body{
+    position: fixed;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    width: 450px;
+    height: fit-content;
+    padding: 20px;
+    box-sizing: border-box;
+    background-color: #fff;
+    margin: 15% auto;
+    border-radius: 3px;
+    z-index: 2;
+    text-align: left;
+    box-shadow: 0 20px 30px rgba(0, 0, 0, 0.2);
+}
+.email{
+    width: 850px;
+}
+.modal-title{
+    font-family:  Helvetica;
+    font-weight: bold;
+    font-size: 20px;
+    padding-left: 7px;
+    text-transform: capitalize;
+}
+
+.line {
+    position: relative;
+    top: -0.25rem;
+    padding-left: 9px;
+    .long{
+        width: 40px;
+        margin-right: 10px;
+        height: 3px;
+        border-radius: 2.5px;
+        background-color: #3359db;
+        display: inline-block;
+    }
+    
+    .short{
+        width: 20px;
+        height: 3px;
+        border-radius: 2.5px;
+        background-color: #3359db;
+        display: inline-block;
+    }
+}
+
+.flex-container{
+    display: flex;
+    flex-wrap: nowrap;
+    margin: 8px;
+    .modal-data{
+        width: 100%;
+        text-align: left;
+        line-height: 10px;
+    }
+    .modal-labels{
+        font-display: Helvetica;
+        font-size: 14px;
+        font-weight: bold;
+        padding-bottom: 5px;
+    }
+    .modal-values{
+        font-display: Helvetica;
+        font-size: 14px;
+        padding-bottom: 5px;
+        color: gray;
+    }
+}
+
+.table-header-details table{
+    margin-top: 4px;
+    thead tr {
+      background-color: #385de0;
+      color: white;
+    }
+}
+
+table.details-table{
+    border-collapse: collapse;
+    table-layout: fixed;
+    width: 100%;
+    &, tr, th, td {
+      border: black;
+      padding: 3px;
+      font-size: 14px;
+      text-align: center;
+    }
+  }
+.table-body-details {
+    &:nth-child(odd) {
+        background-color:whitesmoke;
+      }
+}

--- a/src/components/ReportPage/index.jsx
+++ b/src/components/ReportPage/index.jsx
@@ -10,6 +10,7 @@ import * as constants from '../constants';
 import mockReport from '../../mocks/mockReport';
 import FiltersBar from '../FiltersBar';
 import './styles.scss';
+import AutomationDetails from '../AutomationDetails';
 
 
 /* eslint-disable class-methods-use-this */
@@ -27,6 +28,9 @@ class ReportPage extends PureComponent {
       },
       searchResult: false,
       filteredReport: [],
+      isModalOpen: false,
+      modalContent: {},
+      type: '',
     };
   }
 
@@ -146,6 +150,14 @@ class ReportPage extends PureComponent {
     }
   }
 
+  openModal = () => {
+    this.setState({ isModalOpen: true });
+  }
+
+  closeModal = () => {
+    this.setState({ isModalOpen: false });
+  }
+
   filterWithAutomationStatus(report) {
     const { filters: { automationStatus } } = this.state;
     return automationStatus.every((filterTerm) => {
@@ -234,18 +246,19 @@ class ReportPage extends PureComponent {
     return window.open(`https://ais.andela.com/people/${report.fellowId}`);
   }
 
-  renderAutomationStatus(automationStatus) {
+  changeModalTypes(report, type) {
+    this.setState({ modalContent: report, type });
+  }
+
+  renderAutomationStatus(automationStatus, report, type) {
     return (
-      automationStatus ? (
-        <span>
-          Success&nbsp;
-          <i className="fa fa-info-circle success" />
-        </span>) : (
-          <span>
-            Failed&nbsp;
-            <i className="fa fa-info-circle failed" />
-          </span>
-      )
+      <span>
+        { automationStatus ? 'Success' : 'Failed' }&nbsp;
+        <i
+          className={`fa fa-info-circle ${automationStatus ? 'success' : 'failed'}`}
+          onClick={() => { this.openModal(); this.changeModalTypes(report, type); }}
+        />
+      </span>
     );
   }
 
@@ -283,16 +296,18 @@ class ReportPage extends PureComponent {
         </td>
         <td>{report.partnerName}</td>
         <td>{report.type}</td>
-        <td>{this.renderAutomationStatus(report.slackAutomation.success)}</td>
-        <td>{this.renderAutomationStatus(report.emailAutomation.success)}</td>
-        <td>{this.renderAutomationStatus(report.freckleAutomation.success)}</td>
+        <td>{this.renderAutomationStatus(report.slackAutomation.success, report, 'slack')}</td>
+        <td>{this.renderAutomationStatus(report.emailAutomation.success, report, 'email')}</td>
+        <td>{this.renderAutomationStatus(report.freckleAutomation.success, report, 'freckle')}</td>
       </tr>
     ));
   }
 
   render() {
     const { currentUser, removeCurrentUser, history } = this.props;
-    const { filters } = this.state;
+    const {
+      isModalOpen, modalContent, type, filters,
+    } = this.state;
     return (
       <div>
         <Header
@@ -332,6 +347,12 @@ class ReportPage extends PureComponent {
               </tbody>
             </table>
           </div>
+          <AutomationDetails
+            isModalOpen={isModalOpen}
+            closeModal={this.closeModal}
+            modalType={type}
+            modalContent={modalContent}
+          />
         </div>
       </div>
     );

--- a/src/mocks/mockReport.js
+++ b/src/mocks/mockReport.js
@@ -7,12 +7,37 @@ export default [
     type: 'Onboarding',
     slackAutomation: {
       success: true,
+      slackChannels: [
+        {
+          slackChannel: 'andela-int',
+          type: 'Addition',
+          success: true,
+        },
+        {
+          slackChannel: 'andela',
+          type: 'Removal',
+          success: true,
+        },
+      ],
     },
     freckleAutomation: {
       success: false,
     },
     emailAutomation: {
       success: true,
+      email: [{
+        id: 1,
+        emailTo: 'Tunmise.ogunniy.kariukii@andela.com',
+        subject: 'Onboarding',
+        success: true,
+      },
+      {
+        id: 2,
+        emailTo: 'Tunmise.ogunniyi@andela.com',
+        subject: 'Onboarding',
+        success: true,
+      },
+      ],
     },
     date: '2017-09-29 01:22',
   },
@@ -24,12 +49,37 @@ export default [
     type: 'Onboarding',
     slackAutomation: {
       success: false,
+      slackChannels: [
+        {
+          slackChannel: 'andela-int',
+          type: 'Addition',
+          success: true,
+        },
+        {
+          slackChannel: 'andela',
+          type: 'Removal',
+          success: false,
+        },
+      ],
     },
     freckleAutomation: {
       success: true,
     },
     emailAutomation: {
       success: true,
+      email: [{
+        id: 1,
+        emailTo: 'Tunmise.ogunniyi@andela.com',
+        subject: 'Onboarding',
+        success: true,
+      },
+      {
+        id: 2,
+        emailTo: 'Tunmise.ogunniyi@andela.com',
+        subject: 'Onboarding',
+        success: true,
+      },
+      ],
     },
     date: '2017-09-29 01:22',
   },
@@ -41,12 +91,37 @@ export default [
     type: 'Offboarding',
     slackAutomation: {
       success: true,
+      slackChannels: [
+        {
+          slackChannel: 'andela-int',
+          type: 'Addition',
+          success: true,
+        },
+        {
+          slackChannel: 'andela',
+          type: 'Removal',
+          success: true,
+        },
+      ],
     },
     freckleAutomation: {
       success: true,
     },
     emailAutomation: {
       success: false,
+      email: [{
+        id: 1,
+        emailTo: 'Tunmise.ogunniyi@andela.com',
+        subject: 'Onboarding',
+        success: true,
+      },
+      {
+        id: 2,
+        emailTo: 'Tunmise.ogunniyi@andela.com',
+        subject: 'Onboarding',
+        success: true,
+      },
+      ],
     },
     date: '2017-09-29 01:22',
   },
@@ -58,12 +133,37 @@ export default [
     type: 'Offboarding',
     slackAutomation: {
       success: true,
+      slackChannels: [
+        {
+          slackChannel: 'andela-int',
+          type: 'Addition',
+          success: true,
+        },
+        {
+          slackChannel: 'andela',
+          type: 'Removal',
+          success: true,
+        },
+      ],
     },
     freckleAutomation: {
       success: true,
     },
     emailAutomation: {
       success: true,
+      email: [{
+        id: 1,
+        emailTo: 'Tunmise.ogunniyi@andela.com',
+        subject: 'Onboarding',
+        success: true,
+      },
+      {
+        id: 2,
+        emailTo: 'Tunmise.ogunniyi@andela.com',
+        subject: 'Onboarding',
+        success: true,
+      },
+      ],
     },
     date: '2017-09-29 01:22',
   },
@@ -75,12 +175,37 @@ export default [
     type: 'Offboarding',
     slackAutomation: {
       success: false,
+      slackChannels: [
+        {
+          slackChannel: 'andela-int',
+          type: 'Addition',
+          success: true,
+        },
+        {
+          slackChannel: 'andela',
+          type: 'Removal',
+          success: true,
+        },
+      ],
     },
     freckleAutomation: {
       success: false,
     },
     emailAutomation: {
       success: false,
+      email: [{
+        id: 1,
+        emailTo: 'Tunmise.ogunniyi@andela.com',
+        subject: 'Onboarding',
+        success: true,
+      },
+      {
+        id: 2,
+        emailTo: 'Tunmise.ogunniyi@andela.com',
+        subject: 'Onboarding',
+        success: true,
+      },
+      ],
     },
     date: '2017-09-29 01:22',
   },
@@ -92,12 +217,37 @@ export default [
     type: 'Onboarding',
     slackAutomation: {
       success: true,
+      slackChannels: [
+        {
+          slackChannel: 'andela-int',
+          type: 'Addition',
+          success: true,
+        },
+        {
+          slackChannel: 'andela',
+          type: 'Removal',
+          success: true,
+        },
+      ],
     },
     freckleAutomation: {
       success: false,
     },
     emailAutomation: {
       success: true,
+      email: [{
+        id: 1,
+        emailTo: 'Tunmise.ogunniyi@andela.com',
+        subject: 'Onboarding',
+        success: true,
+      },
+      {
+        id: 2,
+        emailTo: 'Tunmise.ogunniyi@andela.com',
+        subject: 'Onboarding',
+        success: true,
+      },
+      ],
     },
     date: '2017-09-29 01:22',
   },
@@ -109,12 +259,39 @@ export default [
     type: 'Onboarding',
     slackAutomation: {
       success: true,
+      slackChannels: [
+        {
+          id: 1,
+          slackChannel: 'andela-int',
+          type: 'Addition',
+          success: true,
+        },
+        {
+          id: 2,
+          slackChannel: 'andela',
+          type: 'Removal',
+          success: true,
+        },
+      ],
     },
     freckleAutomation: {
       success: false,
     },
     emailAutomation: {
       success: true,
+      email: [{
+        id: 1,
+        emailTo: 'Tunmise.ogunniyi@andela.com',
+        subject: 'Onboarding',
+        success: true,
+      },
+      {
+        id: 2,
+        emailTo: 'Tunmise.ogunniyi@andela.com',
+        subject: 'Onboarding',
+        success: true,
+      },
+      ],
     },
     date: '2017-09-29 01:22',
   },
@@ -126,12 +303,37 @@ export default [
     type: 'Onboarding',
     slackAutomation: {
       success: true,
+      slackChannels: [
+        {
+          slackChannel: 'andela-int',
+          type: 'Addition',
+          success: true,
+        },
+        {
+          slackChannel: 'andela',
+          type: 'Removal',
+          success: true,
+        },
+      ],
     },
     freckleAutomation: {
       success: true,
     },
     emailAutomation: {
       success: true,
+      email: [{
+        id: 1,
+        emailTo: 'Tunmise.ogunniyi@andela.com',
+        subject: 'Onboarding',
+        success: true,
+      },
+      {
+        id: 2,
+        emailTo: 'Tunmise.ogunniyi@andela.com',
+        subject: 'Onboarding',
+        success: true,
+      },
+      ],
     },
     date: '2017-09-29 01:22',
   },
@@ -143,12 +345,37 @@ export default [
     type: 'Onboarding',
     slackAutomation: {
       success: false,
+      slackChannels: [
+        {
+          slackChannel: 'andela-int',
+          type: 'Addition',
+          success: true,
+        },
+        {
+          slackChannel: 'andela',
+          type: 'Removal',
+          success: true,
+        },
+      ],
     },
     freckleAutomation: {
       success: false,
     },
     emailAutomation: {
       success: false,
+      email: [{
+        id: 1,
+        emailTo: 'Tunmise.ogunniyi@andela.com',
+        subject: 'Onboarding',
+        success: true,
+      },
+      {
+        id: 2,
+        emailTo: 'Tunmise.ogunniyi@andela.com',
+        subject: 'Onboarding',
+        success: true,
+      },
+      ],
     },
     date: '2017-09-29 01:22',
   },
@@ -160,12 +387,37 @@ export default [
     type: 'Onboarding',
     slackAutomation: {
       success: true,
+      slackChannels: [
+        {
+          slackChannel: 'andela-int',
+          type: 'Addition',
+          success: true,
+        },
+        {
+          slackChannel: 'andela',
+          type: 'Removal',
+          success: true,
+        },
+      ],
     },
     freckleAutomation: {
       success: false,
     },
     emailAutomation: {
       success: true,
+      email: [{
+        id: 1,
+        emailTo: 'Tunmise.ogunniyi@andela.com',
+        subject: 'Onboarding',
+        success: true,
+      },
+      {
+        id: 2,
+        emailTo: 'Tunmise.ogunniyi@andela.com',
+        subject: 'Onboarding',
+        success: true,
+      },
+      ],
     },
     date: '2017-09-29 01:22',
   },
@@ -177,12 +429,37 @@ export default [
     type: 'Onboarding',
     slackAutomation: {
       success: true,
+      slackChannels: [
+        {
+          slackChannel: 'andela-int',
+          type: 'Addition',
+          success: true,
+        },
+        {
+          slackChannel: 'andela',
+          type: 'Removal',
+          success: true,
+        },
+      ],
     },
     freckleAutomation: {
       success: true,
     },
     emailAutomation: {
       success: false,
+      email: [{
+        id: 1,
+        emailTo: 'Tunmise.ogunniyi@andela.com',
+        subject: 'Onboarding',
+        success: true,
+      },
+      {
+        id: 2,
+        emailTo: 'Tunmise.ogunniyi@andela.com',
+        subject: 'Onboarding',
+        success: true,
+      },
+      ],
     },
     date: '2017-09-29 01:22',
   },
@@ -194,12 +471,37 @@ export default [
     type: 'Onboarding',
     slackAutomation: {
       success: true,
+      slackChannels: [
+        {
+          slackChannel: 'andela-int',
+          type: 'Addition',
+          success: true,
+        },
+        {
+          slackChannel: 'andela',
+          type: 'Removal',
+          success: true,
+        },
+      ],
     },
     freckleAutomation: {
       success: false,
     },
     emailAutomation: {
       success: true,
+      email: [{
+        id: 1,
+        emailTo: 'Tunmise.ogunniyi@andela.com',
+        subject: 'Onboarding',
+        success: true,
+      },
+      {
+        id: 2,
+        emailTo: 'Tunmise.ogunniyi@andela.com',
+        subject: 'Onboarding',
+        success: true,
+      },
+      ],
     },
     date: '2017-09-29 01:22',
   },
@@ -211,12 +513,37 @@ export default [
     type: 'Onboarding',
     slackAutomation: {
       success: true,
+      slackChannels: [
+        {
+          slackChannel: 'andela-int',
+          type: 'Addition',
+          success: true,
+        },
+        {
+          slackChannel: 'andela',
+          type: 'Removal',
+          success: true,
+        },
+      ],
     },
     freckleAutomation: {
       success: false,
     },
     emailAutomation: {
       success: true,
+      email: [{
+        id: 1,
+        emailTo: 'Tunmise.ogunniyi@andela.com',
+        subject: 'Onboarding',
+        success: true,
+      },
+      {
+        id: 2,
+        emailTo: 'Tunmise.ogunniyi@andela.com',
+        subject: 'Onboarding',
+        success: true,
+      },
+      ],
     },
     date: '2017-09-29 01:22',
   },
@@ -228,12 +555,37 @@ export default [
     type: 'Onboarding',
     slackAutomation: {
       success: true,
+      slackChannels: [
+        {
+          slackChannel: 'andela-int',
+          type: 'Addition',
+          success: true,
+        },
+        {
+          slackChannel: 'esa',
+          type: 'Removal',
+          success: true,
+        },
+      ],
     },
     freckleAutomation: {
       success: false,
     },
     emailAutomation: {
       success: true,
+      email: [{
+        id: 1,
+        emailTo: 'Tunmise.ogunniyi@andela.com',
+        subject: 'Onboarding',
+        success: true,
+      },
+      {
+        id: 2,
+        emailTo: 'Tunmise.ogunniyi@andela.com',
+        subject: 'Onboarding',
+        success: true,
+      },
+      ],
     },
     date: '2017-09-29 01:22',
   },
@@ -245,12 +597,37 @@ export default [
     type: 'Onboarding',
     slackAutomation: {
       success: true,
+      slackChannels: [
+        {
+          slackChannel: 'andela-int',
+          type: 'Addition',
+          success: true,
+        },
+        {
+          slackChannel: 'andela',
+          type: 'Removal',
+          success: true,
+        },
+      ],
     },
     freckleAutomation: {
       success: false,
     },
     emailAutomation: {
       success: true,
+      email: [{
+        id: 1,
+        email: 'Tunmise.ogunniyi@andela.com',
+        subject: 'Onboarding',
+        success: true,
+      },
+      {
+        id: 2,
+        email: 'Tunmise.ogunniyi@andela.com',
+        subject: 'Onboarding',
+        success: true,
+      },
+      ],
     },
     date: '2017-09-29 01:22',
   },
@@ -262,12 +639,37 @@ export default [
     type: 'Onboarding',
     slackAutomation: {
       success: true,
+      slackChannels: [
+        {
+          slackChannel: 'andela-int',
+          type: 'Addition',
+          success: true,
+        },
+        {
+          slackChannel: 'andela',
+          type: 'Removal',
+          success: true,
+        },
+      ],
     },
     freckleAutomation: {
       success: false,
     },
     emailAutomation: {
       success: true,
+      email: [{
+        id: 1,
+        emailTo: 'Tunmise.ogunniyi@andela.com',
+        subject: 'Onboarding',
+        success: true,
+      },
+      {
+        id: 2,
+        emailTo: 'Tunmise.ogunniyi@andela.com',
+        subject: 'Onboarding',
+        success: true,
+      },
+      ],
     },
     date: '2017-09-29 01:22',
   },
@@ -279,12 +681,37 @@ export default [
     type: 'Onboarding',
     slackAutomation: {
       success: true,
+      slackChannels: [
+        {
+          slackChannel: 'andela-int',
+          type: 'Addition',
+          success: true,
+        },
+        {
+          slackChannel: 'andela',
+          type: 'Removal',
+          success: true,
+        },
+      ],
     },
     freckleAutomation: {
       success: false,
     },
     emailAutomation: {
       success: true,
+      email: [{
+        id: 1,
+        emailTo: 'Tunmise.ogunniyi@andela.com',
+        subject: 'Onboarding',
+        success: true,
+      },
+      {
+        id: 2,
+        emailTo: 'Tunmise.ogunniyi@andela.com',
+        subject: 'Onboarding',
+        success: true,
+      },
+      ],
     },
     date: '2017-09-29 01:22',
   },
@@ -296,12 +723,37 @@ export default [
     type: 'Onboarding',
     slackAutomation: {
       success: false,
+      slackChannels: [
+        {
+          slackChannel: 'andela-int',
+          type: 'Addition',
+          success: true,
+        },
+        {
+          slackChannel: 'andela',
+          type: 'Removal',
+          success: true,
+        },
+      ],
     },
     freckleAutomation: {
       success: false,
     },
     emailAutomation: {
       success: true,
+      email: [{
+        id: 1,
+        emailTo: 'Tunmise.ogunniyi@andela.com',
+        subject: 'Onboarding',
+        success: true,
+      },
+      {
+        id: 2,
+        emailTo: 'Tunmise.ogunniyi@andela.com',
+        subject: 'Onboarding',
+        success: true,
+      },
+      ],
     },
     date: '2018-09-29 01:22',
   },


### PR DESCRIPTION
**What does this PR do?**

- Adds the service automation details modal
- Adds SCSS for the service automation modal
- Adds tests.

**Description of task to be completed?**
A user should see the details of a service automation in a modal.

**How should this be manually tested?**

- Clone and set up the project using the instruction in the README.
- $ git checkout to `ft-modal-to-show-service-automation-details` branch which contains the changes.
- Use $ npm start to start the application
- Visit http://localhost:3000/.
- On the report page, click the information (i) icons to view the details of the various service automation.

**What are the relevant pivotal tracker stories?**
[[#160437219]](https://www.pivotaltracker.com/story/show/160437219) - Sub-task

**Screenshots:**
##### Slack automation details
<img width="1434" alt="screen shot 2018-11-14 at 15 43 05" src="https://user-images.githubusercontent.com/16057093/48483357-43dfb080-e824-11e8-852d-6bfca0b1e8e7.png">


##### Email automation details
<img width="1437" alt="screen shot 2018-11-14 at 15 43 28" src="https://user-images.githubusercontent.com/16057093/48483363-4b9f5500-e824-11e8-8489-9e1f0801f50e.png">

##### Freckle automation details
<img width="1439" alt="screen shot 2018-11-09 at 12 19 57" src="https://user-images.githubusercontent.com/16057093/48254017-d691e100-e419-11e8-9151-c293fbad4cd7.png">

