### PR TITLE
#160437219 Redirect to Allocations Partner Page

### DIFF
--- a/src/__tests__/components/ReportPage.test.jsx
+++ b/src/__tests__/components/ReportPage.test.jsx
@@ -23,18 +23,19 @@ const sampleReports = [
     fellowName: 'Tunmise',
     partnerName: 'Andela',
     type: 'onboarding',
+    partnerId: '0061a00000F41K1AAJ',
     slackAutomations: {
       status: 'failure',
       slackActivities: [
         {
           channelName: 'andela-int',
           type: 'Addition',
-          status: 'failure'
+          status: 'failure',
         },
         {
           channelName: 'andela',
           type: 'Removal',
-          status: 'success'
+          status: 'success',
         },
       ],
     },
@@ -51,6 +52,7 @@ const sampleReports = [
     fellowName: 'Shakira',
     partnerName: 'ESA',
     type: 'offboarding',
+    partnerId: '0061a00000F41K1AAJ',
     slackAutomations: {
       status: 'success',
     },
@@ -82,14 +84,14 @@ describe('<ReportPage />', () => {
   describe('componenDidUpdate method', () => {
     it(`should call filterReports method if the
     filters in the state is updated`, () => {
-        const component = getComponent();
-        const componentInstance = component.instance();
-        jest.spyOn(componentInstance, 'filterReports');
-        expect(componentInstance.filterReports).toHaveBeenCalledTimes(0);
-        const previousFilters = component.state('filters');
-        component.setState({ filters: { ...previousFilters, updated: true } });
-        expect(componentInstance.filterReports).toHaveBeenCalledTimes(1);
-      });
+      const component = getComponent();
+      const componentInstance = component.instance();
+      jest.spyOn(componentInstance, 'filterReports');
+      expect(componentInstance.filterReports).toHaveBeenCalledTimes(0);
+      const previousFilters = component.state('filters');
+      component.setState({ filters: { ...previousFilters, updated: true } });
+      expect(componentInstance.filterReports).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('setFilter method', () => {
@@ -97,80 +99,80 @@ describe('<ReportPage />', () => {
       const filterSet = 'automationStatus';
       it(`should add a filter to the state and increment the filter length
       if action is add_filter`, () => {
-          const component = getComponent();
-          const componentInstance = component.instance();
-          expect(component.state('filters').automationStatus).toEqual([]);
-          expect(component.state('filters').length).toEqual(0);
-          componentInstance.setFilter(
-            'failed_automations',
-            filterSet,
-            'add_filter',
-          );
-          expect(component.state('filters').automationStatus).toEqual([
-            'failed_automations',
-          ]);
-          expect(component.state('filters').length).toEqual(1);
-        });
+        const component = getComponent();
+        const componentInstance = component.instance();
+        expect(component.state('filters').automationStatus).toEqual([]);
+        expect(component.state('filters').length).toEqual(0);
+        componentInstance.setFilter(
+          'failed_automations',
+          filterSet,
+          'add_filter',
+        );
+        expect(component.state('filters').automationStatus).toEqual([
+          'failed_automations',
+        ]);
+        expect(component.state('filters').length).toEqual(1);
+      });
       it(`should remove a filter in the state and reduce the filter length
        if action is remove_filter`, () => {
-          const component = getComponent();
-          const componentInstance = component.instance();
-          const previousFilters = component.state('filters');
-          component.setState({
-            filters: {
-              ...previousFilters,
-              automationStatus: ['failed_automations'],
-              length: 1,
-            },
-          });
-          componentInstance.setFilter(
-            'failed_automations',
-            filterSet,
-            'remove_filter',
-          );
-          expect(component.state('filters').automationStatus).toEqual([]);
-          expect(component.state('filters').length).toEqual(0);
+        const component = getComponent();
+        const componentInstance = component.instance();
+        const previousFilters = component.state('filters');
+        component.setState({
+          filters: {
+            ...previousFilters,
+            automationStatus: ['failed_automations'],
+            length: 1,
+          },
         });
+        componentInstance.setFilter(
+          'failed_automations',
+          filterSet,
+          'remove_filter',
+        );
+        expect(component.state('filters').automationStatus).toEqual([]);
+        expect(component.state('filters').length).toEqual(0);
+      });
     });
 
     describe('Automation type filter set', () => {
       const filterSet = 'automationType';
       it(`should add a filter to the state and increment the filter length,
       if action is add_filter`, () => {
-          const component = getComponent();
-          const componentInstance = component.instance();
-          expect(component.state('filters').automationType).toEqual([]);
-          expect(component.state('filters').length).toEqual(0);
-          componentInstance.setFilter(
-            'failed_automations',
-            filterSet,
-            'add_filter',
-          );
-          expect(component.state('filters').automationType).toEqual([
-            'failed_automations',
-          ]);
-          expect(component.state('filters').length).toEqual(1);
-        });
+        const component = getComponent();
+        const componentInstance = component.instance();
+        expect(component.state('filters').automationType).toEqual([]);
+        expect(component.state('filters').length).toEqual(0);
+        componentInstance.setFilter(
+          'failed_automations',
+          filterSet,
+          'add_filter',
+        );
+        expect(component.state('filters').automationType).toEqual([
+          'failed_automations',
+        ]);
+        expect(component.state('filters').length).toEqual(1);
+      });
       it(`should remove a filter in the state and reduce the filter length
       if action is remove_filter`, () => {
-          const component = getComponent();
-          const componentInstance = component.instance();
-          const previousFilters = component.state('filters');
-          component.setState({
-            filters: {
-              ...previousFilters,
-              automationType: ['failed_automations'],
-              length: 1,
-            },
-          });
-          componentInstance.setFilter(
-            'failed_automations',
-            filterSet,
-            'remove_filter',
-          );
-          expect(component.state('filters').automationType).toEqual([]);
-          expect(component.state('filters').length).toEqual(0);
+        const component = getComponent();
+        const componentInstance = component.instance();
+        const previousFilters = component.state('filters');
+        component.setState({
+          filters: {
+            ...previousFilters,
+            automationType: ['failed_automations'],
+            length: 1,
+          },
         });
+        componentInstance.setFilter(
+          'failed_automations',
+          filterSet,
+          'remove_filter',
+        );
+        expect(component.state('filters').automationType).toEqual([]);
+        expect(component.state('filters').length).toEqual(0);
+      });
     });
 
     describe('Date filter set', () => {
@@ -178,28 +180,28 @@ describe('<ReportPage />', () => {
       const sampleDateFilter = '12/02/2018';
       it(`should add a date-filter to the state and increment the filter length
       if action is set_from_date`, () => {
-          const component = getComponent();
-          const componentInstance = component.instance();
-          expect(component.state('filters').date.from).toEqual('');
-          expect(component.state('filters').length).toEqual(0);
-          componentInstance.setFilter(
-            sampleDateFilter,
-            filterSet,
-            'set_from_date',
-          );
-          expect(component.state('filters').date.from).toEqual(sampleDateFilter);
-          expect(component.state('filters').length).toEqual(1);
-        });
+        const component = getComponent();
+        const componentInstance = component.instance();
+        expect(component.state('filters').date.from).toEqual('');
+        expect(component.state('filters').length).toEqual(0);
+        componentInstance.setFilter(
+          sampleDateFilter,
+          filterSet,
+          'set_from_date',
+        );
+        expect(component.state('filters').date.from).toEqual(sampleDateFilter);
+        expect(component.state('filters').length).toEqual(1);
+      });
       it(`should add a date-filter to the state and increment the filter length
       if action is set_to_date`, () => {
-          const component = getComponent();
-          const componentInstance = component.instance();
-          expect(component.state('filters').date.to).toEqual('');
-          expect(component.state('filters').length).toEqual(0);
-          componentInstance.setFilter(sampleDateFilter, filterSet, 'set_to_date');
-          expect(component.state('filters').date.to).toEqual(sampleDateFilter);
-          expect(component.state('filters').length).toEqual(1);
-        });
+        const component = getComponent();
+        const componentInstance = component.instance();
+        expect(component.state('filters').date.to).toEqual('');
+        expect(component.state('filters').length).toEqual(0);
+        componentInstance.setFilter(sampleDateFilter, filterSet, 'set_to_date');
+        expect(component.state('filters').date.to).toEqual(sampleDateFilter);
+        expect(component.state('filters').length).toEqual(1);
+      });
       it('should not change filter length if a date filter previously existed', () => {
         const component = getComponent();
         const componentInstance = component.instance();
@@ -452,39 +454,39 @@ describe('<ReportPage />', () => {
   describe('doSearch method', () => {
     it(`should return a filtered report when
     searchResults for fellow in the state is updated`, () => {
-        const component = getComponent();
-        const componentInstance = component.instance();
-        component.setState({ reportData: sampleReports });
-        expect(component.state('searchResult')).toEqual(false);
-        expect(component.state('filteredReport')).toEqual([]);
-        componentInstance.doSearch('Shakira', 1);
-        expect(component.state('searchResult')).toEqual(true);
-        expect(component.state('filteredReport')).toEqual([sampleReports[1]]);
-      });
+      const component = getComponent();
+      const componentInstance = component.instance();
+      component.setState({ reportData: sampleReports });
+      expect(component.state('searchResult')).toEqual(false);
+      expect(component.state('filteredReport')).toEqual([]);
+      componentInstance.doSearch('Shakira', 1);
+      expect(component.state('searchResult')).toEqual(true);
+      expect(component.state('filteredReport')).toEqual([sampleReports[1]]);
+    });
 
     it(`should not return a filtered report when
     searchResults in the state is not updated`, () => {
-        const component = getComponent();
-        const componentInstance = component.instance();
-        component.setState({ reportData: sampleReports });
-        expect(component.state('searchResult')).toEqual(false);
-        expect(component.state('filteredReport')).toEqual([]);
-        componentInstance.doSearch('', '');
-        expect(component.state('searchResult')).toEqual(false);
-        expect(component.state('filteredReport')).toEqual([]);
-      });
+      const component = getComponent();
+      const componentInstance = component.instance();
+      component.setState({ reportData: sampleReports });
+      expect(component.state('searchResult')).toEqual(false);
+      expect(component.state('filteredReport')).toEqual([]);
+      componentInstance.doSearch('', '');
+      expect(component.state('searchResult')).toEqual(false);
+      expect(component.state('filteredReport')).toEqual([]);
+    });
 
     it(`should return a filtered report when
     searchResults in the state is updated`, () => {
-        const component = getComponent();
-        const componentInstance = component.instance();
-        component.setState({ reportData: sampleReports });
-        expect(component.state('searchResult')).toEqual(false);
-        expect(component.state('filteredReport')).toEqual([]);
-        componentInstance.doSearch('Andela', 2);
-        expect(component.state('searchResult')).toEqual(true);
-        expect(component.state('filteredReport')).toEqual([sampleReports[0]]);
-      });
+      const component = getComponent();
+      const componentInstance = component.instance();
+      component.setState({ reportData: sampleReports });
+      expect(component.state('searchResult')).toEqual(false);
+      expect(component.state('filteredReport')).toEqual([]);
+      componentInstance.doSearch('Andela', 2);
+      expect(component.state('searchResult')).toEqual(true);
+      expect(component.state('filteredReport')).toEqual([sampleReports[0]]);
+    });
 
     it('should redirect to the AIS page when you click the fellow name', () => {
       // eslint-disable-next-line no-undef
@@ -499,6 +501,7 @@ describe('<ReportPage />', () => {
       redirectToAIS.simulate('click');
       expect(global.open).toHaveBeenCalled();
     });
+
     it('should render a slack modal when the slack status icons are clicked', () => {
       const component = getComponent();
       component.setState({ reportData: sampleReports, isLoadingReports: false });
@@ -562,6 +565,15 @@ describe('<ReportPage />', () => {
       const component = await getComponent();
       await component.instance().componentDidMount();
       expect(component.instance().state.reportData).toEqual(errorResponse);
+    });
+
+    it('should redirect to the engagement Allocations page when you click the partner name', () => {
+      const component = getComponent();
+      component.setState({ reportData: sampleReports, isLoadingReports: false });
+      const wrapper = component.find('.table-body').find('tr').at(0).find('.engagement');
+      global.open = jest.fn();
+      wrapper.simulate('click');
+      expect(global.open).toHaveBeenCalled();
     });
   });
 });

--- a/src/__tests__/components/Spinner/__snapshots__/Spinner.test.jsx.snap
+++ b/src/__tests__/components/Spinner/__snapshots__/Spinner.test.jsx.snap
@@ -3,7 +3,9 @@
 exports[`Spinner should render as expected 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
-  Symbol(enzyme.__unrendered__): <Spinner />,
+  Symbol(enzyme.__unrendered__): <Spinner
+    size="large"
+  />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
     "checkPropTypes": [Function],
@@ -18,7 +20,7 @@ ShallowWrapper {
     "key": undefined,
     "nodeType": "host",
     "props": Object {
-      "className": "spinner undefined",
+      "className": "spinner large",
     },
     "ref": null,
     "rendered": null,
@@ -30,7 +32,7 @@ ShallowWrapper {
       "key": undefined,
       "nodeType": "host",
       "props": Object {
-        "className": "spinner undefined",
+        "className": "spinner large",
       },
       "ref": null,
       "rendered": null,

--- a/src/__tests__/components/__snapshots__/AutomationDetails.test.jsx.snap
+++ b/src/__tests__/components/__snapshots__/AutomationDetails.test.jsx.snap
@@ -1130,7 +1130,7 @@ ShallowWrapper {
                     "rendered": Array [
                       Object {
                         "instance": null,
-                        "key": "3265d13f-75d5-4a58-839f-26eadfdfd2e8",
+                        "key": "dacc475d-8e42-4771-be99-c89d5399c514",
                         "nodeType": "host",
                         "props": Object {
                           "children": <table
@@ -1281,7 +1281,7 @@ ShallowWrapper {
                       },
                       Object {
                         "instance": null,
-                        "key": "e3f2eacb-fea0-46b0-bb18-32daf42b35e3",
+                        "key": "0f280c41-122b-4389-856c-4f5e6b24275d",
                         "nodeType": "host",
                         "props": Object {
                           "children": <table
@@ -2459,7 +2459,7 @@ ShallowWrapper {
                       "rendered": Array [
                         Object {
                           "instance": null,
-                          "key": "3265d13f-75d5-4a58-839f-26eadfdfd2e8",
+                          "key": "dacc475d-8e42-4771-be99-c89d5399c514",
                           "nodeType": "host",
                           "props": Object {
                             "children": <table
@@ -2610,7 +2610,7 @@ ShallowWrapper {
                         },
                         Object {
                           "instance": null,
-                          "key": "e3f2eacb-fea0-46b0-bb18-32daf42b35e3",
+                          "key": "0f280c41-122b-4389-856c-4f5e6b24275d",
                           "nodeType": "host",
                           "props": Object {
                             "children": <table
@@ -3950,7 +3950,7 @@ ShallowWrapper {
                     "rendered": Array [
                       Object {
                         "instance": null,
-                        "key": "cf2c0ec5-9df9-4690-ad2d-5b5beb9698ac",
+                        "key": "6f2e6ac9-848b-4e46-a7da-92403b4ab556",
                         "nodeType": "host",
                         "props": Object {
                           "children": <table
@@ -4101,7 +4101,7 @@ ShallowWrapper {
                       },
                       Object {
                         "instance": null,
-                        "key": "4cdc1f9b-a78a-4854-8218-e9808c938d27",
+                        "key": "9f7819fa-9e94-414c-aab7-55fa9d054999",
                         "nodeType": "host",
                         "props": Object {
                           "children": <table
@@ -5279,7 +5279,7 @@ ShallowWrapper {
                       "rendered": Array [
                         Object {
                           "instance": null,
-                          "key": "cf2c0ec5-9df9-4690-ad2d-5b5beb9698ac",
+                          "key": "6f2e6ac9-848b-4e46-a7da-92403b4ab556",
                           "nodeType": "host",
                           "props": Object {
                             "children": <table
@@ -5430,7 +5430,7 @@ ShallowWrapper {
                         },
                         Object {
                           "instance": null,
-                          "key": "4cdc1f9b-a78a-4854-8218-e9808c938d27",
+                          "key": "9f7819fa-9e94-414c-aab7-55fa9d054999",
                           "nodeType": "host",
                           "props": Object {
                             "children": <table
@@ -6728,7 +6728,7 @@ ShallowWrapper {
                     "rendered": Array [
                       Object {
                         "instance": null,
-                        "key": "40ee785c-c159-4a92-8366-c9abc6465bb9",
+                        "key": "d47c71ac-1429-43ca-8e15-7f0fb65c3275",
                         "nodeType": "host",
                         "props": Object {
                           "children": <table
@@ -6879,7 +6879,7 @@ ShallowWrapper {
                       },
                       Object {
                         "instance": null,
-                        "key": "93001337-4fd8-4441-94ac-8962a5118a18",
+                        "key": "fc281017-54ee-48f8-a2fd-89c4914282cf",
                         "nodeType": "host",
                         "props": Object {
                           "children": <table
@@ -8057,7 +8057,7 @@ ShallowWrapper {
                       "rendered": Array [
                         Object {
                           "instance": null,
-                          "key": "40ee785c-c159-4a92-8366-c9abc6465bb9",
+                          "key": "d47c71ac-1429-43ca-8e15-7f0fb65c3275",
                           "nodeType": "host",
                           "props": Object {
                             "children": <table
@@ -8208,7 +8208,7 @@ ShallowWrapper {
                         },
                         Object {
                           "instance": null,
-                          "key": "93001337-4fd8-4441-94ac-8962a5118a18",
+                          "key": "fc281017-54ee-48f8-a2fd-89c4914282cf",
                           "nodeType": "host",
                           "props": Object {
                             "children": <table

--- a/src/__tests__/components/__snapshots__/ReportPage.test.jsx.snap
+++ b/src/__tests__/components/__snapshots__/ReportPage.test.jsx.snap
@@ -213,7 +213,6 @@ ShallowWrapper {
             className="table-body"
           >
             <Spinner
-              isAbsolute={true}
               size="large"
             />
           </div>
@@ -418,7 +417,6 @@ ShallowWrapper {
               className="table-body"
             >
               <Spinner
-                isAbsolute={true}
                 size="large"
               />
             </div>,
@@ -965,7 +963,6 @@ ShallowWrapper {
             "nodeType": "host",
             "props": Object {
               "children": <Spinner
-                isAbsolute={true}
                 size="large"
               />,
               "className": "table-body",
@@ -976,7 +973,6 @@ ShallowWrapper {
               "key": undefined,
               "nodeType": "function",
               "props": Object {
-                "isAbsolute": true,
                 "size": "large",
               },
               "ref": null,
@@ -1193,7 +1189,6 @@ ShallowWrapper {
               className="table-body"
             >
               <Spinner
-                isAbsolute={true}
                 size="large"
               />
             </div>
@@ -1398,7 +1393,6 @@ ShallowWrapper {
                 className="table-body"
               >
                 <Spinner
-                  isAbsolute={true}
                   size="large"
                 />
               </div>,
@@ -1945,7 +1939,6 @@ ShallowWrapper {
               "nodeType": "host",
               "props": Object {
                 "children": <Spinner
-                  isAbsolute={true}
                   size="large"
                 />,
                 "className": "table-body",
@@ -1956,7 +1949,6 @@ ShallowWrapper {
                 "key": undefined,
                 "nodeType": "function",
                 "props": Object {
-                  "isAbsolute": true,
                   "size": "large",
                 },
                 "ref": null,

--- a/src/components/ReportPage/index.jsx
+++ b/src/components/ReportPage/index.jsx
@@ -257,10 +257,15 @@ class ReportPage extends PureComponent {
     return `(${stats.successCount}/${activities.length})`;
   }
 
+  redirectToAllocations(engagementId) {
+    return window.open(`https://allocations.andela.com/engagements/open/${engagementId}`);
+  }
+
   renderAutomationStatus(automationStatus, report, type) {
     return (
       <span>
-        {automationStatus}&nbsp;
+        {automationStatus}
+&nbsp;
         <span className={`${automationStatus}-text`}>
           {this.statusBreakdown(report, type)}
         </span>
@@ -306,7 +311,9 @@ class ReportPage extends PureComponent {
         >
           {report.fellowName}
         </td>
-        <td title={report.partnerName}>{report.partnerName}</td>
+        <td className="engagement" onClick={() => this.redirectToAllocations(report.partnerId)}>
+          {report.partnerName}
+        </td>
         <td>{report.type}</td>
         <td>{this.renderAutomationStatus(report.slackAutomations.status, report, 'slack')}</td>
         <td>{this.renderAutomationStatus(report.emailAutomations.status, report, 'email')}</td>


### PR DESCRIPTION
**What does this PR do?**

- Ensures that when you click a partner name you are redirected to the partner page on Allocations.
- Adds tests.

**Description of task to be completed?**
A user should be directed to a partner page on Allocations once they click the partner name.

**How should this be manually tested?**

- Clone and set up the project using the instruction in the README.
- $ git checkout to `ft-160437219-click-on-partner-name-and-get-redirected-to-allocations` branch which contains the changes.
- Use $ npm start to start the application
- Visit http://localhost:3000/.
- On the report page, click a given partner name. You will be directed to the partner's page on Allocations.

**What are the relevant pivotal tracker stories?**
[[#160437219]](https://www.pivotaltracker.com/story/show/160437219) - Sub-task
