### PR TITLE
Feature #160437219 Report Page Feedback

### DIFF
--- a/src/__tests__/components/Search/Search.test.jsx
+++ b/src/__tests__/components/Search/Search.test.jsx
@@ -2,9 +2,6 @@ import React from 'react';
 import Search from '../../../components/Search';
 
 const props = {
-  searchSet: 'search',
-  title: 'Search With',
-  options: [],
   handleSearch: jest.fn(),
 };
 
@@ -31,12 +28,12 @@ describe('<Search />', () => {
     `, () => {
       const component = getComponent();
       expect(component.state('searchValue')).toEqual('');
-      expect(component.state('searchCriteria')).toEqual('');
+      expect(component.state('searchCriteria')).toEqual(1);
       component.setState({
-        searchValue: 'Shakira',
+        searchValue: 'Andela',
         searchCriteria: 1,
       });
-      expect(props.handleSearch).toHaveBeenCalledTimes(1);
+      expect(props.handleSearch).toHaveBeenCalled();
     });
   });
 });

--- a/src/components/ReportPage/index.jsx
+++ b/src/components/ReportPage/index.jsx
@@ -250,15 +250,7 @@ class ReportPage extends PureComponent {
   }
 
   renderSearch() {
-    return constants.searches.map(search => (
-      <Search
-        key={search.id}
-        searchSet={search.searchSet}
-        title={search.title}
-        options={search.options}
-        handleSearch={this.doSearch}
-      />
-    ));
+    return <Search handleSearch={this.doSearch} />;
   }
 
   renderTableRows() {

--- a/src/components/Search/index.jsx
+++ b/src/components/Search/index.jsx
@@ -1,17 +1,16 @@
+
 import React, { PureComponent } from 'react';
 import PropTypes from 'proptypes';
 import './styles.scss';
 import classNames from 'classnames';
 
-/* eslint-disable no-restricted-globals */
 class Search extends PureComponent {
   constructor() {
     super();
     this.state = {
       searchOptionsVisible: false,
       searchValue: '',
-      searchCriteria: '',
-      selectedOption: '',
+      searchCriteria: 1,
     };
   }
 
@@ -30,7 +29,9 @@ class Search extends PureComponent {
   };
 
   handleSearchCriteriaChange = (optionId) => {
-    this.setState({ searchCriteria: optionId });
+    this.setState({
+      searchCriteria: optionId,
+    });
   };
 
   handleSearchValueChange = (event) => {
@@ -38,32 +39,36 @@ class Search extends PureComponent {
   }
 
   renderSearchOptions() {
-    const { options } = this.props;
-    const { searchOptionsVisible, selectedOption } = this.state;
+    const { searchOptionsVisible } = this.state;
     return (
       <ul className={classNames('search-option', { 'search-options-isvisible': searchOptionsVisible })}>
-        {options.map(option => (
-          <li
-            key={option.id}
-          >
-            <input type="radio" value={option.value} onChange={() => this.handleSearchCriteriaChange(option.id)} checked={selectedOption === option.id} />
-            {option.text}
-          </li>
-        ))}
+        <li>
+          <input type="radio" defaultChecked name="search" onChange={() => this.handleSearchCriteriaChange(1)} />
+          {'Fellow Name'}
+        </li>
+        <li>
+          <input type="radio" name="search" onChange={() => this.handleSearchCriteriaChange(2)} />
+          {'Partner Name'}
+        </li>
       </ul>
     );
   }
 
   render() {
     const { searchValue } = this.state;
-    const { title } = this.props;
-    const { searchOptionsVisible } = this.state;
+    const { searchOptionsVisible, searchCriteria } = this.state;
+
     return (
       <div>
         <input type="text" className="search-input" value={searchValue} onChange={this.handleSearchValueChange} />
-        <div className="search" onClick={this.toggleVisibility}>
-          <div className="search-title">
-            <span className="title">{title}</span>
+        <div className="search">
+          <div className="search-title" onClick={event => this.toggleVisibility(event)}>
+            <span className="title">
+              {'Search With'}
+              {' | '}
+              {searchCriteria === 1 ? 'Fellow Name' : 'Partner Name'}
+            </span>
+
             <i
               className={classNames('fa fa-angle-down', { 'rotate-180': searchOptionsVisible })}
             />
@@ -76,8 +81,6 @@ class Search extends PureComponent {
 }
 
 Search.propTypes = {
-  title: PropTypes.string.isRequired,
-  options: PropTypes.array.isRequired,
   handleSearch: PropTypes.func.isRequired,
 };
 

--- a/src/components/Search/styles.scss
+++ b/src/components/Search/styles.scss
@@ -6,27 +6,6 @@
     text-transform:capitalize;
 }
 
-.search-option{
-  visibility: hidden;
-  margin-top: 15px;
-  margin-left: 3%;
-  margin-right: 10px;   
-  li {
-    z-index:1;
-    border: 1px solid #d9d9d9;
-    background-color:  white;
-    padding: 5px;
-    border-bottom: 1px solid #d9d9d9;
-    padding: 5px;
-    input[type=radio] {
-      margin-right: 10px;
-    }
-  }
-  &.search-options-isvisible {
-    visibility: visible;
-  }
-}
-
 .search {
     margin-top: 1%;
     position: absolute;
@@ -44,12 +23,36 @@
         color: black;
       }
       i {
-        margin-left:-2%;
+        margin: -6px 10px;
         font-size: 20px;
         transition: all 0.3s;
         &.rotate-180 {
           transform: rotate(180deg);
       }
     }
-}
+  }
+      .search-option{
+        visibility: hidden;
+        margin-top: 5px;
+        margin-left: 3px;
+        box-shadow: 0px 8px 16px 0px rgba(0, 0, 0, 0.2);
+        width: 97%;
+        border-radius: 6px;
+        overflow: hidden;
+        li {
+          z-index:1;
+          background-color:  white;
+          border-bottom: 1px solid #d9d9d9;
+          color: #4d4d4d;
+          padding: 5px;
+          input[type=radio] {
+            margin-right: 10px;
+          }
+        }
+        &.search-options-isvisible {
+          visibility: visible;
+        }
+      }
+    
+
 }

--- a/src/components/constants.js
+++ b/src/components/constants.js
@@ -71,19 +71,3 @@ export const filters = [
     ],
   },
 ];
-
-export const searches = [
-  {
-    id: 1,
-    title: 'Search With',
-    searchSet: 'search',
-    options: [
-      {
-        id: 1, text: 'Fellow Name', value: FELLOW_NAME, type: 'search',
-      },
-      {
-        id: 2, text: 'Partner Name', value: PARTNER_NAME, type: 'search',
-      },
-    ],
-  },
-];


### PR DESCRIPTION
**What does this PR do?**
Implements the feedback given during the demo.

**Description of Task to be completed?**
Add space between search title and the arrow.
Change on the serach title in regard to the option selected.

**How should this be manually tested?**
Clone and set up the project using the instruction in the README.
Use `$ git checkout ft-filter-report-with-fellow-name` to check out the branch containing the changes of this pull request
Use `$ npm start` to start the application
Visit http://localhost:3000/ to see the report page.
Whe the page is loaded the first time the default value is Fellow name and the search title has Search With Fellow Name
When a user selects Partner Name the search title has Search With Partner Name.
What are the relevant pivotal tracker stories?
[#160437219](https://www.pivotaltracker.com/story/show/160437219)

**Screenshots (if appropriate)**
<img width="1440" alt="screen shot 2018-11-20 at 18 44 29" src="https://user-images.githubusercontent.com/6957960/48789229-a42b9200-ecfd-11e8-9a0c-97d493015320.png">
<img width="1440" alt="screen shot 2018-11-20 at 18 44 41" src="https://user-images.githubusercontent.com/6957960/48788529-126f5500-ecfc-11e8-8ecd-1501911a355b.png">
<img width="1440" alt="screen shot 2018-11-20 at 19 47 49" src="https://user-images.githubusercontent.com/6957960/48789063-3a12ed00-ecfd-11e8-9833-edd00cdc5a1c.png">

