### PR TITLE
Improve success/failure message

### DIFF
--- a/src/__tests__/components/ReportPage.test.jsx
+++ b/src/__tests__/components/ReportPage.test.jsx
@@ -29,10 +29,12 @@ const sampleReports = [
         {
           channelName: 'andela-int',
           type: 'Addition',
+          status: 'failure'
         },
         {
           channelName: 'andela',
           type: 'Removal',
+          status: 'success'
         },
       ],
     },
@@ -80,14 +82,14 @@ describe('<ReportPage />', () => {
   describe('componenDidUpdate method', () => {
     it(`should call filterReports method if the
     filters in the state is updated`, () => {
-      const component = getComponent();
-      const componentInstance = component.instance();
-      jest.spyOn(componentInstance, 'filterReports');
-      expect(componentInstance.filterReports).toHaveBeenCalledTimes(0);
-      const previousFilters = component.state('filters');
-      component.setState({ filters: { ...previousFilters, updated: true } });
-      expect(componentInstance.filterReports).toHaveBeenCalledTimes(1);
-    });
+        const component = getComponent();
+        const componentInstance = component.instance();
+        jest.spyOn(componentInstance, 'filterReports');
+        expect(componentInstance.filterReports).toHaveBeenCalledTimes(0);
+        const previousFilters = component.state('filters');
+        component.setState({ filters: { ...previousFilters, updated: true } });
+        expect(componentInstance.filterReports).toHaveBeenCalledTimes(1);
+      });
   });
 
   describe('setFilter method', () => {
@@ -95,80 +97,80 @@ describe('<ReportPage />', () => {
       const filterSet = 'automationStatus';
       it(`should add a filter to the state and increment the filter length
       if action is add_filter`, () => {
-        const component = getComponent();
-        const componentInstance = component.instance();
-        expect(component.state('filters').automationStatus).toEqual([]);
-        expect(component.state('filters').length).toEqual(0);
-        componentInstance.setFilter(
-          'failed_automations',
-          filterSet,
-          'add_filter',
-        );
-        expect(component.state('filters').automationStatus).toEqual([
-          'failed_automations',
-        ]);
-        expect(component.state('filters').length).toEqual(1);
-      });
+          const component = getComponent();
+          const componentInstance = component.instance();
+          expect(component.state('filters').automationStatus).toEqual([]);
+          expect(component.state('filters').length).toEqual(0);
+          componentInstance.setFilter(
+            'failed_automations',
+            filterSet,
+            'add_filter',
+          );
+          expect(component.state('filters').automationStatus).toEqual([
+            'failed_automations',
+          ]);
+          expect(component.state('filters').length).toEqual(1);
+        });
       it(`should remove a filter in the state and reduce the filter length
        if action is remove_filter`, () => {
-        const component = getComponent();
-        const componentInstance = component.instance();
-        const previousFilters = component.state('filters');
-        component.setState({
-          filters: {
-            ...previousFilters,
-            automationStatus: ['failed_automations'],
-            length: 1,
-          },
+          const component = getComponent();
+          const componentInstance = component.instance();
+          const previousFilters = component.state('filters');
+          component.setState({
+            filters: {
+              ...previousFilters,
+              automationStatus: ['failed_automations'],
+              length: 1,
+            },
+          });
+          componentInstance.setFilter(
+            'failed_automations',
+            filterSet,
+            'remove_filter',
+          );
+          expect(component.state('filters').automationStatus).toEqual([]);
+          expect(component.state('filters').length).toEqual(0);
         });
-        componentInstance.setFilter(
-          'failed_automations',
-          filterSet,
-          'remove_filter',
-        );
-        expect(component.state('filters').automationStatus).toEqual([]);
-        expect(component.state('filters').length).toEqual(0);
-      });
     });
 
     describe('Automation type filter set', () => {
       const filterSet = 'automationType';
       it(`should add a filter to the state and increment the filter length,
       if action is add_filter`, () => {
-        const component = getComponent();
-        const componentInstance = component.instance();
-        expect(component.state('filters').automationType).toEqual([]);
-        expect(component.state('filters').length).toEqual(0);
-        componentInstance.setFilter(
-          'failed_automations',
-          filterSet,
-          'add_filter',
-        );
-        expect(component.state('filters').automationType).toEqual([
-          'failed_automations',
-        ]);
-        expect(component.state('filters').length).toEqual(1);
-      });
+          const component = getComponent();
+          const componentInstance = component.instance();
+          expect(component.state('filters').automationType).toEqual([]);
+          expect(component.state('filters').length).toEqual(0);
+          componentInstance.setFilter(
+            'failed_automations',
+            filterSet,
+            'add_filter',
+          );
+          expect(component.state('filters').automationType).toEqual([
+            'failed_automations',
+          ]);
+          expect(component.state('filters').length).toEqual(1);
+        });
       it(`should remove a filter in the state and reduce the filter length
       if action is remove_filter`, () => {
-        const component = getComponent();
-        const componentInstance = component.instance();
-        const previousFilters = component.state('filters');
-        component.setState({
-          filters: {
-            ...previousFilters,
-            automationType: ['failed_automations'],
-            length: 1,
-          },
+          const component = getComponent();
+          const componentInstance = component.instance();
+          const previousFilters = component.state('filters');
+          component.setState({
+            filters: {
+              ...previousFilters,
+              automationType: ['failed_automations'],
+              length: 1,
+            },
+          });
+          componentInstance.setFilter(
+            'failed_automations',
+            filterSet,
+            'remove_filter',
+          );
+          expect(component.state('filters').automationType).toEqual([]);
+          expect(component.state('filters').length).toEqual(0);
         });
-        componentInstance.setFilter(
-          'failed_automations',
-          filterSet,
-          'remove_filter',
-        );
-        expect(component.state('filters').automationType).toEqual([]);
-        expect(component.state('filters').length).toEqual(0);
-      });
     });
 
     describe('Date filter set', () => {
@@ -176,28 +178,28 @@ describe('<ReportPage />', () => {
       const sampleDateFilter = '12/02/2018';
       it(`should add a date-filter to the state and increment the filter length
       if action is set_from_date`, () => {
-        const component = getComponent();
-        const componentInstance = component.instance();
-        expect(component.state('filters').date.from).toEqual('');
-        expect(component.state('filters').length).toEqual(0);
-        componentInstance.setFilter(
-          sampleDateFilter,
-          filterSet,
-          'set_from_date',
-        );
-        expect(component.state('filters').date.from).toEqual(sampleDateFilter);
-        expect(component.state('filters').length).toEqual(1);
-      });
+          const component = getComponent();
+          const componentInstance = component.instance();
+          expect(component.state('filters').date.from).toEqual('');
+          expect(component.state('filters').length).toEqual(0);
+          componentInstance.setFilter(
+            sampleDateFilter,
+            filterSet,
+            'set_from_date',
+          );
+          expect(component.state('filters').date.from).toEqual(sampleDateFilter);
+          expect(component.state('filters').length).toEqual(1);
+        });
       it(`should add a date-filter to the state and increment the filter length
       if action is set_to_date`, () => {
-        const component = getComponent();
-        const componentInstance = component.instance();
-        expect(component.state('filters').date.to).toEqual('');
-        expect(component.state('filters').length).toEqual(0);
-        componentInstance.setFilter(sampleDateFilter, filterSet, 'set_to_date');
-        expect(component.state('filters').date.to).toEqual(sampleDateFilter);
-        expect(component.state('filters').length).toEqual(1);
-      });
+          const component = getComponent();
+          const componentInstance = component.instance();
+          expect(component.state('filters').date.to).toEqual('');
+          expect(component.state('filters').length).toEqual(0);
+          componentInstance.setFilter(sampleDateFilter, filterSet, 'set_to_date');
+          expect(component.state('filters').date.to).toEqual(sampleDateFilter);
+          expect(component.state('filters').length).toEqual(1);
+        });
       it('should not change filter length if a date filter previously existed', () => {
         const component = getComponent();
         const componentInstance = component.instance();
@@ -450,39 +452,39 @@ describe('<ReportPage />', () => {
   describe('doSearch method', () => {
     it(`should return a filtered report when
     searchResults for fellow in the state is updated`, () => {
-      const component = getComponent();
-      const componentInstance = component.instance();
-      component.setState({ reportData: sampleReports });
-      expect(component.state('searchResult')).toEqual(false);
-      expect(component.state('filteredReport')).toEqual([]);
-      componentInstance.doSearch('Shakira', 1);
-      expect(component.state('searchResult')).toEqual(true);
-      expect(component.state('filteredReport')).toEqual([sampleReports[1]]);
-    });
+        const component = getComponent();
+        const componentInstance = component.instance();
+        component.setState({ reportData: sampleReports });
+        expect(component.state('searchResult')).toEqual(false);
+        expect(component.state('filteredReport')).toEqual([]);
+        componentInstance.doSearch('Shakira', 1);
+        expect(component.state('searchResult')).toEqual(true);
+        expect(component.state('filteredReport')).toEqual([sampleReports[1]]);
+      });
 
     it(`should not return a filtered report when
     searchResults in the state is not updated`, () => {
-      const component = getComponent();
-      const componentInstance = component.instance();
-      component.setState({ reportData: sampleReports });
-      expect(component.state('searchResult')).toEqual(false);
-      expect(component.state('filteredReport')).toEqual([]);
-      componentInstance.doSearch('', '');
-      expect(component.state('searchResult')).toEqual(false);
-      expect(component.state('filteredReport')).toEqual([]);
-    });
+        const component = getComponent();
+        const componentInstance = component.instance();
+        component.setState({ reportData: sampleReports });
+        expect(component.state('searchResult')).toEqual(false);
+        expect(component.state('filteredReport')).toEqual([]);
+        componentInstance.doSearch('', '');
+        expect(component.state('searchResult')).toEqual(false);
+        expect(component.state('filteredReport')).toEqual([]);
+      });
 
     it(`should return a filtered report when
     searchResults in the state is updated`, () => {
-      const component = getComponent();
-      const componentInstance = component.instance();
-      component.setState({ reportData: sampleReports });
-      expect(component.state('searchResult')).toEqual(false);
-      expect(component.state('filteredReport')).toEqual([]);
-      componentInstance.doSearch('Andela', 2);
-      expect(component.state('searchResult')).toEqual(true);
-      expect(component.state('filteredReport')).toEqual([sampleReports[0]]);
-    });
+        const component = getComponent();
+        const componentInstance = component.instance();
+        component.setState({ reportData: sampleReports });
+        expect(component.state('searchResult')).toEqual(false);
+        expect(component.state('filteredReport')).toEqual([]);
+        componentInstance.doSearch('Andela', 2);
+        expect(component.state('searchResult')).toEqual(true);
+        expect(component.state('filteredReport')).toEqual([sampleReports[0]]);
+      });
 
     it('should redirect to the AIS page when you click the fellow name', () => {
       // eslint-disable-next-line no-undef

--- a/src/components/ReportPage/index.jsx
+++ b/src/components/ReportPage/index.jsx
@@ -234,10 +234,26 @@ class ReportPage extends PureComponent {
     this.setState({ modalContent: report, type });
   }
 
+  statusBreakdown(automation, type) {
+    const activities = automation[type + 'Automations'][type + 'Activities'] || [];
+    let stats = { s: 0, f: 0 };
+    activities.map(a => {
+      if (a.status === "success") {
+        stats.s++;
+      } else {
+        stats.f++;
+      }
+    });
+    return '(' + stats.s + '/' + activities.length + ')';
+  }
+
   renderAutomationStatus(automationStatus, report, type) {
     return (
       <span>
-        { automationStatus }&nbsp;
+        {automationStatus}&nbsp;
+        <span className={`${automationStatus}-text`}>
+          {this.statusBreakdown(report, type)}
+        </span>
         <i
           className={`fa fa-info-circle ${automationStatus}`}
           onClick={() => { this.openModal(); this.changeModalTypes(report, type); }}
@@ -355,7 +371,7 @@ ReportPage.propTypes = {
 };
 
 ReportPage.defaultProps = {
-  removeCurrentUser: () => {},
+  removeCurrentUser: () => { },
 };
 
 export default ReportPage;

--- a/src/components/ReportPage/styles.scss
+++ b/src/components/ReportPage/styles.scss
@@ -71,4 +71,12 @@
       line-height: 45px;
     }
   }
+  .success-text {
+    color: #385de0;
+    margin: auto 5px;
+  }
+  .failure-text {
+    color: #ff4d4d;
+    margin: auto 5px;
+  }
 }


### PR DESCRIPTION
Added a success to total ratio on statuses in the table

[#164050622]

#### What does this PR do?
Adds context to the success/failures status messages


#### Description of Task to be completed?
- Add a ratio of success to total actions

#### How should this be manually tested?
1. Clone and set up the project using the instruction in the README.
2. Use `$ npm start` to start the application
3. Visit http://localhost:3000 in your browser
4.  * Note the _(success/total)_ steps beside each status

#### What are the relevant pivotal tracker stories?
[[#164050622](https://www.pivotaltracker.com/story/show/164050622)]

#### Screenshots (If applicable)
![image](https://user-images.githubusercontent.com/6704417/53163872-eeefcb00-35c6-11e9-8238-a893011a055a.png)
