### PR TITLE
Fix email of recipient in `Sent To` column for email automation detail  not showing

### DIFF
--- a/src/components/AutomationDetails/index.jsx
+++ b/src/components/AutomationDetails/index.jsx
@@ -65,14 +65,15 @@ class AutomationDetails extends PureComponent {
               {modalType === 'email' ? <th>Sent to</th> : <th>Channel</th>}
               {modalType === 'email' ? <th>Subject</th> : <th>Auto Type</th>}
               <th>Status</th>
+              <th>Status Message</th>
             </tr>
           </thead>
         </table>
         <div className="automation-table">
           {contents.map((content) => {
-            const { emailTo } = content;
+            const { recipient } = content;
             return (
-              <div key={modalType === 'email' ? emailTo : uuid.v4()} className="table-body-details">
+              <div key={modalType === 'email' ? recipient : uuid.v4()} className="table-body-details">
                 <table className="details-table">
                   <tbody>
                     <tr>
@@ -90,12 +91,12 @@ class AutomationDetails extends PureComponent {
 
   renderTableData = (content, modalType) => {
     const {
-      channelName, type, emailTo, subject, status,
+      channelName, type, recipient, subject, status, statusMessage,
     } = content;
     let automationMedia = channelName;
     let automationTitle = type;
     if (modalType === 'email') {
-      automationMedia = emailTo;
+      automationMedia = recipient;
       automationTitle = subject;
     }
     return (
@@ -103,6 +104,7 @@ class AutomationDetails extends PureComponent {
         <td>{automationMedia}</td>
         <td>{automationTitle}</td>
         {status === 'success' ? <td>Success</td> : <td>Failed</td>}
+        <td>{statusMessage}</td>
       </React.Fragment>
     );
   }


### PR DESCRIPTION
#### What does this PR do?
- add status message column
- fix email of the recipient not showing in automation detail
#### Description of Task to be completed?
Fixes issue with email of recipient not showing in frontend when viewing email automation details.
Add status message to automation detail modal to info user why automation failed

#### How should this be manually tested?
1. On browser, goto app url
2. click on info icon in email column of an automation to view details
3. You should see the email of the recipient in the `Sent To` column
4. You should also see status message of why an automation failed in any of the automation detail modal




#### What are the relevant pivotal tracker stories?
165214528

#### Screenshots (If applicable)
<img width="1421" alt="Screenshot 2019-04-09 at 2 16 59 PM" src="https://user-images.githubusercontent.com/8375520/55803484-4d6afd00-5ad2-11e9-89fb-0ea1ff5b14d0.png">
<img width="1421" alt="Screenshot 2019-04-09 at 2 18 53 PM" src="https://user-images.githubusercontent.com/8375520/55803552-74c1ca00-5ad2-11e9-9118-52f9e672ad64.png">

