### PR TITLE
164210111 Fix the automation reports loading response

### DIFF
--- a/src/__tests__/components/ReportPage.test.jsx
+++ b/src/__tests__/components/ReportPage.test.jsx
@@ -489,7 +489,7 @@ describe('<ReportPage />', () => {
     it('should redirect to the AIS page when you click the fellow name', () => {
       // eslint-disable-next-line no-undef
       const component = getComponent();
-      component.setState({ reportData: sampleReports });
+      component.setState({ reportData: sampleReports, isLoadingReports: false });
       const redirectToAIS = component
         .find('.table-body')
         .find('tr')
@@ -501,7 +501,7 @@ describe('<ReportPage />', () => {
     });
     it('should render a slack modal when the slack status icons are clicked', () => {
       const component = getComponent();
-      component.setState({ reportData: sampleReports });
+      component.setState({ reportData: sampleReports, isLoadingReports: false });
       component
         .find('.fa.fa-info-circle.success')
         .at(0)
@@ -511,7 +511,7 @@ describe('<ReportPage />', () => {
 
     it('should render an email modal when the email status icons are clicked', () => {
       const component = getComponent();
-      component.setState({ reportData: sampleReports });
+      component.setState({ reportData: sampleReports, isLoadingReports: false });
       component
         .find('.fa.fa-info-circle.success')
         .at(1)
@@ -521,7 +521,7 @@ describe('<ReportPage />', () => {
 
     it('should render a freckle modal when the freckle status icons are clicked', () => {
       const component = getComponent();
-      component.setState({ reportData: sampleReports });
+      component.setState({ reportData: sampleReports, isLoadingReports: false });
       component
         .find('.fa.fa-info-circle.success')
         .at(2)
@@ -531,7 +531,7 @@ describe('<ReportPage />', () => {
 
     it('should close modal', () => {
       const component = mount(<ReportPage {...props} />);
-      component.setState({ reportData: sampleReports });
+      component.setState({ reportData: sampleReports, isLoadingReports: false });
       component
         .find('.fa.fa-info-circle.success')
         .at(2)

--- a/src/__tests__/components/Spinner/Spinner.test.jsx
+++ b/src/__tests__/components/Spinner/Spinner.test.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import Spinner from '../../../components/Spinner';
+
+const getComponent = () => shallow(<Spinner />);
+
+describe('Spinner', () => {
+  it('should render as expected', () => {
+    expect(getComponent()).toMatchSnapshot();
+  });
+});

--- a/src/__tests__/components/Spinner/__snapshots__/Spinner.test.jsx.snap
+++ b/src/__tests__/components/Spinner/__snapshots__/Spinner.test.jsx.snap
@@ -1,0 +1,62 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Spinner should render as expected 1`] = `
+ShallowWrapper {
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__unrendered__): <Spinner />,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "checkPropTypes": [Function],
+    "getNode": [Function],
+    "render": [Function],
+    "simulateError": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__node__): Object {
+    "instance": null,
+    "key": undefined,
+    "nodeType": "host",
+    "props": Object {
+      "className": "spinner undefined",
+    },
+    "ref": null,
+    "rendered": null,
+    "type": "div",
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": null,
+      "key": undefined,
+      "nodeType": "host",
+      "props": Object {
+        "className": "spinner undefined",
+      },
+      "ref": null,
+      "rendered": null,
+      "type": "div",
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+        "legacyContextMode": "parent",
+        "lifecycles": Object {
+          "componentDidUpdate": Object {
+            "onSetState": true,
+          },
+          "getChildContext": Object {
+            "calledByRenderer": false,
+          },
+          "getDerivedStateFromProps": true,
+          "getSnapshotBeforeUpdate": true,
+          "setState": Object {
+            "skipsComponentDidUpdateOnNullish": true,
+          },
+        },
+      },
+    },
+  },
+}
+`;

--- a/src/__tests__/components/__snapshots__/AutomationDetails.test.jsx.snap
+++ b/src/__tests__/components/__snapshots__/AutomationDetails.test.jsx.snap
@@ -1130,7 +1130,7 @@ ShallowWrapper {
                     "rendered": Array [
                       Object {
                         "instance": null,
-                        "key": "dbc85b54-6676-4544-a8b6-79e082b9ce2e",
+                        "key": "3265d13f-75d5-4a58-839f-26eadfdfd2e8",
                         "nodeType": "host",
                         "props": Object {
                           "children": <table
@@ -1281,7 +1281,7 @@ ShallowWrapper {
                       },
                       Object {
                         "instance": null,
-                        "key": "f34e1663-52d3-43ca-837a-b725e6de89d3",
+                        "key": "e3f2eacb-fea0-46b0-bb18-32daf42b35e3",
                         "nodeType": "host",
                         "props": Object {
                           "children": <table
@@ -2459,7 +2459,7 @@ ShallowWrapper {
                       "rendered": Array [
                         Object {
                           "instance": null,
-                          "key": "dbc85b54-6676-4544-a8b6-79e082b9ce2e",
+                          "key": "3265d13f-75d5-4a58-839f-26eadfdfd2e8",
                           "nodeType": "host",
                           "props": Object {
                             "children": <table
@@ -2610,7 +2610,7 @@ ShallowWrapper {
                         },
                         Object {
                           "instance": null,
-                          "key": "f34e1663-52d3-43ca-837a-b725e6de89d3",
+                          "key": "e3f2eacb-fea0-46b0-bb18-32daf42b35e3",
                           "nodeType": "host",
                           "props": Object {
                             "children": <table
@@ -3950,7 +3950,7 @@ ShallowWrapper {
                     "rendered": Array [
                       Object {
                         "instance": null,
-                        "key": "1d36a29a-73fd-4f5e-912c-230f891f1c82",
+                        "key": "cf2c0ec5-9df9-4690-ad2d-5b5beb9698ac",
                         "nodeType": "host",
                         "props": Object {
                           "children": <table
@@ -4101,7 +4101,7 @@ ShallowWrapper {
                       },
                       Object {
                         "instance": null,
-                        "key": "3cab9efe-576c-4465-b4ea-3b4c3d621b19",
+                        "key": "4cdc1f9b-a78a-4854-8218-e9808c938d27",
                         "nodeType": "host",
                         "props": Object {
                           "children": <table
@@ -5279,7 +5279,7 @@ ShallowWrapper {
                       "rendered": Array [
                         Object {
                           "instance": null,
-                          "key": "1d36a29a-73fd-4f5e-912c-230f891f1c82",
+                          "key": "cf2c0ec5-9df9-4690-ad2d-5b5beb9698ac",
                           "nodeType": "host",
                           "props": Object {
                             "children": <table
@@ -5430,7 +5430,7 @@ ShallowWrapper {
                         },
                         Object {
                           "instance": null,
-                          "key": "3cab9efe-576c-4465-b4ea-3b4c3d621b19",
+                          "key": "4cdc1f9b-a78a-4854-8218-e9808c938d27",
                           "nodeType": "host",
                           "props": Object {
                             "children": <table
@@ -6728,7 +6728,7 @@ ShallowWrapper {
                     "rendered": Array [
                       Object {
                         "instance": null,
-                        "key": "cbb31a41-bc8d-4189-aea2-1840542c7eaf",
+                        "key": "40ee785c-c159-4a92-8366-c9abc6465bb9",
                         "nodeType": "host",
                         "props": Object {
                           "children": <table
@@ -6879,7 +6879,7 @@ ShallowWrapper {
                       },
                       Object {
                         "instance": null,
-                        "key": "65bacf14-4f50-40fa-9659-ab7153d58dee",
+                        "key": "93001337-4fd8-4441-94ac-8962a5118a18",
                         "nodeType": "host",
                         "props": Object {
                           "children": <table
@@ -8057,7 +8057,7 @@ ShallowWrapper {
                       "rendered": Array [
                         Object {
                           "instance": null,
-                          "key": "cbb31a41-bc8d-4189-aea2-1840542c7eaf",
+                          "key": "40ee785c-c159-4a92-8366-c9abc6465bb9",
                           "nodeType": "host",
                           "props": Object {
                             "children": <table
@@ -8208,7 +8208,7 @@ ShallowWrapper {
                         },
                         Object {
                           "instance": null,
-                          "key": "65bacf14-4f50-40fa-9659-ab7153d58dee",
+                          "key": "93001337-4fd8-4441-94ac-8962a5118a18",
                           "nodeType": "host",
                           "props": Object {
                             "children": <table

--- a/src/__tests__/components/__snapshots__/ReportPage.test.jsx.snap
+++ b/src/__tests__/components/__snapshots__/ReportPage.test.jsx.snap
@@ -212,11 +212,10 @@ ShallowWrapper {
           <div
             className="table-body"
           >
-            <table
-              className="report-table"
-            >
-              <tbody />
-            </table>
+            <Spinner
+              isAbsolute={true}
+              size="large"
+            />
           </div>
           <AutomationDetails
             closeModal={[Function]}
@@ -418,11 +417,10 @@ ShallowWrapper {
             <div
               className="table-body"
             >
-              <table
-                className="report-table"
-              >
-                <tbody />
-              </table>
+              <Spinner
+                isAbsolute={true}
+                size="large"
+              />
             </div>,
             <AutomationDetails
               closeModal={[Function]}
@@ -966,35 +964,24 @@ ShallowWrapper {
             "key": undefined,
             "nodeType": "host",
             "props": Object {
-              "children": <table
-                className="report-table"
-              >
-                <tbody />
-              </table>,
+              "children": <Spinner
+                isAbsolute={true}
+                size="large"
+              />,
               "className": "table-body",
             },
             "ref": null,
             "rendered": Object {
               "instance": null,
               "key": undefined,
-              "nodeType": "host",
+              "nodeType": "function",
               "props": Object {
-                "children": <tbody />,
-                "className": "report-table",
+                "isAbsolute": true,
+                "size": "large",
               },
               "ref": null,
-              "rendered": Object {
-                "instance": null,
-                "key": undefined,
-                "nodeType": "host",
-                "props": Object {
-                  "children": Array [],
-                },
-                "ref": null,
-                "rendered": Array [],
-                "type": "tbody",
-              },
-              "type": "table",
+              "rendered": null,
+              "type": [Function],
             },
             "type": "div",
           },
@@ -1205,11 +1192,10 @@ ShallowWrapper {
             <div
               className="table-body"
             >
-              <table
-                className="report-table"
-              >
-                <tbody />
-              </table>
+              <Spinner
+                isAbsolute={true}
+                size="large"
+              />
             </div>
             <AutomationDetails
               closeModal={[Function]}
@@ -1411,11 +1397,10 @@ ShallowWrapper {
               <div
                 className="table-body"
               >
-                <table
-                  className="report-table"
-                >
-                  <tbody />
-                </table>
+                <Spinner
+                  isAbsolute={true}
+                  size="large"
+                />
               </div>,
               <AutomationDetails
                 closeModal={[Function]}
@@ -1959,35 +1944,24 @@ ShallowWrapper {
               "key": undefined,
               "nodeType": "host",
               "props": Object {
-                "children": <table
-                  className="report-table"
-                >
-                  <tbody />
-                </table>,
+                "children": <Spinner
+                  isAbsolute={true}
+                  size="large"
+                />,
                 "className": "table-body",
               },
               "ref": null,
               "rendered": Object {
                 "instance": null,
                 "key": undefined,
-                "nodeType": "host",
+                "nodeType": "function",
                 "props": Object {
-                  "children": <tbody />,
-                  "className": "report-table",
+                  "isAbsolute": true,
+                  "size": "large",
                 },
                 "ref": null,
-                "rendered": Object {
-                  "instance": null,
-                  "key": undefined,
-                  "nodeType": "host",
-                  "props": Object {
-                    "children": Array [],
-                  },
-                  "ref": null,
-                  "rendered": Array [],
-                  "type": "tbody",
-                },
-                "type": "table",
+                "rendered": null,
+                "type": [Function],
               },
               "type": "div",
             },

--- a/src/components/ReportPage/index.jsx
+++ b/src/components/ReportPage/index.jsx
@@ -11,6 +11,7 @@ import * as constants from '../constants';
 import FiltersBar from '../FiltersBar';
 import './styles.scss';
 import AutomationDetails from '../AutomationDetails';
+import Spinner from '../Spinner';
 
 
 /* eslint-disable class-methods-use-this */
@@ -31,12 +32,16 @@ class ReportPage extends PureComponent {
       isModalOpen: false,
       modalContent: {},
       type: '',
+      isLoadingReports: false,
     };
   }
 
   async componentDidMount() {
     const reportData = await this.reportData();
-    this.setState({ reportData });
+    this.setState({
+      isLoadingReports: false,
+      reportData,
+    });
   }
 
   componentDidUpdate() {
@@ -47,6 +52,10 @@ class ReportPage extends PureComponent {
   }
 
   reportData = async () => {
+    const { isLoadingReports } = this.state;
+    this.setState({
+      isLoadingReports: !isLoadingReports,
+    });
     const url = 'https://api-staging-esa.andela.com/api/v1/automations';
     const data = await axios
       .get(url)
@@ -308,6 +317,7 @@ class ReportPage extends PureComponent {
 
   render() {
     const { currentUser, removeCurrentUser, history } = this.props;
+    const { isLoadingReports } = this.state;
     const {
       isModalOpen, modalContent, type, filters,
     } = this.state;
@@ -346,11 +356,17 @@ class ReportPage extends PureComponent {
             </table>
           </div>
           <div className="table-body">
-            <table className="report-table">
-              <tbody>
-                {this.renderTableRows()}
-              </tbody>
-            </table>
+            {
+              isLoadingReports
+                ? <Spinner />
+                : (
+                  <table className="report-table">
+                    <tbody>
+                      {this.renderTableRows()}
+                    </tbody>
+                  </table>
+                )
+            }
           </div>
           <AutomationDetails
             isModalOpen={isModalOpen}

--- a/src/components/Spinner/index.jsx
+++ b/src/components/Spinner/index.jsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import PropTypes from 'proptypes';
+import './styles.scss';
+
+const Spinner = ({ size }) => (
+  <div className={`spinner ${size}`} />
+);
+
+Spinner.propTypes = {
+  size: PropTypes.string,
+};
+
+Spinner.defaultProps = {
+  size: 'large',
+};
+
+export default Spinner;

--- a/src/components/Spinner/styles.scss
+++ b/src/components/Spinner/styles.scss
@@ -1,0 +1,32 @@
+.spinner {
+  box-sizing: border-box;
+  border-top: 3px solid #3359db;
+  border-right: 2px solid transparent;
+  border-radius: 50%;
+  content: '';
+  animation: spinner 1s ease infinite;
+
+  &.small {
+    width: 16px;
+    height: 16px;
+  }
+
+  &.medium {
+    width: 30px;
+    height: 30px;
+  }
+
+  &.large {
+    position: absolute;
+    top: 55%;
+    left: 50%;
+    width: 60px;
+    height: 60px;
+  }
+}
+
+@keyframes spinner {
+  to {
+    transform: rotate(360deg);
+  }
+}


### PR DESCRIPTION
  **What does this PR do?**

This PR adds a reusable page loader component to display on the automation reports table when the page is still loading.

**Description of the task to be completed?**
- Add `Spinner` component
- Add CSS styles for the component
- Add `isLoadingReports` state
- Change the logic for displaying the automation table content.

**How should this be manually tested?**

1. Clone the repo `https://github.com/andela/bp-esa-frontend`
2. Check out to `bp-esa-frontend` folder and run this command on your terminal `git fetch && git checkout `bg-fix-loading-response-164210111` and run `yarn install` on your terminal
3. Start the application with the command `yarn start`

**What are the relevant pivotal tracker stories?**
[#164210111](https://www.pivotaltracker.com/story/show/164210111)
