### PR TITLE
Adjust the css to increase width for automation status dropdown

### DIFF
--- a/src/components/Filter/styles.scss
+++ b/src/components/Filter/styles.scss
@@ -28,7 +28,7 @@
     visibility: hidden;
     display: block;
     position: absolute;
-    width: 100%;
+    width: 120%;
     border-radius: 3px;
     background-color: white;
     box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);


### PR DESCRIPTION
#### What does this PR do?
Adjusts the css to increase width for automation status dropdown

#### Description of Task to be completed?
During the demo, the stakeholders pointed out that we increase the width of the drop down.

#### How should this be manually tested?

- Clone and set up the project using the instruction in the README.
- $ git checkout to fix-css-automationstatus branch which contains the changes.
- Use $ npm start to start the application
- Visit http://localhost:3000/.

#### Screenshots (If applicable)
Before: 
![screenshot 2019-01-04 at 11 00 46](https://user-images.githubusercontent.com/6957960/50678612-982b3380-1010-11e9-8c70-f65b4ea39429.png)
After:
![screenshot 2019-01-04 at 11 00 24](https://user-images.githubusercontent.com/6957960/50678608-92cde900-1010-11e9-86ec-ffaacda6247a.png)