### PR TITLE
#164133528 Add pagination to the report page

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "firebase": "^5.8.2",
     "fs-extra": "3.0.1",
     "jquery": "^1.9.1",
+    "lodash": "^4.17.11",
     "moment": "^2.22.2",
     "postcss-flexbugs-fixes": "3.2.0",
     "postcss-loader": "2.0.8",

--- a/src/__tests__/components/ReportPage.test.jsx
+++ b/src/__tests__/components/ReportPage.test.jsx
@@ -29,12 +29,12 @@ const sampleReports = [
         {
           channelName: 'andela-int',
           type: 'Addition',
-          status: 'failure'
+          status: 'failure',
         },
         {
           channelName: 'andela',
           type: 'Removal',
-          status: 'success'
+          status: 'success',
         },
       ],
     },
@@ -63,6 +63,15 @@ const sampleReports = [
     updatedAt: '2018-09-29',
   },
 ];
+
+const pagination = {
+  pagination: {
+    currentPage: 1,
+    numberOfPages: 722,
+    dataCount: 7212,
+    nextPage: 2,
+  },
+};
 class CustomError extends Error {
   constructor(...params) {
     super(...params);
@@ -82,14 +91,14 @@ describe('<ReportPage />', () => {
   describe('componenDidUpdate method', () => {
     it(`should call filterReports method if the
     filters in the state is updated`, () => {
-        const component = getComponent();
-        const componentInstance = component.instance();
-        jest.spyOn(componentInstance, 'filterReports');
-        expect(componentInstance.filterReports).toHaveBeenCalledTimes(0);
-        const previousFilters = component.state('filters');
-        component.setState({ filters: { ...previousFilters, updated: true } });
-        expect(componentInstance.filterReports).toHaveBeenCalledTimes(1);
-      });
+      const component = getComponent();
+      const componentInstance = component.instance();
+      jest.spyOn(componentInstance, 'filterReports');
+      expect(componentInstance.filterReports).toHaveBeenCalledTimes(0);
+      const previousFilters = component.state('filters');
+      component.setState({ filters: { ...previousFilters, updated: true } });
+      expect(componentInstance.filterReports).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('setFilter method', () => {
@@ -97,80 +106,80 @@ describe('<ReportPage />', () => {
       const filterSet = 'automationStatus';
       it(`should add a filter to the state and increment the filter length
       if action is add_filter`, () => {
-          const component = getComponent();
-          const componentInstance = component.instance();
-          expect(component.state('filters').automationStatus).toEqual([]);
-          expect(component.state('filters').length).toEqual(0);
-          componentInstance.setFilter(
-            'failed_automations',
-            filterSet,
-            'add_filter',
-          );
-          expect(component.state('filters').automationStatus).toEqual([
-            'failed_automations',
-          ]);
-          expect(component.state('filters').length).toEqual(1);
-        });
+        const component = getComponent();
+        const componentInstance = component.instance();
+        expect(component.state('filters').automationStatus).toEqual([]);
+        expect(component.state('filters').length).toEqual(0);
+        componentInstance.setFilter(
+          'failed_automations',
+          filterSet,
+          'add_filter',
+        );
+        expect(component.state('filters').automationStatus).toEqual([
+          'failed_automations',
+        ]);
+        expect(component.state('filters').length).toEqual(1);
+      });
       it(`should remove a filter in the state and reduce the filter length
        if action is remove_filter`, () => {
-          const component = getComponent();
-          const componentInstance = component.instance();
-          const previousFilters = component.state('filters');
-          component.setState({
-            filters: {
-              ...previousFilters,
-              automationStatus: ['failed_automations'],
-              length: 1,
-            },
-          });
-          componentInstance.setFilter(
-            'failed_automations',
-            filterSet,
-            'remove_filter',
-          );
-          expect(component.state('filters').automationStatus).toEqual([]);
-          expect(component.state('filters').length).toEqual(0);
+        const component = getComponent();
+        const componentInstance = component.instance();
+        const previousFilters = component.state('filters');
+        component.setState({
+          filters: {
+            ...previousFilters,
+            automationStatus: ['failed_automations'],
+            length: 1,
+          },
         });
+        componentInstance.setFilter(
+          'failed_automations',
+          filterSet,
+          'remove_filter',
+        );
+        expect(component.state('filters').automationStatus).toEqual([]);
+        expect(component.state('filters').length).toEqual(0);
+      });
     });
 
     describe('Automation type filter set', () => {
       const filterSet = 'automationType';
       it(`should add a filter to the state and increment the filter length,
       if action is add_filter`, () => {
-          const component = getComponent();
-          const componentInstance = component.instance();
-          expect(component.state('filters').automationType).toEqual([]);
-          expect(component.state('filters').length).toEqual(0);
-          componentInstance.setFilter(
-            'failed_automations',
-            filterSet,
-            'add_filter',
-          );
-          expect(component.state('filters').automationType).toEqual([
-            'failed_automations',
-          ]);
-          expect(component.state('filters').length).toEqual(1);
-        });
+        const component = getComponent();
+        const componentInstance = component.instance();
+        expect(component.state('filters').automationType).toEqual([]);
+        expect(component.state('filters').length).toEqual(0);
+        componentInstance.setFilter(
+          'failed_automations',
+          filterSet,
+          'add_filter',
+        );
+        expect(component.state('filters').automationType).toEqual([
+          'failed_automations',
+        ]);
+        expect(component.state('filters').length).toEqual(1);
+      });
       it(`should remove a filter in the state and reduce the filter length
       if action is remove_filter`, () => {
-          const component = getComponent();
-          const componentInstance = component.instance();
-          const previousFilters = component.state('filters');
-          component.setState({
-            filters: {
-              ...previousFilters,
-              automationType: ['failed_automations'],
-              length: 1,
-            },
-          });
-          componentInstance.setFilter(
-            'failed_automations',
-            filterSet,
-            'remove_filter',
-          );
-          expect(component.state('filters').automationType).toEqual([]);
-          expect(component.state('filters').length).toEqual(0);
+        const component = getComponent();
+        const componentInstance = component.instance();
+        const previousFilters = component.state('filters');
+        component.setState({
+          filters: {
+            ...previousFilters,
+            automationType: ['failed_automations'],
+            length: 1,
+          },
         });
+        componentInstance.setFilter(
+          'failed_automations',
+          filterSet,
+          'remove_filter',
+        );
+        expect(component.state('filters').automationType).toEqual([]);
+        expect(component.state('filters').length).toEqual(0);
+      });
     });
 
     describe('Date filter set', () => {
@@ -178,28 +187,28 @@ describe('<ReportPage />', () => {
       const sampleDateFilter = '12/02/2018';
       it(`should add a date-filter to the state and increment the filter length
       if action is set_from_date`, () => {
-          const component = getComponent();
-          const componentInstance = component.instance();
-          expect(component.state('filters').date.from).toEqual('');
-          expect(component.state('filters').length).toEqual(0);
-          componentInstance.setFilter(
-            sampleDateFilter,
-            filterSet,
-            'set_from_date',
-          );
-          expect(component.state('filters').date.from).toEqual(sampleDateFilter);
-          expect(component.state('filters').length).toEqual(1);
-        });
+        const component = getComponent();
+        const componentInstance = component.instance();
+        expect(component.state('filters').date.from).toEqual('');
+        expect(component.state('filters').length).toEqual(0);
+        componentInstance.setFilter(
+          sampleDateFilter,
+          filterSet,
+          'set_from_date',
+        );
+        expect(component.state('filters').date.from).toEqual(sampleDateFilter);
+        expect(component.state('filters').length).toEqual(1);
+      });
       it(`should add a date-filter to the state and increment the filter length
       if action is set_to_date`, () => {
-          const component = getComponent();
-          const componentInstance = component.instance();
-          expect(component.state('filters').date.to).toEqual('');
-          expect(component.state('filters').length).toEqual(0);
-          componentInstance.setFilter(sampleDateFilter, filterSet, 'set_to_date');
-          expect(component.state('filters').date.to).toEqual(sampleDateFilter);
-          expect(component.state('filters').length).toEqual(1);
-        });
+        const component = getComponent();
+        const componentInstance = component.instance();
+        expect(component.state('filters').date.to).toEqual('');
+        expect(component.state('filters').length).toEqual(0);
+        componentInstance.setFilter(sampleDateFilter, filterSet, 'set_to_date');
+        expect(component.state('filters').date.to).toEqual(sampleDateFilter);
+        expect(component.state('filters').length).toEqual(1);
+      });
       it('should not change filter length if a date filter previously existed', () => {
         const component = getComponent();
         const componentInstance = component.instance();
@@ -252,6 +261,7 @@ describe('<ReportPage />', () => {
           length: 1,
           updated: true,
         },
+        pagination,
       });
       expect(component.state('filteredReport')).toEqual([sampleReports[0]]);
     });
@@ -452,39 +462,39 @@ describe('<ReportPage />', () => {
   describe('doSearch method', () => {
     it(`should return a filtered report when
     searchResults for fellow in the state is updated`, () => {
-        const component = getComponent();
-        const componentInstance = component.instance();
-        component.setState({ reportData: sampleReports });
-        expect(component.state('searchResult')).toEqual(false);
-        expect(component.state('filteredReport')).toEqual([]);
-        componentInstance.doSearch('Shakira', 1);
-        expect(component.state('searchResult')).toEqual(true);
-        expect(component.state('filteredReport')).toEqual([sampleReports[1]]);
-      });
+      const component = getComponent();
+      const componentInstance = component.instance();
+      component.setState({ reportData: sampleReports });
+      expect(component.state('searchResult')).toEqual(false);
+      expect(component.state('filteredReport')).toEqual([]);
+      componentInstance.doSearch('Shakira', 1);
+      expect(component.state('searchResult')).toEqual(true);
+      expect(component.state('filteredReport')).toEqual([sampleReports[1]]);
+    });
 
     it(`should not return a filtered report when
     searchResults in the state is not updated`, () => {
-        const component = getComponent();
-        const componentInstance = component.instance();
-        component.setState({ reportData: sampleReports });
-        expect(component.state('searchResult')).toEqual(false);
-        expect(component.state('filteredReport')).toEqual([]);
-        componentInstance.doSearch('', '');
-        expect(component.state('searchResult')).toEqual(false);
-        expect(component.state('filteredReport')).toEqual([]);
-      });
+      const component = getComponent();
+      const componentInstance = component.instance();
+      component.setState({ reportData: sampleReports });
+      expect(component.state('searchResult')).toEqual(false);
+      expect(component.state('filteredReport')).toEqual([]);
+      componentInstance.doSearch('', '');
+      expect(component.state('searchResult')).toEqual(false);
+      expect(component.state('filteredReport')).toEqual([]);
+    });
 
     it(`should return a filtered report when
     searchResults in the state is updated`, () => {
-        const component = getComponent();
-        const componentInstance = component.instance();
-        component.setState({ reportData: sampleReports });
-        expect(component.state('searchResult')).toEqual(false);
-        expect(component.state('filteredReport')).toEqual([]);
-        componentInstance.doSearch('Andela', 2);
-        expect(component.state('searchResult')).toEqual(true);
-        expect(component.state('filteredReport')).toEqual([sampleReports[0]]);
-      });
+      const component = getComponent();
+      const componentInstance = component.instance();
+      component.setState({ reportData: sampleReports });
+      expect(component.state('searchResult')).toEqual(false);
+      expect(component.state('filteredReport')).toEqual([]);
+      componentInstance.doSearch('Andela', 2);
+      expect(component.state('searchResult')).toEqual(true);
+      expect(component.state('filteredReport')).toEqual([sampleReports[0]]);
+    });
 
     it('should redirect to the AIS page when you click the fellow name', () => {
       // eslint-disable-next-line no-undef
@@ -545,7 +555,7 @@ describe('<ReportPage />', () => {
   describe('querying the backend', () => {
     it('should get allocations from the backend', async () => {
       Object.defineProperty(axios, 'get', {
-        value: url => new Promise(resolve => resolve({ data: { data: sampleReports } })),
+        value: url => new Promise(resolve => resolve({ data: { data: sampleReports, pagination } })),
       });
       const component = await getComponent();
       const spy = jest.spyOn(component.instance(), 'componentDidMount');
@@ -561,7 +571,7 @@ describe('<ReportPage />', () => {
       });
       const component = await getComponent();
       await component.instance().componentDidMount();
-      expect(component.instance().state.reportData).toEqual(errorResponse);
+      expect(component.instance().state.reportData).toEqual([]);
     });
   });
 });

--- a/src/__tests__/components/Search/__snapshots__/Search.test.jsx.snap
+++ b/src/__tests__/components/Search/__snapshots__/Search.test.jsx.snap
@@ -68,6 +68,7 @@ ShallowWrapper {
           </ul>
         </div>,
       ],
+      "className": "search-container",
     },
     "ref": null,
     "rendered": Array [
@@ -347,6 +348,7 @@ ShallowWrapper {
             </ul>
           </div>,
         ],
+        "className": "search-container",
       },
       "ref": null,
       "rendered": Array [

--- a/src/__tests__/components/Spinner/__snapshots__/Spinner.test.jsx.snap
+++ b/src/__tests__/components/Spinner/__snapshots__/Spinner.test.jsx.snap
@@ -3,7 +3,9 @@
 exports[`Spinner should render as expected 1`] = `
 ShallowWrapper {
   Symbol(enzyme.__root__): [Circular],
-  Symbol(enzyme.__unrendered__): <Spinner />,
+  Symbol(enzyme.__unrendered__): <Spinner
+    size="large"
+  />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
     "checkPropTypes": [Function],
@@ -18,7 +20,7 @@ ShallowWrapper {
     "key": undefined,
     "nodeType": "host",
     "props": Object {
-      "className": "spinner undefined",
+      "className": "spinner large",
     },
     "ref": null,
     "rendered": null,
@@ -30,7 +32,7 @@ ShallowWrapper {
       "key": undefined,
       "nodeType": "host",
       "props": Object {
-        "className": "spinner undefined",
+        "className": "spinner large",
       },
       "ref": null,
       "rendered": null,

--- a/src/__tests__/components/__snapshots__/AutomationDetails.test.jsx.snap
+++ b/src/__tests__/components/__snapshots__/AutomationDetails.test.jsx.snap
@@ -1130,7 +1130,7 @@ ShallowWrapper {
                     "rendered": Array [
                       Object {
                         "instance": null,
-                        "key": "3265d13f-75d5-4a58-839f-26eadfdfd2e8",
+                        "key": "085937a5-36ab-4867-98be-dc6f39e4595d",
                         "nodeType": "host",
                         "props": Object {
                           "children": <table
@@ -1281,7 +1281,7 @@ ShallowWrapper {
                       },
                       Object {
                         "instance": null,
-                        "key": "e3f2eacb-fea0-46b0-bb18-32daf42b35e3",
+                        "key": "40c23b5d-7690-41d9-af75-129ed0fff7a3",
                         "nodeType": "host",
                         "props": Object {
                           "children": <table
@@ -2459,7 +2459,7 @@ ShallowWrapper {
                       "rendered": Array [
                         Object {
                           "instance": null,
-                          "key": "3265d13f-75d5-4a58-839f-26eadfdfd2e8",
+                          "key": "085937a5-36ab-4867-98be-dc6f39e4595d",
                           "nodeType": "host",
                           "props": Object {
                             "children": <table
@@ -2610,7 +2610,7 @@ ShallowWrapper {
                         },
                         Object {
                           "instance": null,
-                          "key": "e3f2eacb-fea0-46b0-bb18-32daf42b35e3",
+                          "key": "40c23b5d-7690-41d9-af75-129ed0fff7a3",
                           "nodeType": "host",
                           "props": Object {
                             "children": <table
@@ -3950,7 +3950,7 @@ ShallowWrapper {
                     "rendered": Array [
                       Object {
                         "instance": null,
-                        "key": "cf2c0ec5-9df9-4690-ad2d-5b5beb9698ac",
+                        "key": "2f70e596-1ce5-4a68-8103-bf91f4f26356",
                         "nodeType": "host",
                         "props": Object {
                           "children": <table
@@ -4101,7 +4101,7 @@ ShallowWrapper {
                       },
                       Object {
                         "instance": null,
-                        "key": "4cdc1f9b-a78a-4854-8218-e9808c938d27",
+                        "key": "f021dd53-d56d-44d3-b959-91d7095e64cd",
                         "nodeType": "host",
                         "props": Object {
                           "children": <table
@@ -5279,7 +5279,7 @@ ShallowWrapper {
                       "rendered": Array [
                         Object {
                           "instance": null,
-                          "key": "cf2c0ec5-9df9-4690-ad2d-5b5beb9698ac",
+                          "key": "2f70e596-1ce5-4a68-8103-bf91f4f26356",
                           "nodeType": "host",
                           "props": Object {
                             "children": <table
@@ -5430,7 +5430,7 @@ ShallowWrapper {
                         },
                         Object {
                           "instance": null,
-                          "key": "4cdc1f9b-a78a-4854-8218-e9808c938d27",
+                          "key": "f021dd53-d56d-44d3-b959-91d7095e64cd",
                           "nodeType": "host",
                           "props": Object {
                             "children": <table
@@ -6728,7 +6728,7 @@ ShallowWrapper {
                     "rendered": Array [
                       Object {
                         "instance": null,
-                        "key": "40ee785c-c159-4a92-8366-c9abc6465bb9",
+                        "key": "728e628f-630b-4587-a217-87d1b3c46dd1",
                         "nodeType": "host",
                         "props": Object {
                           "children": <table
@@ -6879,7 +6879,7 @@ ShallowWrapper {
                       },
                       Object {
                         "instance": null,
-                        "key": "93001337-4fd8-4441-94ac-8962a5118a18",
+                        "key": "3159efe1-4774-4778-b525-b6969d096c92",
                         "nodeType": "host",
                         "props": Object {
                           "children": <table
@@ -8057,7 +8057,7 @@ ShallowWrapper {
                       "rendered": Array [
                         Object {
                           "instance": null,
-                          "key": "40ee785c-c159-4a92-8366-c9abc6465bb9",
+                          "key": "728e628f-630b-4587-a217-87d1b3c46dd1",
                           "nodeType": "host",
                           "props": Object {
                             "children": <table
@@ -8208,7 +8208,7 @@ ShallowWrapper {
                         },
                         Object {
                           "instance": null,
-                          "key": "93001337-4fd8-4441-94ac-8962a5118a18",
+                          "key": "3159efe1-4774-4778-b525-b6969d096c92",
                           "nodeType": "host",
                           "props": Object {
                             "children": <table

--- a/src/__tests__/components/__snapshots__/ReportPage.test.jsx.snap
+++ b/src/__tests__/components/__snapshots__/ReportPage.test.jsx.snap
@@ -213,7 +213,6 @@ ShallowWrapper {
             className="table-body"
           >
             <Spinner
-              isAbsolute={true}
               size="large"
             />
           </div>
@@ -418,7 +417,6 @@ ShallowWrapper {
               className="table-body"
             >
               <Spinner
-                isAbsolute={true}
                 size="large"
               />
             </div>,
@@ -965,7 +963,6 @@ ShallowWrapper {
             "nodeType": "host",
             "props": Object {
               "children": <Spinner
-                isAbsolute={true}
                 size="large"
               />,
               "className": "table-body",
@@ -976,7 +973,6 @@ ShallowWrapper {
               "key": undefined,
               "nodeType": "function",
               "props": Object {
-                "isAbsolute": true,
                 "size": "large",
               },
               "ref": null,
@@ -1193,7 +1189,6 @@ ShallowWrapper {
               className="table-body"
             >
               <Spinner
-                isAbsolute={true}
                 size="large"
               />
             </div>
@@ -1398,7 +1393,6 @@ ShallowWrapper {
                 className="table-body"
               >
                 <Spinner
-                  isAbsolute={true}
                   size="large"
                 />
               </div>,
@@ -1945,7 +1939,6 @@ ShallowWrapper {
               "nodeType": "host",
               "props": Object {
                 "children": <Spinner
-                  isAbsolute={true}
                   size="large"
                 />,
                 "className": "table-body",
@@ -1956,7 +1949,6 @@ ShallowWrapper {
                 "key": undefined,
                 "nodeType": "function",
                 "props": Object {
-                  "isAbsolute": true,
                   "size": "large",
                 },
                 "ref": null,

--- a/src/assets/icons/first-page-icon.svg
+++ b/src/assets/icons/first-page-icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill='#385de0'><path d="M18.41 16.59L13.82 12l4.59-4.59L17 6l-6 6 6 6zM6 6h2v12H6z"/><path fill="none" d="M24 24H0V0h24v24z"/></svg>

--- a/src/assets/icons/last-page-icon.svg
+++ b/src/assets/icons/last-page-icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill='#385de0'><path d="M5.59 7.41L10.18 12l-4.59 4.59L7 18l6-6-6-6zM16 6h2v12h-2z"/><path fill="none" d="M0 0h24v24H0V0z"/></svg>

--- a/src/assets/icons/next-icon.svg
+++ b/src/assets/icons/next-icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill='#385de0'><path d="M8.59 16.59L13.17 12 8.59 7.41 10 6l6 6-6 6-1.41-1.41z"/><path fill="none" d="M0 0h24v24H0V0z"/></svg>

--- a/src/assets/icons/previous-icon.svg
+++ b/src/assets/icons/previous-icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill='#385de0'><path d="M15.41 16.59L10.83 12l4.58-4.59L14 6l-6 6 6 6 1.41-1.41z"/><path fill="none" d="M0 0h24v24H0V0z"/></svg>

--- a/src/components/Filter/styles.scss
+++ b/src/components/Filter/styles.scss
@@ -5,17 +5,22 @@
   margin-left: 25px;
   text-transform: capitalize;
   .filter-title {
+    border-radius: 3px;
+    display: flex;
+    flex-direction: row;
     padding: 8px 20px 8px 20px;
     border: 1px solid grey;
     text-align: center;
     margin: 5px;
     color: #4d4d4d;
-    cursor: pointer; 
+    cursor: pointer;
     &:hover {
       color: black;
+      background: lighten(#385de0, 45%);
     }
     i {
       margin-left: 10px;
+      padding-top: 2px;
       font-size: 20px;
       transition: all 0.3s;
       &.rotate-180 {
@@ -32,7 +37,7 @@
     border-radius: 3px;
     background-color: white;
     box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
-    transition: all 0.3s;    
+    transition: all 0.3s;
     li {
       border-bottom: 1px solid #d9d9d9;
       padding: 5px;

--- a/src/components/Pagination/index.jsx
+++ b/src/components/Pagination/index.jsx
@@ -1,0 +1,77 @@
+import React, { Fragment } from 'react';
+import './index.scss';
+import PropTypes from 'prop-types';
+import nextPageIcon from '../../assets/icons/next-icon.svg';
+import prevPageIcon from '../../assets/icons/previous-icon.svg';
+import lastPageIcon from '../../assets/icons/last-page-icon.svg';
+import firstPageIcon from '../../assets/icons/first-page-icon.svg';
+
+export default function Pagination({
+  pagination: { numberOfPages, currentPage, limit },
+  handlePagination, onChangePage, onChangeRowCount,
+}) {
+  const renderButton = (icon, text, handleNav, disabled) => (
+    <button className={`${disabled ? 'disabled' : 'page-btn icon-btn'}`} type="button" disabled={disabled} onClick={() => handleNav(text)}>
+      <img className="nav-icon" src={icon} alt={text} />
+    </button>
+  );
+
+  const renderPageNumber = page => (
+    <Fragment>
+      <input
+        className="form-input"
+        type="text"
+        name="pageNumber"
+        value={page}
+        onChange={(e) => { onChangePage(e); }}
+      />
+    </Fragment>
+  );
+
+  const renderLimitDropdown = () => (
+    <form>
+      <label>
+          Rows per page: &nbsp;
+        <select className="select" value={limit} onChange={(e) => { onChangeRowCount(e); }}>
+          <option value={10}>10</option>
+          <option value={25}>25</option>
+          <option value={50}>50</option>
+          <option value={100}>100</option>
+        </select>
+      </label>
+    </form>
+  );
+
+  const renderPaginationPanel = (pages, page) => (
+    <Fragment>
+      <div className="pagination">
+        <div className="center-item">
+          <p>
+            {`Page ${currentPage} of ${pages}`}
+          </p>
+        </div>
+        {renderLimitDropdown()}
+        <div className="page-panel">
+          {renderButton(firstPageIcon, 'firstPage', handlePagination, (!(page > 1)))}
+          {renderButton(prevPageIcon, 'previous', handlePagination, (!(page > 1)))}
+          {renderPageNumber(page)}
+          {renderButton(nextPageIcon, 'next', handlePagination, (!(page < pages)))}
+          {renderButton(lastPageIcon, 'lastPage', handlePagination, (!(page < pages)))}
+        </div>
+      </div>
+    </Fragment>
+  );
+
+  return (
+    <Fragment>
+      {renderPaginationPanel(numberOfPages, currentPage)}
+    </Fragment>
+  );
+}
+
+Pagination.propTypes = {
+  pagination: PropTypes.object.isRequired,
+  handlePagination: PropTypes.func.isRequired,
+  onChangePage: PropTypes.func.isRequired,
+  onChangeRowCount: PropTypes.func.isRequired,
+};

--- a/src/components/Pagination/index.scss
+++ b/src/components/Pagination/index.scss
@@ -1,0 +1,101 @@
+.pagination{
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  color: gray;
+  font-size: 0.8rem;
+  padding: 15px;
+  margin-top: 20px;
+
+  .page-btn{
+    min-height: 40px;
+    min-width: 40px;
+    color: #385de0;
+    border: none;
+    border-radius: 50%;
+    transition: background-color, 0.2s;
+    font-size: 1rem;
+    margin: 5px;
+
+    &:focus{
+      outline: none;
+    }
+
+    &:hover{
+      background-color: lighten($color: #385de0, $amount: 10%);
+      color: #fff;
+    }
+
+    &.icon-btn{
+      display: flex;
+      justify-content: center;
+
+      &.nav-text{
+        padding: 5px;
+      }
+      &:hover{
+        background-color: inherit;
+        border: solid 1px #385de0;
+      }
+    }
+  }
+}
+
+.active{
+  border: solid 1px lighten($color: #385de0, $amount: 10%)!important;
+}
+
+.page-panel{
+  width: 16%;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  place-items: center;
+  margin-left: 20px;
+  margin-bottom: 6px;
+}
+
+.nav-icon{
+  height: 20px;
+  width: 20px;
+}
+
+.disabled{
+  min-height: 40px;
+  min-width: 40px;
+  border: none;
+  margin: 5px;
+}
+
+.form-input{
+    // margin: 0.7rem;
+    border: none;
+    width: 50px;
+    border-bottom: 1px solid gray;
+    text-align: center;
+    color: gray;
+
+    &:focus{
+      outline: none;
+    }
+}
+
+.select{
+    border: none;
+    background-color: inherit;
+    color: gray;
+
+    &:focus{
+      outline: none;
+    }
+}
+
+.center-item{
+  width: 50%;
+
+  >p {
+    margin-bottom: 0.5rem;
+  }
+}
+
+

--- a/src/components/ReportPage/styles.scss
+++ b/src/components/ReportPage/styles.scss
@@ -9,7 +9,6 @@
   }
   .table-body {
     height: 85vh;
-    overflow: scroll;
     padding: 1px;
     tr {
       font-size: 15px;

--- a/src/components/Search/index.jsx
+++ b/src/components/Search/index.jsx
@@ -24,20 +24,20 @@ class Search extends PureComponent {
   }
 
 
-  toggleVisibility = e => {
+  toggleVisibility = (e) => {
     // The DOM's UL element holding the list of options
     const searchOptionsEl = ReactDOM.findDOMNode(this)
-                            .getElementsByClassName('search-option')[0];
-    const clickOff = ev => {
+      .getElementsByClassName('search-option')[0];
+    const clickOff = (ev) => {
       if (ev.target === searchOptionsEl) return;
       if (e !== ev) {
-        this.setState(() => ({ searchOptionsVisible:  false}));
+        this.setState(() => ({ searchOptionsVisible: false }));
         document.removeEventListener('click', clickOff);
       }
-    }
+    };
 
     if (!this.state.searchOptionsVisible) {
-      this.setState(() => ({ searchOptionsVisible: true}));
+      this.setState(() => ({ searchOptionsVisible: true }));
       document.addEventListener('click', clickOff);
     }
   }
@@ -73,7 +73,7 @@ class Search extends PureComponent {
     const { searchValue } = this.state;
     const { searchOptionsVisible, searchCriteria } = this.state;
     return (
-      <div>
+      <div className="search-container">
         <input type="text" className="search-input" value={searchValue} onChange={this.handleSearchValueChange} />
         <div className="search">
           <div className="search-title" onClick={event => this.toggleVisibility(event)}>

--- a/src/components/Search/styles.scss
+++ b/src/components/Search/styles.scss
@@ -1,30 +1,48 @@
+.search-container{
+  display: flex;
+  flex-direction: row;
+  margin-top: 15px;
+  height: 40px;
+}
+
 .search-input{
-    margin-top: 15px;
-    margin-left: 2%;
-    padding: 8px 20px 8px 20px;
+    margin-left: 1.7%;
+    padding: 8px 20px;
     width: 50%;
-    z-index: 1;
+    border-radius: 3px;
+    border: 1px solid grey;
     text-transform:capitalize;
+    transition: border 0.5s;
+    &:focus{
+      outline: none;
+      border: 2px solid lighten(grey, 20%);
+    }
+    &:hover{
+      border: 2px solid lighten(grey, 20%);
+    }
 }
 
 .search {
-    margin-top: 1%;
-    position: absolute;
-    display: inline-block;
     font-size: 14px;
     margin-left: 2%;
+
     .search-title {
+      display: flex;
+      flex-direction: row;
       font-family: 'Din Pro';
-      padding: 8px 20px 8px 20px;
+      height: 100%;
+      padding: 8.5px 20px;
       border: 1px solid grey;
-      margin: 5px;
+      border-radius: 3px;
       color: #4d4d4d;
       cursor: pointer;
+      transition-property: color;
       &:hover {
-        color: black;
+        background: lighten(#385de0, 45%);
       }
       i {
-        margin: -6px 10px;
+        padding-top: 7.4px;
+        margin: -6px 0px -6px 10px;
         font-size: 20px;
         transition: all 0.3s;
         &.rotate-180 {

--- a/src/utils/index.jsx
+++ b/src/utils/index.jsx
@@ -1,0 +1,34 @@
+export const pageNavigation = (action, currentPage, numberOfPages) => {
+  let page = 1;
+  switch (action) {
+    case 'next':
+      page = currentPage + 1;
+      break;
+    case 'previous':
+      page = currentPage - 1;
+      break;
+    case 'firstPage':
+      page = 1;
+      break;
+    case 'lastPage':
+      page = numberOfPages;
+      break;
+    default:
+      page = currentPage;
+      break;
+  }
+  return page;
+};
+
+export const pageChange = (value, numberOfPages) => {
+  const page = parseInt(value, 10);
+  let currentPage = 1;
+  if (page > 0 && page <= numberOfPages) {
+    currentPage = page;
+  } else if (isNaN(page)) {
+    currentPage = '';
+  } else {
+    currentPage = numberOfPages;
+  }
+  return currentPage;
+};


### PR DESCRIPTION
#### What does this PR do?
Adds pagination to display a specific number of items per page. The user can navigate to various pages.

#### Description of Task to be completed?
- Navigate to the next, previous, first and last page
- Select the limit of items to display per page

#### How should this be manually tested?
##### Prerequisite
- Your backend server should be running
- Set the URL in `src/components/ReportPage/index.jsx` line 64 to your localhost URL

##### Steps
1. Git clone this repository
2. Checkout to this branch i.e `ft-add-pagination-164133528`
3. Run yarn install
4. Run yarn start. You will be redirected to your browser

On your browser...
1. Navigate to the next page, previous page, last page and first page
2. Change the limit to display the selected number of rows per page


#### Any background context you want to provide?
None

#### What are the relevant pivotal tracker stories?
[#164133528](https://www.pivotaltracker.com/n/projects/2197045/stories/164133528)

#### Screenshots (If applicable)
<img width="1440" alt="Screen Shot 2019-03-28 at 12 19 54" src="https://user-images.githubusercontent.com/13402544/55145794-7eebdc00-5154-11e9-91b4-eba5a98af031.png">