### PR TITLE
#165530853 Write end-to-end tests for the automations filter feature

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,10 +1,11 @@
 {
   "root": true,
-  "extends": "airbnb",
+  "extends": [ "airbnb", "plugin:cypress/recommended" ],
   "plugins": [
     "react",
     "jsx-a11y",
-    "import"
+    "import",
+    "cypress"
   ],
   "env": {
     "es6": true,
@@ -12,7 +13,8 @@
     "jest": true
   },
   "globals": {
-    "shallow": true
+    "shallow": true,
+    "cy": true
   },
   "parser": "babel-eslint",
   "parserOptions": {

--- a/cypress/fixtures/automations/automationsOffboarding.json
+++ b/cypress/fixtures/automations/automationsOffboarding.json
@@ -1,0 +1,42 @@
+{
+  "status": "success",
+  "message": "Successfully fetched automations",
+  "data": [{
+          "id": 11734,
+          "fellowId": "1e5fc5d0-5403-4ed2-afd8-5976122cb98a",
+          "email": "valentine.mayaki@andela.com",
+          "fellowName": "Annabelle, Conn",
+          "partnerId": "-KXGyJcC1oimjQgFj184",
+          "partnerName": "Lincon, Abraham",
+          "type": "offboarding",
+          "createdAt": "2019-05-01T22:25:37.541Z",
+          "updatedAt": "2019-05-01T22:25:37.541Z",
+          "slackAutomations": {
+              "status": "failure",
+              "slackActivities": [
+                  {
+                      "status": "failure",
+                      "statusMessage": "An API error occurred: channel_not_found",
+                      "type": "kick",
+                      "channelId": null,
+                      "channelName": null,
+                      "slackUserId": null
+                  }
+              ]
+          },
+          "emailAutomations": {
+              "status": "failure",
+              "emailActivities": []
+          },
+          "freckleAutomations": {
+              "status": "failure",
+              "freckleActivities": []
+          }
+      }],
+  "pagination": {
+    "currentPage": 1, 
+    "numberOfPages": 2, 
+    "dataCount": "5", 
+    "nextPage": 2
+   }
+}

--- a/cypress/fixtures/automations/automationsOnboarding.json
+++ b/cypress/fixtures/automations/automationsOnboarding.json
@@ -1,0 +1,42 @@
+{
+  "status": "success",
+  "message": "Successfully fetched automations",
+  "data": [{
+          "id": 11734,
+          "fellowId": "1e5fc5d0-5403-4ed2-afd8-5976122cb98a",
+          "email": "valentine.mayaki@andela.com",
+          "fellowName": "Kory, Conn",
+          "partnerId": "-KXGyJcC1oimjQgFj184",
+          "partnerName": "Fadel, Gislason and Huels",
+          "type": "onboarding",
+          "createdAt": "2019-05-01T22:25:37.541Z",
+          "updatedAt": "2019-05-01T22:25:37.541Z",
+          "slackAutomations": {
+              "status": "failure",
+              "slackActivities": [
+                  {
+                      "status": "failure",
+                      "statusMessage": "An API error occurred: channel_not_found",
+                      "type": "kick",
+                      "channelId": null,
+                      "channelName": null,
+                      "slackUserId": null
+                  }
+              ]
+          },
+          "emailAutomations": {
+              "status": "failure",
+              "emailActivities": []
+          },
+          "freckleAutomations": {
+              "status": "failure",
+              "freckleActivities": []
+          }
+      }],
+  "pagination": {
+    "currentPage": 1, 
+    "numberOfPages": 2, 
+    "dataCount": "5", 
+    "nextPage": 2
+   }
+}

--- a/cypress/integration/filters.spec.js
+++ b/cypress/integration/filters.spec.js
@@ -1,0 +1,192 @@
+import {
+  stubbedOnboardingUrl,
+  stubbedOffboardingUrl,
+  stubbedFellowOnboarding,
+  stubbedFellowOffboarding,
+  stubbedPartnerOnboarding,
+  stubbedPartnerOffboarding,
+  stubbedDateFilter,
+  onboardingFixtures,
+  offboardingFixtures
+} from '../stubs/filterStubs';
+
+
+describe('Filter test', () => {
+  beforeEach(() => {
+    cy.authenticateUser();
+    cy.server();
+    cy.route('GET', stubbedOnboardingUrl, onboardingFixtures);
+    cy.route('GET', stubbedOffboardingUrl, offboardingFixtures);
+    cy.route('GET', stubbedFellowOnboarding, onboardingFixtures);
+    cy.route('GET', stubbedFellowOffboarding, offboardingFixtures);
+    cy.route('GET', stubbedPartnerOnboarding, onboardingFixtures);
+    cy.route('GET', stubbedPartnerOffboarding, offboardingFixtures);
+    cy.route('GET', stubbedDateFilter, onboardingFixtures);
+    cy.visit('/');
+    cy.wait(3000);
+  });
+
+  describe('Filter automation data', () => {
+    it('searches for an engineer by name', () => {
+      cy.get('input.search-input')
+        .click()
+        .type('Kory');
+      cy.get('.filter-button')
+        .click();
+      cy.get('button.apply-filters')
+        .click();
+      cy.get('span.developerName')
+        .contains('Kory');
+    });
+
+    it('filters data to get onboarding results only', () => {
+      cy.get('.filter-button')
+        .click();
+      cy.get('.automation-type-onboarding-label')
+        .click()
+      cy.get('button.apply-filters')
+        .click();
+      cy.wait(2000);
+      cy.get('#0-id')
+        .click()
+      cy.get('.automation-type')
+        .contains('onboarding');
+      cy.get('.modal-close-button-group')
+        .click();
+    })
+
+    it('filters data to get offboarding results only', () => {
+      cy.get('.filter-button')
+        .click();
+      cy.get('.automation-type-offboarding-label')
+        .click()
+      cy.get('button.apply-filters')
+        .click();
+      cy.wait(2000);
+      cy.get('#0-id')
+        .click()
+      cy.get('.automation-type')
+        .contains('offboarding');
+      cy.get('.modal-close-button-group')
+        .click();
+    })
+
+    it('searches for a specified engineer name for onboarding activities ', () => {
+      cy.get('input.search-input')
+        .click()
+        .clear()
+        .type('Kory');
+      cy.get('.filter-button')
+        .click();
+      cy.get('.search-by-fellow-label')
+        .click();
+      cy.get('.automation-type-onboarding-label')
+        .click()
+      cy.get('button.apply-filters')
+        .click();
+      cy.wait(2000);
+      cy.get('#0-id')
+        .click()
+      cy.get('.developer-name')
+        .contains('Kory')
+      cy.get('.automation-type')
+        .contains('onboarding');
+      cy.get('.modal-close-button-group')
+        .click();
+    })
+
+    it('searches for a specified engineer name for offboarding activities ', () => {
+      cy.get('input.search-input')
+        .click()
+        .clear()
+        .type('Annabelle');
+      cy.get('.filter-button')
+        .click();
+      cy.get('.search-by-fellow-label')
+        .click();
+      cy.get('.automation-type-offboarding-label')
+        .click()
+      cy.get('button.apply-filters')
+        .click();
+      cy.wait(2000);
+      cy.get('#0-id')
+        .click()
+      cy.get('.developer-name')
+        .contains('Annabelle')
+      cy.get('.automation-type')
+        .contains('offboarding');
+      cy.get('.modal-close-button-group')
+        .click();
+    })
+
+    it('searches for a specified partner name for onboarding activities ', () => {
+      cy.get('input.search-input')
+        .click()
+        .clear()
+        .type('Fadel');
+      cy.get('.filter-button')
+        .click();
+      cy.get('.search-by-partner-label')
+        .click();
+      cy.get('.automation-type-onboarding-label')
+        .click()
+      cy.get('button.apply-filters')
+        .click();
+      cy.wait(2000);
+      cy.get('#0-id')
+        .click()
+      cy.get('.partner-name')
+        .contains('Fadel')
+      cy.get('.automation-type')
+        .contains('onboarding');
+      cy.get('.modal-close-button-group')
+        .click();
+    })
+
+    it('searches for a specified partner name for offboarding activities ', () => {
+      cy.get('input.search-input')
+        .click()
+        .clear()
+        .type('Lincon');
+      cy.get('.filter-button')
+        .click();
+      cy.get('.search-by-partner-label')
+        .click();
+      cy.get('.automation-type-offboarding-label')
+        .click()
+      cy.get('button.apply-filters')
+        .click();
+      cy.wait(2000);
+      cy.get('#0-id')
+        .click()
+      cy.get('.partner-name')
+        .contains('Lincon')
+      cy.get('.automation-type')
+        .contains('offboarding');
+      cy.get('.modal-close-button-group')
+        .click();
+    })
+
+    it('filters by automation date ', () => {
+      cy.get('.filter-button')
+        .click();
+      cy.get('#from')
+        .click()
+        .type('May 01, 2019')
+      cy.get('#to')
+        .click()
+        .type('May 01, 2019')
+      cy.get('.filter-dropdown-parent')
+        .click();
+      cy.get('button.apply-filters')
+        .click();
+      cy.wait(2000);
+      cy.get('#0-id')
+        .click()
+      cy.get('.automation-date')
+        .contains('5/1/2019')
+      cy.get('.modal-close-button-group')
+        .click();
+    })
+  });  
+});

--- a/cypress/stubs/filterStubs.js
+++ b/cypress/stubs/filterStubs.js
@@ -1,0 +1,10 @@
+export const stubbedOnboardingUrl = '/api/v1/automations?page=1&limit=10&emailAutomation=&slackAutomation=&freckleAutomation=&searchTerm=&searchBy=&type=onboarding&date[from]=&date[to]=';
+export const stubbedOffboardingUrl = '/api/v1/automations?page=1&limit=10&emailAutomation=&slackAutomation=&freckleAutomation=&searchTerm=&searchBy=&type=offboarding&date[from]=&date[to]=';
+export const stubbedFellowOnboarding = '/api/v1/automations?page=1&limit=10&emailAutomation=&slackAutomation=&freckleAutomation=&searchTerm=Kory&searchBy=fellow&type=onboarding&date[from]=&date[to]=';
+export const stubbedFellowOffboarding = '/api/v1/automations?page=1&limit=10&emailAutomation=&slackAutomation=&freckleAutomation=&searchTerm=Annabelle&searchBy=fellow&type=offboarding&date[from]=&date[to]=';
+export const stubbedPartnerOnboarding = '/api/v1/automations?page=1&limit=10&emailAutomation=&slackAutomation=&freckleAutomation=&searchTerm=Fadel&searchBy=partner&type=onboarding&date[from]=&date[to]=';
+export const stubbedPartnerOffboarding = '/api/v1/automations?page=1&limit=10&emailAutomation=&slackAutomation=&freckleAutomation=&searchTerm=Lincon&searchBy=partner&type=offboarding&date[from]=&date[to]=';
+export const stubbedDateFilter = '/api/v1/automations?page=1&limit=10&emailAutomation=&slackAutomation=&freckleAutomation=&searchTerm=&=&searchBy=&type=&date[from]=2019-04-30T23:00:00.000Z&date[to]=2019-04-30T23:00:00.000Z';
+
+export const onboardingFixtures = 'fixture:automations/automationsOnboarding.json';
+export const offboardingFixtures = 'fixture:automations/automationsOffboarding.json';

--- a/src/components/AutomationDetails/styles.scss
+++ b/src/components/AutomationDetails/styles.scss
@@ -30,7 +30,7 @@
 }
 
 .modal-body{
-    position: fixed;
+    position: absolute;
     top: 0;
     bottom: 0;
     left: 0;

--- a/src/components/developerCards/index.jsx
+++ b/src/components/developerCards/index.jsx
@@ -80,7 +80,7 @@ class DeveloperCard extends Component {
     const metric = (activities, status) => (
       automation(activities.length) ? automationMetric(activities, status) : 0
     );
-    return data.map((card) => {
+    return data.map((card, index) => {
       const name = card.fellowName;
       const newName = _.split(name, ',');
       const firstInitials = newName[0].charAt(0);
@@ -90,7 +90,7 @@ class DeveloperCard extends Component {
           <div className="info-cont">
             { /* TODO Update the onboarding icon to match mockups */}
             <img className="info-icon onBoarding-icon" src={offboarding} alt="onboarding icon" />
-            <img className="info-icon" src={InfoIcon} alt="info icon" role="presentation" onClick={() => { openModal(); changeModalTypes(card); }} />
+            <img className="info-icon" src={InfoIcon} alt="info icon" role="presentation" onClick={() => { openModal(); changeModalTypes(card); }} id={`${index}-id`} />
           </div>
           {this.renderDeveloperPic(firstInitials, secondInitials)}
           {this.renderDetails('developerDetails', 'developerName', card.fellowName)}


### PR DESCRIPTION
#### What does this PR do?
Write end-to-end tests for the filter feature

#### Description of Task to be completed?
- Set-up a fixtures file for automation data to return a stable result in all environments
- Write e2e tests to try out the filter feature

#### How should this be manually tested?
1. From the command line, start up the servers for the front and back-end code bases
2. Open another terminal for the front-end codebase and run `npm run test:end2end`
3. When a browser pops up, select the `filters.spec.js` file to run the e2e test for filters. Tests should be passing.

#### Any background context you want to provide?
You need to have your authentication data stored in the `cypress.env.json` file. checkout the PR [here](https://github.com/andela/bp-esa-frontend/pull/73) on how to set this up if you haven't.

#### What are the relevant pivotal tracker stories?
[165530853](https://www.pivotaltracker.com/story/show/165530853)

#### Postman Documentation


#### Screenshots (If applicable)