### PR TITLE
bg(search):fix the search functionality to allow multiple word searching

### DIFF
--- a/src/components/ReportPage/index.jsx
+++ b/src/components/ReportPage/index.jsx
@@ -137,7 +137,7 @@ class ReportPage extends PureComponent {
 
     if (searchValue) {
       filteredReport = reportData.filter(
-        report => report[searchCriteria].toLowerCase() === searchValue.toLowerCase(),
+        report => report[searchCriteria].toLowerCase().includes(searchValue.toLowerCase()),
       );
     }
     if (filteredReport) {

--- a/src/mocks/mockReport.js
+++ b/src/mocks/mockReport.js
@@ -87,7 +87,7 @@ export default [
     id: 3,
     fellowName: 'Angela',
     fellowId: '-L6q5mRZ0jk9jf-RVjdg',
-    partnerName: 'MEA',
+    partnerName: 'MEA California',
     type: 'Offboarding',
     slackAutomation: {
       success: true,


### PR DESCRIPTION
#### What does this PR do?
It fixes the search functionality and allows a user to search for multiple-word names using one word.

#### Description of Task to be completed?
Ensures that one can search for multiple-word names using one word or a combination of characters.

#### How should this be manually tested?
- Clone and set up the project using the instruction in the README.
- $ git checkout to`bg-163720246-fix-the-search-functionality` branch which contains the changes.
- Use $ npm start to start the application
- Visit http://localhost:3000/.
- On the search box, type a character, or a combination of characters, or even a word and see the results displayed.

#### Any background context you want to provide?
- Initially, one could only search for a full word and in the case of multiple-word names you had to write all the words to actually get a result.

#### What are the relevant pivotal tracker stories?
[#163720246](https://www.pivotaltracker.com/story/show/163720246)