### PR TITLE
fix(dropdowns): Dropdowns close when they/their child element lose focus

### DIFF
--- a/src/components/Filter/index.jsx
+++ b/src/components/Filter/index.jsx
@@ -21,6 +21,15 @@ class Filter extends PureComponent {
     });
   }
 
+  onBlurHandler = (event) => {
+    const target = event.currentTarget || event.target;
+    setTimeout(() => {
+      if (target.querySelectorAll(':focus').length === 0) {
+        this.setState({ filterOptionsIsVisible: false });
+      }
+    }, 0);
+  }
+
   toggleVisibility = () => {
     const { filterOptionsIsVisible } = this.state;
     this.setState({ filterOptionsIsVisible: !filterOptionsIsVisible });
@@ -103,7 +112,7 @@ class Filter extends PureComponent {
     const { title } = this.props;
     const { filterOptionsIsVisible } = this.state;
     return (
-      <div className="filter">
+      <div className="filter" onBlur={this.onBlurHandler} tabIndex="-1">
         <div className="filter-title" onClick={this.toggleVisibility}>
           <span className="title">{title}</span>
           <i


### PR DESCRIPTION
#### What does this PR do?
* Fixes a bug on filters/drop downs where they do not close when you click outside of them until you manually close them 

#### Description of Task to be completed?
* The dropdown should close once the user clicks outside the icon.

#### How should this be manually tested?
1. Clone and set up the project using the instruction in the README.
2. Use `$ npm start` to start the application
3. Visit http://localhost:3000/ in your browser
4. * Click to open one of the filters, then click anywhere else on the page
    * Click to open one of the filters, then click a different an item on the dropdown list, the filter remains open; clicking outside the filter altogether closes it

#### What are the relevant pivotal tracker stories?
[[#163692020](https://www.pivotaltracker.com/story/show/163692020)] - Fix dropdowns