### PR TITLE
#165879813 Card housing components

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -69,6 +69,7 @@ class App extends React.PureComponent {
               render={props => ((authenticated === true)
                 ? <Redirect to="/" /> : <Login setCurrentUser={this.setCurrentUser} {...props} />)}
             />
+
             <AuthenticatedRoute
               exact
               path="/"

--- a/src/__tests__/components/Dashboard/Card.test.jsx
+++ b/src/__tests__/components/Dashboard/Card.test.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import Card from '../../../components/Dashboard/Card';
+
+describe('Dashboard card', () => {
+  let wrapper;
+  const props = {
+    classes: 'class',
+    title: 'Title Card',
+    component: jest.fn(),
+  };
+  beforeEach(() => {
+    wrapper = mount(<Card {...props} />);
+  });
+  afterEach(() => {
+    wrapper.unmount();
+  });
+  it('renders appropriately', () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+  it('renders dashboard card with title if provided', () => {
+    const card = wrapper.find('.dashboard-card');
+    const className = wrapper.find('.class');
+    expect(card.length).toEqual(1);
+    expect(className.length).toEqual(1);
+    expect(card.text()).toEqual('Title Card');
+  });
+});

--- a/src/__tests__/components/Dashboard/__snapshots__/Card.test.jsx.snap
+++ b/src/__tests__/components/Dashboard/__snapshots__/Card.test.jsx.snap
@@ -1,0 +1,3239 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Dashboard card renders appropriately 1`] = `
+ReactWrapper {
+  Symbol(enzyme.__unrendered__): <Card
+    classes="class"
+    component={
+      [MockFunction] {
+        "calls": Array [
+          Array [],
+        ],
+        "results": Array [
+          Object {
+            "isThrow": false,
+            "value": undefined,
+          },
+        ],
+      }
+    }
+    title="Title Card"
+  />,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "getNode": [Function],
+    "getWrappingComponentRenderer": [Function],
+    "render": [Function],
+    "simulateError": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__node__): Object {
+    "instance": Card {
+      "_reactInternalFiber": FiberNode {
+        "_debugHookTypes": null,
+        "_debugID": 63,
+        "_debugIsCurrentlyTiming": false,
+        "_debugOwner": FiberNode {
+          "_debugHookTypes": null,
+          "_debugID": 62,
+          "_debugIsCurrentlyTiming": false,
+          "_debugOwner": null,
+          "_debugSource": null,
+          "actualDuration": 0,
+          "actualStartTime": -1,
+          "alternate": null,
+          "child": [Circular],
+          "childExpirationTime": 0,
+          "contextDependencies": null,
+          "effectTag": 1,
+          "elementType": [Function],
+          "expirationTime": 0,
+          "firstEffect": null,
+          "index": 0,
+          "key": null,
+          "lastEffect": null,
+          "memoizedProps": Object {
+            "Component": [Function],
+            "context": null,
+            "props": Object {
+              "classes": "class",
+              "component": [MockFunction] {
+                "calls": Array [
+                  Array [],
+                ],
+                "results": Array [
+                  Object {
+                    "isThrow": false,
+                    "value": undefined,
+                  },
+                ],
+              },
+              "title": "Title Card",
+            },
+            "wrappingComponentProps": null,
+          },
+          "memoizedState": Object {
+            "context": null,
+            "mount": true,
+            "props": Object {
+              "classes": "class",
+              "component": [MockFunction] {
+                "calls": Array [
+                  Array [],
+                ],
+                "results": Array [
+                  Object {
+                    "isThrow": false,
+                    "value": undefined,
+                  },
+                ],
+              },
+              "title": "Title Card",
+            },
+            "wrappingComponentProps": null,
+          },
+          "mode": 0,
+          "nextEffect": FiberNode {
+            "_debugHookTypes": null,
+            "_debugID": 60,
+            "_debugIsCurrentlyTiming": false,
+            "_debugOwner": null,
+            "_debugSource": null,
+            "actualDuration": 0,
+            "actualStartTime": -1,
+            "alternate": FiberNode {
+              "_debugHookTypes": null,
+              "_debugID": 60,
+              "_debugIsCurrentlyTiming": false,
+              "_debugOwner": null,
+              "_debugSource": null,
+              "actualDuration": 0,
+              "actualStartTime": -1,
+              "alternate": [Circular],
+              "child": null,
+              "childExpirationTime": 0,
+              "contextDependencies": null,
+              "effectTag": 0,
+              "elementType": null,
+              "expirationTime": 1073741823,
+              "firstEffect": null,
+              "index": 0,
+              "key": null,
+              "lastEffect": null,
+              "memoizedProps": null,
+              "memoizedState": null,
+              "mode": 0,
+              "nextEffect": null,
+              "pendingProps": null,
+              "ref": null,
+              "return": null,
+              "selfBaseDuration": 0,
+              "sibling": null,
+              "stateNode": Object {
+                "containerInfo": <div>
+                  <div
+                    class="dashboard-card class"
+                  >
+                    <div
+                      class="title"
+                    >
+                      Title Card
+                    </div>
+                  </div>
+                </div>,
+                "context": Object {},
+                "current": [Circular],
+                "didError": false,
+                "earliestPendingTime": 0,
+                "earliestSuspendedTime": 0,
+                "expirationTime": 0,
+                "finishedWork": null,
+                "firstBatch": null,
+                "hydrate": false,
+                "interactionThreadID": 15,
+                "latestPendingTime": 0,
+                "latestPingedTime": 0,
+                "latestSuspendedTime": 0,
+                "memoizedInteractions": Set {},
+                "nextExpirationTimeToWorkOn": 0,
+                "nextScheduledRoot": null,
+                "pendingChildren": null,
+                "pendingCommitExpirationTime": 0,
+                "pendingContext": null,
+                "pendingInteractionMap": Map {},
+                "pingCache": null,
+                "timeoutHandle": -1,
+              },
+              "tag": 3,
+              "treeBaseDuration": 0,
+              "type": null,
+              "updateQueue": Object {
+                "baseState": null,
+                "firstCapturedEffect": null,
+                "firstCapturedUpdate": null,
+                "firstEffect": null,
+                "firstUpdate": Object {
+                  "callback": null,
+                  "expirationTime": 1073741823,
+                  "next": null,
+                  "nextEffect": null,
+                  "payload": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={
+                        Object {
+                          "classes": "class",
+                          "component": [MockFunction] {
+                            "calls": Array [
+                              Array [],
+                            ],
+                            "results": Array [
+                              Object {
+                                "isThrow": false,
+                                "value": undefined,
+                              },
+                            ],
+                          },
+                          "title": "Title Card",
+                        }
+                      }
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "tag": 0,
+                },
+                "lastCapturedEffect": null,
+                "lastCapturedUpdate": null,
+                "lastEffect": null,
+                "lastUpdate": Object {
+                  "callback": null,
+                  "expirationTime": 1073741823,
+                  "next": null,
+                  "nextEffect": null,
+                  "payload": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={
+                        Object {
+                          "classes": "class",
+                          "component": [MockFunction] {
+                            "calls": Array [
+                              Array [],
+                            ],
+                            "results": Array [
+                              Object {
+                                "isThrow": false,
+                                "value": undefined,
+                              },
+                            ],
+                          },
+                          "title": "Title Card",
+                        }
+                      }
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "tag": 0,
+                },
+              },
+            },
+            "child": [Circular],
+            "childExpirationTime": 0,
+            "contextDependencies": null,
+            "effectTag": 32,
+            "elementType": null,
+            "expirationTime": 0,
+            "firstEffect": [Circular],
+            "index": 0,
+            "key": null,
+            "lastEffect": [Circular],
+            "memoizedProps": null,
+            "memoizedState": Object {
+              "element": <WrapperComponent
+                Component={[Function]}
+                context={null}
+                props={
+                  Object {
+                    "classes": "class",
+                    "component": [MockFunction] {
+                      "calls": Array [
+                        Array [],
+                      ],
+                      "results": Array [
+                        Object {
+                          "isThrow": false,
+                          "value": undefined,
+                        },
+                      ],
+                    },
+                    "title": "Title Card",
+                  }
+                }
+                wrappingComponentProps={null}
+              />,
+            },
+            "mode": 0,
+            "nextEffect": null,
+            "pendingProps": null,
+            "ref": null,
+            "return": null,
+            "selfBaseDuration": 0,
+            "sibling": null,
+            "stateNode": Object {
+              "containerInfo": <div>
+                <div
+                  class="dashboard-card class"
+                >
+                  <div
+                    class="title"
+                  >
+                    Title Card
+                  </div>
+                </div>
+              </div>,
+              "context": Object {},
+              "current": [Circular],
+              "didError": false,
+              "earliestPendingTime": 0,
+              "earliestSuspendedTime": 0,
+              "expirationTime": 0,
+              "finishedWork": null,
+              "firstBatch": null,
+              "hydrate": false,
+              "interactionThreadID": 15,
+              "latestPendingTime": 0,
+              "latestPingedTime": 0,
+              "latestSuspendedTime": 0,
+              "memoizedInteractions": Set {},
+              "nextExpirationTimeToWorkOn": 0,
+              "nextScheduledRoot": null,
+              "pendingChildren": null,
+              "pendingCommitExpirationTime": 0,
+              "pendingContext": null,
+              "pendingInteractionMap": Map {},
+              "pingCache": null,
+              "timeoutHandle": -1,
+            },
+            "tag": 3,
+            "treeBaseDuration": 0,
+            "type": null,
+            "updateQueue": Object {
+              "baseState": Object {
+                "element": <WrapperComponent
+                  Component={[Function]}
+                  context={null}
+                  props={
+                    Object {
+                      "classes": "class",
+                      "component": [MockFunction] {
+                        "calls": Array [
+                          Array [],
+                        ],
+                        "results": Array [
+                          Object {
+                            "isThrow": false,
+                            "value": undefined,
+                          },
+                        ],
+                      },
+                      "title": "Title Card",
+                    }
+                  }
+                  wrappingComponentProps={null}
+                />,
+              },
+              "firstCapturedEffect": null,
+              "firstCapturedUpdate": null,
+              "firstEffect": null,
+              "firstUpdate": null,
+              "lastCapturedEffect": null,
+              "lastCapturedUpdate": null,
+              "lastEffect": null,
+              "lastUpdate": null,
+            },
+          },
+          "pendingProps": Object {
+            "Component": [Function],
+            "context": null,
+            "props": Object {
+              "classes": "class",
+              "component": [MockFunction] {
+                "calls": Array [
+                  Array [],
+                ],
+                "results": Array [
+                  Object {
+                    "isThrow": false,
+                    "value": undefined,
+                  },
+                ],
+              },
+              "title": "Title Card",
+            },
+            "wrappingComponentProps": null,
+          },
+          "ref": null,
+          "return": FiberNode {
+            "_debugHookTypes": null,
+            "_debugID": 60,
+            "_debugIsCurrentlyTiming": false,
+            "_debugOwner": null,
+            "_debugSource": null,
+            "actualDuration": 0,
+            "actualStartTime": -1,
+            "alternate": FiberNode {
+              "_debugHookTypes": null,
+              "_debugID": 60,
+              "_debugIsCurrentlyTiming": false,
+              "_debugOwner": null,
+              "_debugSource": null,
+              "actualDuration": 0,
+              "actualStartTime": -1,
+              "alternate": [Circular],
+              "child": null,
+              "childExpirationTime": 0,
+              "contextDependencies": null,
+              "effectTag": 0,
+              "elementType": null,
+              "expirationTime": 1073741823,
+              "firstEffect": null,
+              "index": 0,
+              "key": null,
+              "lastEffect": null,
+              "memoizedProps": null,
+              "memoizedState": null,
+              "mode": 0,
+              "nextEffect": null,
+              "pendingProps": null,
+              "ref": null,
+              "return": null,
+              "selfBaseDuration": 0,
+              "sibling": null,
+              "stateNode": Object {
+                "containerInfo": <div>
+                  <div
+                    class="dashboard-card class"
+                  >
+                    <div
+                      class="title"
+                    >
+                      Title Card
+                    </div>
+                  </div>
+                </div>,
+                "context": Object {},
+                "current": [Circular],
+                "didError": false,
+                "earliestPendingTime": 0,
+                "earliestSuspendedTime": 0,
+                "expirationTime": 0,
+                "finishedWork": null,
+                "firstBatch": null,
+                "hydrate": false,
+                "interactionThreadID": 15,
+                "latestPendingTime": 0,
+                "latestPingedTime": 0,
+                "latestSuspendedTime": 0,
+                "memoizedInteractions": Set {},
+                "nextExpirationTimeToWorkOn": 0,
+                "nextScheduledRoot": null,
+                "pendingChildren": null,
+                "pendingCommitExpirationTime": 0,
+                "pendingContext": null,
+                "pendingInteractionMap": Map {},
+                "pingCache": null,
+                "timeoutHandle": -1,
+              },
+              "tag": 3,
+              "treeBaseDuration": 0,
+              "type": null,
+              "updateQueue": Object {
+                "baseState": null,
+                "firstCapturedEffect": null,
+                "firstCapturedUpdate": null,
+                "firstEffect": null,
+                "firstUpdate": Object {
+                  "callback": null,
+                  "expirationTime": 1073741823,
+                  "next": null,
+                  "nextEffect": null,
+                  "payload": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={
+                        Object {
+                          "classes": "class",
+                          "component": [MockFunction] {
+                            "calls": Array [
+                              Array [],
+                            ],
+                            "results": Array [
+                              Object {
+                                "isThrow": false,
+                                "value": undefined,
+                              },
+                            ],
+                          },
+                          "title": "Title Card",
+                        }
+                      }
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "tag": 0,
+                },
+                "lastCapturedEffect": null,
+                "lastCapturedUpdate": null,
+                "lastEffect": null,
+                "lastUpdate": Object {
+                  "callback": null,
+                  "expirationTime": 1073741823,
+                  "next": null,
+                  "nextEffect": null,
+                  "payload": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={
+                        Object {
+                          "classes": "class",
+                          "component": [MockFunction] {
+                            "calls": Array [
+                              Array [],
+                            ],
+                            "results": Array [
+                              Object {
+                                "isThrow": false,
+                                "value": undefined,
+                              },
+                            ],
+                          },
+                          "title": "Title Card",
+                        }
+                      }
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "tag": 0,
+                },
+              },
+            },
+            "child": [Circular],
+            "childExpirationTime": 0,
+            "contextDependencies": null,
+            "effectTag": 32,
+            "elementType": null,
+            "expirationTime": 0,
+            "firstEffect": [Circular],
+            "index": 0,
+            "key": null,
+            "lastEffect": [Circular],
+            "memoizedProps": null,
+            "memoizedState": Object {
+              "element": <WrapperComponent
+                Component={[Function]}
+                context={null}
+                props={
+                  Object {
+                    "classes": "class",
+                    "component": [MockFunction] {
+                      "calls": Array [
+                        Array [],
+                      ],
+                      "results": Array [
+                        Object {
+                          "isThrow": false,
+                          "value": undefined,
+                        },
+                      ],
+                    },
+                    "title": "Title Card",
+                  }
+                }
+                wrappingComponentProps={null}
+              />,
+            },
+            "mode": 0,
+            "nextEffect": null,
+            "pendingProps": null,
+            "ref": null,
+            "return": null,
+            "selfBaseDuration": 0,
+            "sibling": null,
+            "stateNode": Object {
+              "containerInfo": <div>
+                <div
+                  class="dashboard-card class"
+                >
+                  <div
+                    class="title"
+                  >
+                    Title Card
+                  </div>
+                </div>
+              </div>,
+              "context": Object {},
+              "current": [Circular],
+              "didError": false,
+              "earliestPendingTime": 0,
+              "earliestSuspendedTime": 0,
+              "expirationTime": 0,
+              "finishedWork": null,
+              "firstBatch": null,
+              "hydrate": false,
+              "interactionThreadID": 15,
+              "latestPendingTime": 0,
+              "latestPingedTime": 0,
+              "latestSuspendedTime": 0,
+              "memoizedInteractions": Set {},
+              "nextExpirationTimeToWorkOn": 0,
+              "nextScheduledRoot": null,
+              "pendingChildren": null,
+              "pendingCommitExpirationTime": 0,
+              "pendingContext": null,
+              "pendingInteractionMap": Map {},
+              "pingCache": null,
+              "timeoutHandle": -1,
+            },
+            "tag": 3,
+            "treeBaseDuration": 0,
+            "type": null,
+            "updateQueue": Object {
+              "baseState": Object {
+                "element": <WrapperComponent
+                  Component={[Function]}
+                  context={null}
+                  props={
+                    Object {
+                      "classes": "class",
+                      "component": [MockFunction] {
+                        "calls": Array [
+                          Array [],
+                        ],
+                        "results": Array [
+                          Object {
+                            "isThrow": false,
+                            "value": undefined,
+                          },
+                        ],
+                      },
+                      "title": "Title Card",
+                    }
+                  }
+                  wrappingComponentProps={null}
+                />,
+              },
+              "firstCapturedEffect": null,
+              "firstCapturedUpdate": null,
+              "firstEffect": null,
+              "firstUpdate": null,
+              "lastCapturedEffect": null,
+              "lastCapturedUpdate": null,
+              "lastEffect": null,
+              "lastUpdate": null,
+            },
+          },
+          "selfBaseDuration": 0,
+          "sibling": null,
+          "stateNode": WrapperComponent {
+            "_reactInternalFiber": [Circular],
+            "_reactInternalInstance": Object {},
+            "context": Object {},
+            "props": Object {
+              "Component": [Function],
+              "context": null,
+              "props": Object {
+                "classes": "class",
+                "component": [MockFunction] {
+                  "calls": Array [
+                    Array [],
+                  ],
+                  "results": Array [
+                    Object {
+                      "isThrow": false,
+                      "value": undefined,
+                    },
+                  ],
+                },
+                "title": "Title Card",
+              },
+              "wrappingComponentProps": null,
+            },
+            "refs": Object {},
+            "rootFinderInstance": null,
+            "state": Object {
+              "context": null,
+              "mount": true,
+              "props": Object {
+                "classes": "class",
+                "component": [MockFunction] {
+                  "calls": Array [
+                    Array [],
+                  ],
+                  "results": Array [
+                    Object {
+                      "isThrow": false,
+                      "value": undefined,
+                    },
+                  ],
+                },
+                "title": "Title Card",
+              },
+              "wrappingComponentProps": null,
+            },
+            "updater": Object {
+              "enqueueForceUpdate": [Function],
+              "enqueueReplaceState": [Function],
+              "enqueueSetState": [Function],
+              "isMounted": [Function],
+            },
+          },
+          "tag": 1,
+          "treeBaseDuration": 0,
+          "type": [Function],
+          "updateQueue": null,
+        },
+        "_debugSource": null,
+        "actualDuration": 0,
+        "actualStartTime": -1,
+        "alternate": null,
+        "child": FiberNode {
+          "_debugHookTypes": null,
+          "_debugID": 64,
+          "_debugIsCurrentlyTiming": false,
+          "_debugOwner": [Circular],
+          "_debugSource": Object {
+            "fileName": "/Users/kevinkoech/Documents/bp-esa-frontend/src/components/Dashboard/Card.jsx",
+            "lineNumber": 20,
+          },
+          "actualDuration": 0,
+          "actualStartTime": -1,
+          "alternate": null,
+          "child": FiberNode {
+            "_debugHookTypes": null,
+            "_debugID": 65,
+            "_debugIsCurrentlyTiming": false,
+            "_debugOwner": [Circular],
+            "_debugSource": Object {
+              "fileName": "/Users/kevinkoech/Documents/bp-esa-frontend/src/components/Dashboard/Card.jsx",
+              "lineNumber": 21,
+            },
+            "actualDuration": 0,
+            "actualStartTime": -1,
+            "alternate": null,
+            "child": null,
+            "childExpirationTime": 0,
+            "contextDependencies": null,
+            "effectTag": 0,
+            "elementType": "div",
+            "expirationTime": 0,
+            "firstEffect": null,
+            "index": 0,
+            "key": null,
+            "lastEffect": null,
+            "memoizedProps": Object {
+              "children": "Title Card",
+              "className": "title",
+            },
+            "memoizedState": null,
+            "mode": 0,
+            "nextEffect": null,
+            "pendingProps": Object {
+              "children": "Title Card",
+              "className": "title",
+            },
+            "ref": null,
+            "return": [Circular],
+            "selfBaseDuration": 0,
+            "sibling": null,
+            "stateNode": <div
+              class="title"
+            >
+              Title Card
+            </div>,
+            "tag": 5,
+            "treeBaseDuration": 0,
+            "type": "div",
+            "updateQueue": null,
+          },
+          "childExpirationTime": 0,
+          "contextDependencies": null,
+          "effectTag": 0,
+          "elementType": "div",
+          "expirationTime": 0,
+          "firstEffect": null,
+          "index": 0,
+          "key": null,
+          "lastEffect": null,
+          "memoizedProps": Object {
+            "children": Array [
+              <div
+                className="title"
+              >
+                Title Card
+              </div>,
+              undefined,
+            ],
+            "className": "dashboard-card class",
+          },
+          "memoizedState": null,
+          "mode": 0,
+          "nextEffect": null,
+          "pendingProps": Object {
+            "children": Array [
+              <div
+                className="title"
+              >
+                Title Card
+              </div>,
+              undefined,
+            ],
+            "className": "dashboard-card class",
+          },
+          "ref": null,
+          "return": [Circular],
+          "selfBaseDuration": 0,
+          "sibling": null,
+          "stateNode": <div
+            class="dashboard-card class"
+          >
+            <div
+              class="title"
+            >
+              Title Card
+            </div>
+          </div>,
+          "tag": 5,
+          "treeBaseDuration": 0,
+          "type": "div",
+          "updateQueue": null,
+        },
+        "childExpirationTime": 0,
+        "contextDependencies": null,
+        "effectTag": 1,
+        "elementType": [Function],
+        "expirationTime": 0,
+        "firstEffect": null,
+        "index": 0,
+        "key": null,
+        "lastEffect": null,
+        "memoizedProps": Object {
+          "classes": "class",
+          "component": [MockFunction] {
+            "calls": Array [
+              Array [],
+            ],
+            "results": Array [
+              Object {
+                "isThrow": false,
+                "value": undefined,
+              },
+            ],
+          },
+          "title": "Title Card",
+        },
+        "memoizedState": null,
+        "mode": 0,
+        "nextEffect": null,
+        "pendingProps": Object {
+          "classes": "class",
+          "component": [MockFunction] {
+            "calls": Array [
+              Array [],
+            ],
+            "results": Array [
+              Object {
+                "isThrow": false,
+                "value": undefined,
+              },
+            ],
+          },
+          "title": "Title Card",
+        },
+        "ref": null,
+        "return": FiberNode {
+          "_debugHookTypes": null,
+          "_debugID": 62,
+          "_debugIsCurrentlyTiming": false,
+          "_debugOwner": null,
+          "_debugSource": null,
+          "actualDuration": 0,
+          "actualStartTime": -1,
+          "alternate": null,
+          "child": [Circular],
+          "childExpirationTime": 0,
+          "contextDependencies": null,
+          "effectTag": 1,
+          "elementType": [Function],
+          "expirationTime": 0,
+          "firstEffect": null,
+          "index": 0,
+          "key": null,
+          "lastEffect": null,
+          "memoizedProps": Object {
+            "Component": [Function],
+            "context": null,
+            "props": Object {
+              "classes": "class",
+              "component": [MockFunction] {
+                "calls": Array [
+                  Array [],
+                ],
+                "results": Array [
+                  Object {
+                    "isThrow": false,
+                    "value": undefined,
+                  },
+                ],
+              },
+              "title": "Title Card",
+            },
+            "wrappingComponentProps": null,
+          },
+          "memoizedState": Object {
+            "context": null,
+            "mount": true,
+            "props": Object {
+              "classes": "class",
+              "component": [MockFunction] {
+                "calls": Array [
+                  Array [],
+                ],
+                "results": Array [
+                  Object {
+                    "isThrow": false,
+                    "value": undefined,
+                  },
+                ],
+              },
+              "title": "Title Card",
+            },
+            "wrappingComponentProps": null,
+          },
+          "mode": 0,
+          "nextEffect": FiberNode {
+            "_debugHookTypes": null,
+            "_debugID": 60,
+            "_debugIsCurrentlyTiming": false,
+            "_debugOwner": null,
+            "_debugSource": null,
+            "actualDuration": 0,
+            "actualStartTime": -1,
+            "alternate": FiberNode {
+              "_debugHookTypes": null,
+              "_debugID": 60,
+              "_debugIsCurrentlyTiming": false,
+              "_debugOwner": null,
+              "_debugSource": null,
+              "actualDuration": 0,
+              "actualStartTime": -1,
+              "alternate": [Circular],
+              "child": null,
+              "childExpirationTime": 0,
+              "contextDependencies": null,
+              "effectTag": 0,
+              "elementType": null,
+              "expirationTime": 1073741823,
+              "firstEffect": null,
+              "index": 0,
+              "key": null,
+              "lastEffect": null,
+              "memoizedProps": null,
+              "memoizedState": null,
+              "mode": 0,
+              "nextEffect": null,
+              "pendingProps": null,
+              "ref": null,
+              "return": null,
+              "selfBaseDuration": 0,
+              "sibling": null,
+              "stateNode": Object {
+                "containerInfo": <div>
+                  <div
+                    class="dashboard-card class"
+                  >
+                    <div
+                      class="title"
+                    >
+                      Title Card
+                    </div>
+                  </div>
+                </div>,
+                "context": Object {},
+                "current": [Circular],
+                "didError": false,
+                "earliestPendingTime": 0,
+                "earliestSuspendedTime": 0,
+                "expirationTime": 0,
+                "finishedWork": null,
+                "firstBatch": null,
+                "hydrate": false,
+                "interactionThreadID": 15,
+                "latestPendingTime": 0,
+                "latestPingedTime": 0,
+                "latestSuspendedTime": 0,
+                "memoizedInteractions": Set {},
+                "nextExpirationTimeToWorkOn": 0,
+                "nextScheduledRoot": null,
+                "pendingChildren": null,
+                "pendingCommitExpirationTime": 0,
+                "pendingContext": null,
+                "pendingInteractionMap": Map {},
+                "pingCache": null,
+                "timeoutHandle": -1,
+              },
+              "tag": 3,
+              "treeBaseDuration": 0,
+              "type": null,
+              "updateQueue": Object {
+                "baseState": null,
+                "firstCapturedEffect": null,
+                "firstCapturedUpdate": null,
+                "firstEffect": null,
+                "firstUpdate": Object {
+                  "callback": null,
+                  "expirationTime": 1073741823,
+                  "next": null,
+                  "nextEffect": null,
+                  "payload": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={
+                        Object {
+                          "classes": "class",
+                          "component": [MockFunction] {
+                            "calls": Array [
+                              Array [],
+                            ],
+                            "results": Array [
+                              Object {
+                                "isThrow": false,
+                                "value": undefined,
+                              },
+                            ],
+                          },
+                          "title": "Title Card",
+                        }
+                      }
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "tag": 0,
+                },
+                "lastCapturedEffect": null,
+                "lastCapturedUpdate": null,
+                "lastEffect": null,
+                "lastUpdate": Object {
+                  "callback": null,
+                  "expirationTime": 1073741823,
+                  "next": null,
+                  "nextEffect": null,
+                  "payload": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={
+                        Object {
+                          "classes": "class",
+                          "component": [MockFunction] {
+                            "calls": Array [
+                              Array [],
+                            ],
+                            "results": Array [
+                              Object {
+                                "isThrow": false,
+                                "value": undefined,
+                              },
+                            ],
+                          },
+                          "title": "Title Card",
+                        }
+                      }
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "tag": 0,
+                },
+              },
+            },
+            "child": [Circular],
+            "childExpirationTime": 0,
+            "contextDependencies": null,
+            "effectTag": 32,
+            "elementType": null,
+            "expirationTime": 0,
+            "firstEffect": [Circular],
+            "index": 0,
+            "key": null,
+            "lastEffect": [Circular],
+            "memoizedProps": null,
+            "memoizedState": Object {
+              "element": <WrapperComponent
+                Component={[Function]}
+                context={null}
+                props={
+                  Object {
+                    "classes": "class",
+                    "component": [MockFunction] {
+                      "calls": Array [
+                        Array [],
+                      ],
+                      "results": Array [
+                        Object {
+                          "isThrow": false,
+                          "value": undefined,
+                        },
+                      ],
+                    },
+                    "title": "Title Card",
+                  }
+                }
+                wrappingComponentProps={null}
+              />,
+            },
+            "mode": 0,
+            "nextEffect": null,
+            "pendingProps": null,
+            "ref": null,
+            "return": null,
+            "selfBaseDuration": 0,
+            "sibling": null,
+            "stateNode": Object {
+              "containerInfo": <div>
+                <div
+                  class="dashboard-card class"
+                >
+                  <div
+                    class="title"
+                  >
+                    Title Card
+                  </div>
+                </div>
+              </div>,
+              "context": Object {},
+              "current": [Circular],
+              "didError": false,
+              "earliestPendingTime": 0,
+              "earliestSuspendedTime": 0,
+              "expirationTime": 0,
+              "finishedWork": null,
+              "firstBatch": null,
+              "hydrate": false,
+              "interactionThreadID": 15,
+              "latestPendingTime": 0,
+              "latestPingedTime": 0,
+              "latestSuspendedTime": 0,
+              "memoizedInteractions": Set {},
+              "nextExpirationTimeToWorkOn": 0,
+              "nextScheduledRoot": null,
+              "pendingChildren": null,
+              "pendingCommitExpirationTime": 0,
+              "pendingContext": null,
+              "pendingInteractionMap": Map {},
+              "pingCache": null,
+              "timeoutHandle": -1,
+            },
+            "tag": 3,
+            "treeBaseDuration": 0,
+            "type": null,
+            "updateQueue": Object {
+              "baseState": Object {
+                "element": <WrapperComponent
+                  Component={[Function]}
+                  context={null}
+                  props={
+                    Object {
+                      "classes": "class",
+                      "component": [MockFunction] {
+                        "calls": Array [
+                          Array [],
+                        ],
+                        "results": Array [
+                          Object {
+                            "isThrow": false,
+                            "value": undefined,
+                          },
+                        ],
+                      },
+                      "title": "Title Card",
+                    }
+                  }
+                  wrappingComponentProps={null}
+                />,
+              },
+              "firstCapturedEffect": null,
+              "firstCapturedUpdate": null,
+              "firstEffect": null,
+              "firstUpdate": null,
+              "lastCapturedEffect": null,
+              "lastCapturedUpdate": null,
+              "lastEffect": null,
+              "lastUpdate": null,
+            },
+          },
+          "pendingProps": Object {
+            "Component": [Function],
+            "context": null,
+            "props": Object {
+              "classes": "class",
+              "component": [MockFunction] {
+                "calls": Array [
+                  Array [],
+                ],
+                "results": Array [
+                  Object {
+                    "isThrow": false,
+                    "value": undefined,
+                  },
+                ],
+              },
+              "title": "Title Card",
+            },
+            "wrappingComponentProps": null,
+          },
+          "ref": null,
+          "return": FiberNode {
+            "_debugHookTypes": null,
+            "_debugID": 60,
+            "_debugIsCurrentlyTiming": false,
+            "_debugOwner": null,
+            "_debugSource": null,
+            "actualDuration": 0,
+            "actualStartTime": -1,
+            "alternate": FiberNode {
+              "_debugHookTypes": null,
+              "_debugID": 60,
+              "_debugIsCurrentlyTiming": false,
+              "_debugOwner": null,
+              "_debugSource": null,
+              "actualDuration": 0,
+              "actualStartTime": -1,
+              "alternate": [Circular],
+              "child": null,
+              "childExpirationTime": 0,
+              "contextDependencies": null,
+              "effectTag": 0,
+              "elementType": null,
+              "expirationTime": 1073741823,
+              "firstEffect": null,
+              "index": 0,
+              "key": null,
+              "lastEffect": null,
+              "memoizedProps": null,
+              "memoizedState": null,
+              "mode": 0,
+              "nextEffect": null,
+              "pendingProps": null,
+              "ref": null,
+              "return": null,
+              "selfBaseDuration": 0,
+              "sibling": null,
+              "stateNode": Object {
+                "containerInfo": <div>
+                  <div
+                    class="dashboard-card class"
+                  >
+                    <div
+                      class="title"
+                    >
+                      Title Card
+                    </div>
+                  </div>
+                </div>,
+                "context": Object {},
+                "current": [Circular],
+                "didError": false,
+                "earliestPendingTime": 0,
+                "earliestSuspendedTime": 0,
+                "expirationTime": 0,
+                "finishedWork": null,
+                "firstBatch": null,
+                "hydrate": false,
+                "interactionThreadID": 15,
+                "latestPendingTime": 0,
+                "latestPingedTime": 0,
+                "latestSuspendedTime": 0,
+                "memoizedInteractions": Set {},
+                "nextExpirationTimeToWorkOn": 0,
+                "nextScheduledRoot": null,
+                "pendingChildren": null,
+                "pendingCommitExpirationTime": 0,
+                "pendingContext": null,
+                "pendingInteractionMap": Map {},
+                "pingCache": null,
+                "timeoutHandle": -1,
+              },
+              "tag": 3,
+              "treeBaseDuration": 0,
+              "type": null,
+              "updateQueue": Object {
+                "baseState": null,
+                "firstCapturedEffect": null,
+                "firstCapturedUpdate": null,
+                "firstEffect": null,
+                "firstUpdate": Object {
+                  "callback": null,
+                  "expirationTime": 1073741823,
+                  "next": null,
+                  "nextEffect": null,
+                  "payload": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={
+                        Object {
+                          "classes": "class",
+                          "component": [MockFunction] {
+                            "calls": Array [
+                              Array [],
+                            ],
+                            "results": Array [
+                              Object {
+                                "isThrow": false,
+                                "value": undefined,
+                              },
+                            ],
+                          },
+                          "title": "Title Card",
+                        }
+                      }
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "tag": 0,
+                },
+                "lastCapturedEffect": null,
+                "lastCapturedUpdate": null,
+                "lastEffect": null,
+                "lastUpdate": Object {
+                  "callback": null,
+                  "expirationTime": 1073741823,
+                  "next": null,
+                  "nextEffect": null,
+                  "payload": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={
+                        Object {
+                          "classes": "class",
+                          "component": [MockFunction] {
+                            "calls": Array [
+                              Array [],
+                            ],
+                            "results": Array [
+                              Object {
+                                "isThrow": false,
+                                "value": undefined,
+                              },
+                            ],
+                          },
+                          "title": "Title Card",
+                        }
+                      }
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "tag": 0,
+                },
+              },
+            },
+            "child": [Circular],
+            "childExpirationTime": 0,
+            "contextDependencies": null,
+            "effectTag": 32,
+            "elementType": null,
+            "expirationTime": 0,
+            "firstEffect": [Circular],
+            "index": 0,
+            "key": null,
+            "lastEffect": [Circular],
+            "memoizedProps": null,
+            "memoizedState": Object {
+              "element": <WrapperComponent
+                Component={[Function]}
+                context={null}
+                props={
+                  Object {
+                    "classes": "class",
+                    "component": [MockFunction] {
+                      "calls": Array [
+                        Array [],
+                      ],
+                      "results": Array [
+                        Object {
+                          "isThrow": false,
+                          "value": undefined,
+                        },
+                      ],
+                    },
+                    "title": "Title Card",
+                  }
+                }
+                wrappingComponentProps={null}
+              />,
+            },
+            "mode": 0,
+            "nextEffect": null,
+            "pendingProps": null,
+            "ref": null,
+            "return": null,
+            "selfBaseDuration": 0,
+            "sibling": null,
+            "stateNode": Object {
+              "containerInfo": <div>
+                <div
+                  class="dashboard-card class"
+                >
+                  <div
+                    class="title"
+                  >
+                    Title Card
+                  </div>
+                </div>
+              </div>,
+              "context": Object {},
+              "current": [Circular],
+              "didError": false,
+              "earliestPendingTime": 0,
+              "earliestSuspendedTime": 0,
+              "expirationTime": 0,
+              "finishedWork": null,
+              "firstBatch": null,
+              "hydrate": false,
+              "interactionThreadID": 15,
+              "latestPendingTime": 0,
+              "latestPingedTime": 0,
+              "latestSuspendedTime": 0,
+              "memoizedInteractions": Set {},
+              "nextExpirationTimeToWorkOn": 0,
+              "nextScheduledRoot": null,
+              "pendingChildren": null,
+              "pendingCommitExpirationTime": 0,
+              "pendingContext": null,
+              "pendingInteractionMap": Map {},
+              "pingCache": null,
+              "timeoutHandle": -1,
+            },
+            "tag": 3,
+            "treeBaseDuration": 0,
+            "type": null,
+            "updateQueue": Object {
+              "baseState": Object {
+                "element": <WrapperComponent
+                  Component={[Function]}
+                  context={null}
+                  props={
+                    Object {
+                      "classes": "class",
+                      "component": [MockFunction] {
+                        "calls": Array [
+                          Array [],
+                        ],
+                        "results": Array [
+                          Object {
+                            "isThrow": false,
+                            "value": undefined,
+                          },
+                        ],
+                      },
+                      "title": "Title Card",
+                    }
+                  }
+                  wrappingComponentProps={null}
+                />,
+              },
+              "firstCapturedEffect": null,
+              "firstCapturedUpdate": null,
+              "firstEffect": null,
+              "firstUpdate": null,
+              "lastCapturedEffect": null,
+              "lastCapturedUpdate": null,
+              "lastEffect": null,
+              "lastUpdate": null,
+            },
+          },
+          "selfBaseDuration": 0,
+          "sibling": null,
+          "stateNode": WrapperComponent {
+            "_reactInternalFiber": [Circular],
+            "_reactInternalInstance": Object {},
+            "context": Object {},
+            "props": Object {
+              "Component": [Function],
+              "context": null,
+              "props": Object {
+                "classes": "class",
+                "component": [MockFunction] {
+                  "calls": Array [
+                    Array [],
+                  ],
+                  "results": Array [
+                    Object {
+                      "isThrow": false,
+                      "value": undefined,
+                    },
+                  ],
+                },
+                "title": "Title Card",
+              },
+              "wrappingComponentProps": null,
+            },
+            "refs": Object {},
+            "rootFinderInstance": null,
+            "state": Object {
+              "context": null,
+              "mount": true,
+              "props": Object {
+                "classes": "class",
+                "component": [MockFunction] {
+                  "calls": Array [
+                    Array [],
+                  ],
+                  "results": Array [
+                    Object {
+                      "isThrow": false,
+                      "value": undefined,
+                    },
+                  ],
+                },
+                "title": "Title Card",
+              },
+              "wrappingComponentProps": null,
+            },
+            "updater": Object {
+              "enqueueForceUpdate": [Function],
+              "enqueueReplaceState": [Function],
+              "enqueueSetState": [Function],
+              "isMounted": [Function],
+            },
+          },
+          "tag": 1,
+          "treeBaseDuration": 0,
+          "type": [Function],
+          "updateQueue": null,
+        },
+        "selfBaseDuration": 0,
+        "sibling": null,
+        "stateNode": [Circular],
+        "tag": 1,
+        "treeBaseDuration": 0,
+        "type": [Function],
+        "updateQueue": null,
+      },
+      "_reactInternalInstance": Object {},
+      "context": Object {},
+      "props": Object {
+        "classes": "class",
+        "component": [MockFunction] {
+          "calls": Array [
+            Array [],
+          ],
+          "results": Array [
+            Object {
+              "isThrow": false,
+              "value": undefined,
+            },
+          ],
+        },
+        "title": "Title Card",
+      },
+      "refs": Object {},
+      "state": null,
+      "updater": Object {
+        "enqueueForceUpdate": [Function],
+        "enqueueReplaceState": [Function],
+        "enqueueSetState": [Function],
+        "isMounted": [Function],
+      },
+    },
+    "key": undefined,
+    "nodeType": "class",
+    "props": Object {
+      "classes": "class",
+      "component": [MockFunction] {
+        "calls": Array [
+          Array [],
+        ],
+        "results": Array [
+          Object {
+            "isThrow": false,
+            "value": undefined,
+          },
+        ],
+      },
+      "title": "Title Card",
+    },
+    "ref": null,
+    "rendered": Object {
+      "instance": <div
+        class="dashboard-card class"
+      >
+        <div
+          class="title"
+        >
+          Title Card
+        </div>
+      </div>,
+      "key": undefined,
+      "nodeType": "host",
+      "props": Object {
+        "children": Array [
+          <div
+            className="title"
+          >
+            Title Card
+          </div>,
+          undefined,
+        ],
+        "className": "dashboard-card class",
+      },
+      "ref": null,
+      "rendered": Array [
+        Object {
+          "instance": <div
+            class="title"
+          >
+            Title Card
+          </div>,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": "Title Card",
+            "className": "title",
+          },
+          "ref": null,
+          "rendered": Array [
+            "Title Card",
+          ],
+          "type": "div",
+        },
+      ],
+      "type": "div",
+    },
+    "type": [Function],
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": Card {
+        "_reactInternalFiber": FiberNode {
+          "_debugHookTypes": null,
+          "_debugID": 63,
+          "_debugIsCurrentlyTiming": false,
+          "_debugOwner": FiberNode {
+            "_debugHookTypes": null,
+            "_debugID": 62,
+            "_debugIsCurrentlyTiming": false,
+            "_debugOwner": null,
+            "_debugSource": null,
+            "actualDuration": 0,
+            "actualStartTime": -1,
+            "alternate": null,
+            "child": [Circular],
+            "childExpirationTime": 0,
+            "contextDependencies": null,
+            "effectTag": 1,
+            "elementType": [Function],
+            "expirationTime": 0,
+            "firstEffect": null,
+            "index": 0,
+            "key": null,
+            "lastEffect": null,
+            "memoizedProps": Object {
+              "Component": [Function],
+              "context": null,
+              "props": Object {
+                "classes": "class",
+                "component": [MockFunction] {
+                  "calls": Array [
+                    Array [],
+                  ],
+                  "results": Array [
+                    Object {
+                      "isThrow": false,
+                      "value": undefined,
+                    },
+                  ],
+                },
+                "title": "Title Card",
+              },
+              "wrappingComponentProps": null,
+            },
+            "memoizedState": Object {
+              "context": null,
+              "mount": true,
+              "props": Object {
+                "classes": "class",
+                "component": [MockFunction] {
+                  "calls": Array [
+                    Array [],
+                  ],
+                  "results": Array [
+                    Object {
+                      "isThrow": false,
+                      "value": undefined,
+                    },
+                  ],
+                },
+                "title": "Title Card",
+              },
+              "wrappingComponentProps": null,
+            },
+            "mode": 0,
+            "nextEffect": FiberNode {
+              "_debugHookTypes": null,
+              "_debugID": 60,
+              "_debugIsCurrentlyTiming": false,
+              "_debugOwner": null,
+              "_debugSource": null,
+              "actualDuration": 0,
+              "actualStartTime": -1,
+              "alternate": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 60,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": null,
+                "_debugSource": null,
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": [Circular],
+                "child": null,
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 0,
+                "elementType": null,
+                "expirationTime": 1073741823,
+                "firstEffect": null,
+                "index": 0,
+                "key": null,
+                "lastEffect": null,
+                "memoizedProps": null,
+                "memoizedState": null,
+                "mode": 0,
+                "nextEffect": null,
+                "pendingProps": null,
+                "ref": null,
+                "return": null,
+                "selfBaseDuration": 0,
+                "sibling": null,
+                "stateNode": Object {
+                  "containerInfo": <div>
+                    <div
+                      class="dashboard-card class"
+                    >
+                      <div
+                        class="title"
+                      >
+                        Title Card
+                      </div>
+                    </div>
+                  </div>,
+                  "context": Object {},
+                  "current": [Circular],
+                  "didError": false,
+                  "earliestPendingTime": 0,
+                  "earliestSuspendedTime": 0,
+                  "expirationTime": 0,
+                  "finishedWork": null,
+                  "firstBatch": null,
+                  "hydrate": false,
+                  "interactionThreadID": 15,
+                  "latestPendingTime": 0,
+                  "latestPingedTime": 0,
+                  "latestSuspendedTime": 0,
+                  "memoizedInteractions": Set {},
+                  "nextExpirationTimeToWorkOn": 0,
+                  "nextScheduledRoot": null,
+                  "pendingChildren": null,
+                  "pendingCommitExpirationTime": 0,
+                  "pendingContext": null,
+                  "pendingInteractionMap": Map {},
+                  "pingCache": null,
+                  "timeoutHandle": -1,
+                },
+                "tag": 3,
+                "treeBaseDuration": 0,
+                "type": null,
+                "updateQueue": Object {
+                  "baseState": null,
+                  "firstCapturedEffect": null,
+                  "firstCapturedUpdate": null,
+                  "firstEffect": null,
+                  "firstUpdate": Object {
+                    "callback": null,
+                    "expirationTime": 1073741823,
+                    "next": null,
+                    "nextEffect": null,
+                    "payload": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={
+                          Object {
+                            "classes": "class",
+                            "component": [MockFunction] {
+                              "calls": Array [
+                                Array [],
+                              ],
+                              "results": Array [
+                                Object {
+                                  "isThrow": false,
+                                  "value": undefined,
+                                },
+                              ],
+                            },
+                            "title": "Title Card",
+                          }
+                        }
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "tag": 0,
+                  },
+                  "lastCapturedEffect": null,
+                  "lastCapturedUpdate": null,
+                  "lastEffect": null,
+                  "lastUpdate": Object {
+                    "callback": null,
+                    "expirationTime": 1073741823,
+                    "next": null,
+                    "nextEffect": null,
+                    "payload": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={
+                          Object {
+                            "classes": "class",
+                            "component": [MockFunction] {
+                              "calls": Array [
+                                Array [],
+                              ],
+                              "results": Array [
+                                Object {
+                                  "isThrow": false,
+                                  "value": undefined,
+                                },
+                              ],
+                            },
+                            "title": "Title Card",
+                          }
+                        }
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "tag": 0,
+                  },
+                },
+              },
+              "child": [Circular],
+              "childExpirationTime": 0,
+              "contextDependencies": null,
+              "effectTag": 32,
+              "elementType": null,
+              "expirationTime": 0,
+              "firstEffect": [Circular],
+              "index": 0,
+              "key": null,
+              "lastEffect": [Circular],
+              "memoizedProps": null,
+              "memoizedState": Object {
+                "element": <WrapperComponent
+                  Component={[Function]}
+                  context={null}
+                  props={
+                    Object {
+                      "classes": "class",
+                      "component": [MockFunction] {
+                        "calls": Array [
+                          Array [],
+                        ],
+                        "results": Array [
+                          Object {
+                            "isThrow": false,
+                            "value": undefined,
+                          },
+                        ],
+                      },
+                      "title": "Title Card",
+                    }
+                  }
+                  wrappingComponentProps={null}
+                />,
+              },
+              "mode": 0,
+              "nextEffect": null,
+              "pendingProps": null,
+              "ref": null,
+              "return": null,
+              "selfBaseDuration": 0,
+              "sibling": null,
+              "stateNode": Object {
+                "containerInfo": <div>
+                  <div
+                    class="dashboard-card class"
+                  >
+                    <div
+                      class="title"
+                    >
+                      Title Card
+                    </div>
+                  </div>
+                </div>,
+                "context": Object {},
+                "current": [Circular],
+                "didError": false,
+                "earliestPendingTime": 0,
+                "earliestSuspendedTime": 0,
+                "expirationTime": 0,
+                "finishedWork": null,
+                "firstBatch": null,
+                "hydrate": false,
+                "interactionThreadID": 15,
+                "latestPendingTime": 0,
+                "latestPingedTime": 0,
+                "latestSuspendedTime": 0,
+                "memoizedInteractions": Set {},
+                "nextExpirationTimeToWorkOn": 0,
+                "nextScheduledRoot": null,
+                "pendingChildren": null,
+                "pendingCommitExpirationTime": 0,
+                "pendingContext": null,
+                "pendingInteractionMap": Map {},
+                "pingCache": null,
+                "timeoutHandle": -1,
+              },
+              "tag": 3,
+              "treeBaseDuration": 0,
+              "type": null,
+              "updateQueue": Object {
+                "baseState": Object {
+                  "element": <WrapperComponent
+                    Component={[Function]}
+                    context={null}
+                    props={
+                      Object {
+                        "classes": "class",
+                        "component": [MockFunction] {
+                          "calls": Array [
+                            Array [],
+                          ],
+                          "results": Array [
+                            Object {
+                              "isThrow": false,
+                              "value": undefined,
+                            },
+                          ],
+                        },
+                        "title": "Title Card",
+                      }
+                    }
+                    wrappingComponentProps={null}
+                  />,
+                },
+                "firstCapturedEffect": null,
+                "firstCapturedUpdate": null,
+                "firstEffect": null,
+                "firstUpdate": null,
+                "lastCapturedEffect": null,
+                "lastCapturedUpdate": null,
+                "lastEffect": null,
+                "lastUpdate": null,
+              },
+            },
+            "pendingProps": Object {
+              "Component": [Function],
+              "context": null,
+              "props": Object {
+                "classes": "class",
+                "component": [MockFunction] {
+                  "calls": Array [
+                    Array [],
+                  ],
+                  "results": Array [
+                    Object {
+                      "isThrow": false,
+                      "value": undefined,
+                    },
+                  ],
+                },
+                "title": "Title Card",
+              },
+              "wrappingComponentProps": null,
+            },
+            "ref": null,
+            "return": FiberNode {
+              "_debugHookTypes": null,
+              "_debugID": 60,
+              "_debugIsCurrentlyTiming": false,
+              "_debugOwner": null,
+              "_debugSource": null,
+              "actualDuration": 0,
+              "actualStartTime": -1,
+              "alternate": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 60,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": null,
+                "_debugSource": null,
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": [Circular],
+                "child": null,
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 0,
+                "elementType": null,
+                "expirationTime": 1073741823,
+                "firstEffect": null,
+                "index": 0,
+                "key": null,
+                "lastEffect": null,
+                "memoizedProps": null,
+                "memoizedState": null,
+                "mode": 0,
+                "nextEffect": null,
+                "pendingProps": null,
+                "ref": null,
+                "return": null,
+                "selfBaseDuration": 0,
+                "sibling": null,
+                "stateNode": Object {
+                  "containerInfo": <div>
+                    <div
+                      class="dashboard-card class"
+                    >
+                      <div
+                        class="title"
+                      >
+                        Title Card
+                      </div>
+                    </div>
+                  </div>,
+                  "context": Object {},
+                  "current": [Circular],
+                  "didError": false,
+                  "earliestPendingTime": 0,
+                  "earliestSuspendedTime": 0,
+                  "expirationTime": 0,
+                  "finishedWork": null,
+                  "firstBatch": null,
+                  "hydrate": false,
+                  "interactionThreadID": 15,
+                  "latestPendingTime": 0,
+                  "latestPingedTime": 0,
+                  "latestSuspendedTime": 0,
+                  "memoizedInteractions": Set {},
+                  "nextExpirationTimeToWorkOn": 0,
+                  "nextScheduledRoot": null,
+                  "pendingChildren": null,
+                  "pendingCommitExpirationTime": 0,
+                  "pendingContext": null,
+                  "pendingInteractionMap": Map {},
+                  "pingCache": null,
+                  "timeoutHandle": -1,
+                },
+                "tag": 3,
+                "treeBaseDuration": 0,
+                "type": null,
+                "updateQueue": Object {
+                  "baseState": null,
+                  "firstCapturedEffect": null,
+                  "firstCapturedUpdate": null,
+                  "firstEffect": null,
+                  "firstUpdate": Object {
+                    "callback": null,
+                    "expirationTime": 1073741823,
+                    "next": null,
+                    "nextEffect": null,
+                    "payload": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={
+                          Object {
+                            "classes": "class",
+                            "component": [MockFunction] {
+                              "calls": Array [
+                                Array [],
+                              ],
+                              "results": Array [
+                                Object {
+                                  "isThrow": false,
+                                  "value": undefined,
+                                },
+                              ],
+                            },
+                            "title": "Title Card",
+                          }
+                        }
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "tag": 0,
+                  },
+                  "lastCapturedEffect": null,
+                  "lastCapturedUpdate": null,
+                  "lastEffect": null,
+                  "lastUpdate": Object {
+                    "callback": null,
+                    "expirationTime": 1073741823,
+                    "next": null,
+                    "nextEffect": null,
+                    "payload": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={
+                          Object {
+                            "classes": "class",
+                            "component": [MockFunction] {
+                              "calls": Array [
+                                Array [],
+                              ],
+                              "results": Array [
+                                Object {
+                                  "isThrow": false,
+                                  "value": undefined,
+                                },
+                              ],
+                            },
+                            "title": "Title Card",
+                          }
+                        }
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "tag": 0,
+                  },
+                },
+              },
+              "child": [Circular],
+              "childExpirationTime": 0,
+              "contextDependencies": null,
+              "effectTag": 32,
+              "elementType": null,
+              "expirationTime": 0,
+              "firstEffect": [Circular],
+              "index": 0,
+              "key": null,
+              "lastEffect": [Circular],
+              "memoizedProps": null,
+              "memoizedState": Object {
+                "element": <WrapperComponent
+                  Component={[Function]}
+                  context={null}
+                  props={
+                    Object {
+                      "classes": "class",
+                      "component": [MockFunction] {
+                        "calls": Array [
+                          Array [],
+                        ],
+                        "results": Array [
+                          Object {
+                            "isThrow": false,
+                            "value": undefined,
+                          },
+                        ],
+                      },
+                      "title": "Title Card",
+                    }
+                  }
+                  wrappingComponentProps={null}
+                />,
+              },
+              "mode": 0,
+              "nextEffect": null,
+              "pendingProps": null,
+              "ref": null,
+              "return": null,
+              "selfBaseDuration": 0,
+              "sibling": null,
+              "stateNode": Object {
+                "containerInfo": <div>
+                  <div
+                    class="dashboard-card class"
+                  >
+                    <div
+                      class="title"
+                    >
+                      Title Card
+                    </div>
+                  </div>
+                </div>,
+                "context": Object {},
+                "current": [Circular],
+                "didError": false,
+                "earliestPendingTime": 0,
+                "earliestSuspendedTime": 0,
+                "expirationTime": 0,
+                "finishedWork": null,
+                "firstBatch": null,
+                "hydrate": false,
+                "interactionThreadID": 15,
+                "latestPendingTime": 0,
+                "latestPingedTime": 0,
+                "latestSuspendedTime": 0,
+                "memoizedInteractions": Set {},
+                "nextExpirationTimeToWorkOn": 0,
+                "nextScheduledRoot": null,
+                "pendingChildren": null,
+                "pendingCommitExpirationTime": 0,
+                "pendingContext": null,
+                "pendingInteractionMap": Map {},
+                "pingCache": null,
+                "timeoutHandle": -1,
+              },
+              "tag": 3,
+              "treeBaseDuration": 0,
+              "type": null,
+              "updateQueue": Object {
+                "baseState": Object {
+                  "element": <WrapperComponent
+                    Component={[Function]}
+                    context={null}
+                    props={
+                      Object {
+                        "classes": "class",
+                        "component": [MockFunction] {
+                          "calls": Array [
+                            Array [],
+                          ],
+                          "results": Array [
+                            Object {
+                              "isThrow": false,
+                              "value": undefined,
+                            },
+                          ],
+                        },
+                        "title": "Title Card",
+                      }
+                    }
+                    wrappingComponentProps={null}
+                  />,
+                },
+                "firstCapturedEffect": null,
+                "firstCapturedUpdate": null,
+                "firstEffect": null,
+                "firstUpdate": null,
+                "lastCapturedEffect": null,
+                "lastCapturedUpdate": null,
+                "lastEffect": null,
+                "lastUpdate": null,
+              },
+            },
+            "selfBaseDuration": 0,
+            "sibling": null,
+            "stateNode": WrapperComponent {
+              "_reactInternalFiber": [Circular],
+              "_reactInternalInstance": Object {},
+              "context": Object {},
+              "props": Object {
+                "Component": [Function],
+                "context": null,
+                "props": Object {
+                  "classes": "class",
+                  "component": [MockFunction] {
+                    "calls": Array [
+                      Array [],
+                    ],
+                    "results": Array [
+                      Object {
+                        "isThrow": false,
+                        "value": undefined,
+                      },
+                    ],
+                  },
+                  "title": "Title Card",
+                },
+                "wrappingComponentProps": null,
+              },
+              "refs": Object {},
+              "rootFinderInstance": null,
+              "state": Object {
+                "context": null,
+                "mount": true,
+                "props": Object {
+                  "classes": "class",
+                  "component": [MockFunction] {
+                    "calls": Array [
+                      Array [],
+                    ],
+                    "results": Array [
+                      Object {
+                        "isThrow": false,
+                        "value": undefined,
+                      },
+                    ],
+                  },
+                  "title": "Title Card",
+                },
+                "wrappingComponentProps": null,
+              },
+              "updater": Object {
+                "enqueueForceUpdate": [Function],
+                "enqueueReplaceState": [Function],
+                "enqueueSetState": [Function],
+                "isMounted": [Function],
+              },
+            },
+            "tag": 1,
+            "treeBaseDuration": 0,
+            "type": [Function],
+            "updateQueue": null,
+          },
+          "_debugSource": null,
+          "actualDuration": 0,
+          "actualStartTime": -1,
+          "alternate": null,
+          "child": FiberNode {
+            "_debugHookTypes": null,
+            "_debugID": 64,
+            "_debugIsCurrentlyTiming": false,
+            "_debugOwner": [Circular],
+            "_debugSource": Object {
+              "fileName": "/Users/kevinkoech/Documents/bp-esa-frontend/src/components/Dashboard/Card.jsx",
+              "lineNumber": 20,
+            },
+            "actualDuration": 0,
+            "actualStartTime": -1,
+            "alternate": null,
+            "child": FiberNode {
+              "_debugHookTypes": null,
+              "_debugID": 65,
+              "_debugIsCurrentlyTiming": false,
+              "_debugOwner": [Circular],
+              "_debugSource": Object {
+                "fileName": "/Users/kevinkoech/Documents/bp-esa-frontend/src/components/Dashboard/Card.jsx",
+                "lineNumber": 21,
+              },
+              "actualDuration": 0,
+              "actualStartTime": -1,
+              "alternate": null,
+              "child": null,
+              "childExpirationTime": 0,
+              "contextDependencies": null,
+              "effectTag": 0,
+              "elementType": "div",
+              "expirationTime": 0,
+              "firstEffect": null,
+              "index": 0,
+              "key": null,
+              "lastEffect": null,
+              "memoizedProps": Object {
+                "children": "Title Card",
+                "className": "title",
+              },
+              "memoizedState": null,
+              "mode": 0,
+              "nextEffect": null,
+              "pendingProps": Object {
+                "children": "Title Card",
+                "className": "title",
+              },
+              "ref": null,
+              "return": [Circular],
+              "selfBaseDuration": 0,
+              "sibling": null,
+              "stateNode": <div
+                class="title"
+              >
+                Title Card
+              </div>,
+              "tag": 5,
+              "treeBaseDuration": 0,
+              "type": "div",
+              "updateQueue": null,
+            },
+            "childExpirationTime": 0,
+            "contextDependencies": null,
+            "effectTag": 0,
+            "elementType": "div",
+            "expirationTime": 0,
+            "firstEffect": null,
+            "index": 0,
+            "key": null,
+            "lastEffect": null,
+            "memoizedProps": Object {
+              "children": Array [
+                <div
+                  className="title"
+                >
+                  Title Card
+                </div>,
+                undefined,
+              ],
+              "className": "dashboard-card class",
+            },
+            "memoizedState": null,
+            "mode": 0,
+            "nextEffect": null,
+            "pendingProps": Object {
+              "children": Array [
+                <div
+                  className="title"
+                >
+                  Title Card
+                </div>,
+                undefined,
+              ],
+              "className": "dashboard-card class",
+            },
+            "ref": null,
+            "return": [Circular],
+            "selfBaseDuration": 0,
+            "sibling": null,
+            "stateNode": <div
+              class="dashboard-card class"
+            >
+              <div
+                class="title"
+              >
+                Title Card
+              </div>
+            </div>,
+            "tag": 5,
+            "treeBaseDuration": 0,
+            "type": "div",
+            "updateQueue": null,
+          },
+          "childExpirationTime": 0,
+          "contextDependencies": null,
+          "effectTag": 1,
+          "elementType": [Function],
+          "expirationTime": 0,
+          "firstEffect": null,
+          "index": 0,
+          "key": null,
+          "lastEffect": null,
+          "memoizedProps": Object {
+            "classes": "class",
+            "component": [MockFunction] {
+              "calls": Array [
+                Array [],
+              ],
+              "results": Array [
+                Object {
+                  "isThrow": false,
+                  "value": undefined,
+                },
+              ],
+            },
+            "title": "Title Card",
+          },
+          "memoizedState": null,
+          "mode": 0,
+          "nextEffect": null,
+          "pendingProps": Object {
+            "classes": "class",
+            "component": [MockFunction] {
+              "calls": Array [
+                Array [],
+              ],
+              "results": Array [
+                Object {
+                  "isThrow": false,
+                  "value": undefined,
+                },
+              ],
+            },
+            "title": "Title Card",
+          },
+          "ref": null,
+          "return": FiberNode {
+            "_debugHookTypes": null,
+            "_debugID": 62,
+            "_debugIsCurrentlyTiming": false,
+            "_debugOwner": null,
+            "_debugSource": null,
+            "actualDuration": 0,
+            "actualStartTime": -1,
+            "alternate": null,
+            "child": [Circular],
+            "childExpirationTime": 0,
+            "contextDependencies": null,
+            "effectTag": 1,
+            "elementType": [Function],
+            "expirationTime": 0,
+            "firstEffect": null,
+            "index": 0,
+            "key": null,
+            "lastEffect": null,
+            "memoizedProps": Object {
+              "Component": [Function],
+              "context": null,
+              "props": Object {
+                "classes": "class",
+                "component": [MockFunction] {
+                  "calls": Array [
+                    Array [],
+                  ],
+                  "results": Array [
+                    Object {
+                      "isThrow": false,
+                      "value": undefined,
+                    },
+                  ],
+                },
+                "title": "Title Card",
+              },
+              "wrappingComponentProps": null,
+            },
+            "memoizedState": Object {
+              "context": null,
+              "mount": true,
+              "props": Object {
+                "classes": "class",
+                "component": [MockFunction] {
+                  "calls": Array [
+                    Array [],
+                  ],
+                  "results": Array [
+                    Object {
+                      "isThrow": false,
+                      "value": undefined,
+                    },
+                  ],
+                },
+                "title": "Title Card",
+              },
+              "wrappingComponentProps": null,
+            },
+            "mode": 0,
+            "nextEffect": FiberNode {
+              "_debugHookTypes": null,
+              "_debugID": 60,
+              "_debugIsCurrentlyTiming": false,
+              "_debugOwner": null,
+              "_debugSource": null,
+              "actualDuration": 0,
+              "actualStartTime": -1,
+              "alternate": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 60,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": null,
+                "_debugSource": null,
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": [Circular],
+                "child": null,
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 0,
+                "elementType": null,
+                "expirationTime": 1073741823,
+                "firstEffect": null,
+                "index": 0,
+                "key": null,
+                "lastEffect": null,
+                "memoizedProps": null,
+                "memoizedState": null,
+                "mode": 0,
+                "nextEffect": null,
+                "pendingProps": null,
+                "ref": null,
+                "return": null,
+                "selfBaseDuration": 0,
+                "sibling": null,
+                "stateNode": Object {
+                  "containerInfo": <div>
+                    <div
+                      class="dashboard-card class"
+                    >
+                      <div
+                        class="title"
+                      >
+                        Title Card
+                      </div>
+                    </div>
+                  </div>,
+                  "context": Object {},
+                  "current": [Circular],
+                  "didError": false,
+                  "earliestPendingTime": 0,
+                  "earliestSuspendedTime": 0,
+                  "expirationTime": 0,
+                  "finishedWork": null,
+                  "firstBatch": null,
+                  "hydrate": false,
+                  "interactionThreadID": 15,
+                  "latestPendingTime": 0,
+                  "latestPingedTime": 0,
+                  "latestSuspendedTime": 0,
+                  "memoizedInteractions": Set {},
+                  "nextExpirationTimeToWorkOn": 0,
+                  "nextScheduledRoot": null,
+                  "pendingChildren": null,
+                  "pendingCommitExpirationTime": 0,
+                  "pendingContext": null,
+                  "pendingInteractionMap": Map {},
+                  "pingCache": null,
+                  "timeoutHandle": -1,
+                },
+                "tag": 3,
+                "treeBaseDuration": 0,
+                "type": null,
+                "updateQueue": Object {
+                  "baseState": null,
+                  "firstCapturedEffect": null,
+                  "firstCapturedUpdate": null,
+                  "firstEffect": null,
+                  "firstUpdate": Object {
+                    "callback": null,
+                    "expirationTime": 1073741823,
+                    "next": null,
+                    "nextEffect": null,
+                    "payload": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={
+                          Object {
+                            "classes": "class",
+                            "component": [MockFunction] {
+                              "calls": Array [
+                                Array [],
+                              ],
+                              "results": Array [
+                                Object {
+                                  "isThrow": false,
+                                  "value": undefined,
+                                },
+                              ],
+                            },
+                            "title": "Title Card",
+                          }
+                        }
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "tag": 0,
+                  },
+                  "lastCapturedEffect": null,
+                  "lastCapturedUpdate": null,
+                  "lastEffect": null,
+                  "lastUpdate": Object {
+                    "callback": null,
+                    "expirationTime": 1073741823,
+                    "next": null,
+                    "nextEffect": null,
+                    "payload": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={
+                          Object {
+                            "classes": "class",
+                            "component": [MockFunction] {
+                              "calls": Array [
+                                Array [],
+                              ],
+                              "results": Array [
+                                Object {
+                                  "isThrow": false,
+                                  "value": undefined,
+                                },
+                              ],
+                            },
+                            "title": "Title Card",
+                          }
+                        }
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "tag": 0,
+                  },
+                },
+              },
+              "child": [Circular],
+              "childExpirationTime": 0,
+              "contextDependencies": null,
+              "effectTag": 32,
+              "elementType": null,
+              "expirationTime": 0,
+              "firstEffect": [Circular],
+              "index": 0,
+              "key": null,
+              "lastEffect": [Circular],
+              "memoizedProps": null,
+              "memoizedState": Object {
+                "element": <WrapperComponent
+                  Component={[Function]}
+                  context={null}
+                  props={
+                    Object {
+                      "classes": "class",
+                      "component": [MockFunction] {
+                        "calls": Array [
+                          Array [],
+                        ],
+                        "results": Array [
+                          Object {
+                            "isThrow": false,
+                            "value": undefined,
+                          },
+                        ],
+                      },
+                      "title": "Title Card",
+                    }
+                  }
+                  wrappingComponentProps={null}
+                />,
+              },
+              "mode": 0,
+              "nextEffect": null,
+              "pendingProps": null,
+              "ref": null,
+              "return": null,
+              "selfBaseDuration": 0,
+              "sibling": null,
+              "stateNode": Object {
+                "containerInfo": <div>
+                  <div
+                    class="dashboard-card class"
+                  >
+                    <div
+                      class="title"
+                    >
+                      Title Card
+                    </div>
+                  </div>
+                </div>,
+                "context": Object {},
+                "current": [Circular],
+                "didError": false,
+                "earliestPendingTime": 0,
+                "earliestSuspendedTime": 0,
+                "expirationTime": 0,
+                "finishedWork": null,
+                "firstBatch": null,
+                "hydrate": false,
+                "interactionThreadID": 15,
+                "latestPendingTime": 0,
+                "latestPingedTime": 0,
+                "latestSuspendedTime": 0,
+                "memoizedInteractions": Set {},
+                "nextExpirationTimeToWorkOn": 0,
+                "nextScheduledRoot": null,
+                "pendingChildren": null,
+                "pendingCommitExpirationTime": 0,
+                "pendingContext": null,
+                "pendingInteractionMap": Map {},
+                "pingCache": null,
+                "timeoutHandle": -1,
+              },
+              "tag": 3,
+              "treeBaseDuration": 0,
+              "type": null,
+              "updateQueue": Object {
+                "baseState": Object {
+                  "element": <WrapperComponent
+                    Component={[Function]}
+                    context={null}
+                    props={
+                      Object {
+                        "classes": "class",
+                        "component": [MockFunction] {
+                          "calls": Array [
+                            Array [],
+                          ],
+                          "results": Array [
+                            Object {
+                              "isThrow": false,
+                              "value": undefined,
+                            },
+                          ],
+                        },
+                        "title": "Title Card",
+                      }
+                    }
+                    wrappingComponentProps={null}
+                  />,
+                },
+                "firstCapturedEffect": null,
+                "firstCapturedUpdate": null,
+                "firstEffect": null,
+                "firstUpdate": null,
+                "lastCapturedEffect": null,
+                "lastCapturedUpdate": null,
+                "lastEffect": null,
+                "lastUpdate": null,
+              },
+            },
+            "pendingProps": Object {
+              "Component": [Function],
+              "context": null,
+              "props": Object {
+                "classes": "class",
+                "component": [MockFunction] {
+                  "calls": Array [
+                    Array [],
+                  ],
+                  "results": Array [
+                    Object {
+                      "isThrow": false,
+                      "value": undefined,
+                    },
+                  ],
+                },
+                "title": "Title Card",
+              },
+              "wrappingComponentProps": null,
+            },
+            "ref": null,
+            "return": FiberNode {
+              "_debugHookTypes": null,
+              "_debugID": 60,
+              "_debugIsCurrentlyTiming": false,
+              "_debugOwner": null,
+              "_debugSource": null,
+              "actualDuration": 0,
+              "actualStartTime": -1,
+              "alternate": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 60,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": null,
+                "_debugSource": null,
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": [Circular],
+                "child": null,
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 0,
+                "elementType": null,
+                "expirationTime": 1073741823,
+                "firstEffect": null,
+                "index": 0,
+                "key": null,
+                "lastEffect": null,
+                "memoizedProps": null,
+                "memoizedState": null,
+                "mode": 0,
+                "nextEffect": null,
+                "pendingProps": null,
+                "ref": null,
+                "return": null,
+                "selfBaseDuration": 0,
+                "sibling": null,
+                "stateNode": Object {
+                  "containerInfo": <div>
+                    <div
+                      class="dashboard-card class"
+                    >
+                      <div
+                        class="title"
+                      >
+                        Title Card
+                      </div>
+                    </div>
+                  </div>,
+                  "context": Object {},
+                  "current": [Circular],
+                  "didError": false,
+                  "earliestPendingTime": 0,
+                  "earliestSuspendedTime": 0,
+                  "expirationTime": 0,
+                  "finishedWork": null,
+                  "firstBatch": null,
+                  "hydrate": false,
+                  "interactionThreadID": 15,
+                  "latestPendingTime": 0,
+                  "latestPingedTime": 0,
+                  "latestSuspendedTime": 0,
+                  "memoizedInteractions": Set {},
+                  "nextExpirationTimeToWorkOn": 0,
+                  "nextScheduledRoot": null,
+                  "pendingChildren": null,
+                  "pendingCommitExpirationTime": 0,
+                  "pendingContext": null,
+                  "pendingInteractionMap": Map {},
+                  "pingCache": null,
+                  "timeoutHandle": -1,
+                },
+                "tag": 3,
+                "treeBaseDuration": 0,
+                "type": null,
+                "updateQueue": Object {
+                  "baseState": null,
+                  "firstCapturedEffect": null,
+                  "firstCapturedUpdate": null,
+                  "firstEffect": null,
+                  "firstUpdate": Object {
+                    "callback": null,
+                    "expirationTime": 1073741823,
+                    "next": null,
+                    "nextEffect": null,
+                    "payload": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={
+                          Object {
+                            "classes": "class",
+                            "component": [MockFunction] {
+                              "calls": Array [
+                                Array [],
+                              ],
+                              "results": Array [
+                                Object {
+                                  "isThrow": false,
+                                  "value": undefined,
+                                },
+                              ],
+                            },
+                            "title": "Title Card",
+                          }
+                        }
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "tag": 0,
+                  },
+                  "lastCapturedEffect": null,
+                  "lastCapturedUpdate": null,
+                  "lastEffect": null,
+                  "lastUpdate": Object {
+                    "callback": null,
+                    "expirationTime": 1073741823,
+                    "next": null,
+                    "nextEffect": null,
+                    "payload": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={
+                          Object {
+                            "classes": "class",
+                            "component": [MockFunction] {
+                              "calls": Array [
+                                Array [],
+                              ],
+                              "results": Array [
+                                Object {
+                                  "isThrow": false,
+                                  "value": undefined,
+                                },
+                              ],
+                            },
+                            "title": "Title Card",
+                          }
+                        }
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "tag": 0,
+                  },
+                },
+              },
+              "child": [Circular],
+              "childExpirationTime": 0,
+              "contextDependencies": null,
+              "effectTag": 32,
+              "elementType": null,
+              "expirationTime": 0,
+              "firstEffect": [Circular],
+              "index": 0,
+              "key": null,
+              "lastEffect": [Circular],
+              "memoizedProps": null,
+              "memoizedState": Object {
+                "element": <WrapperComponent
+                  Component={[Function]}
+                  context={null}
+                  props={
+                    Object {
+                      "classes": "class",
+                      "component": [MockFunction] {
+                        "calls": Array [
+                          Array [],
+                        ],
+                        "results": Array [
+                          Object {
+                            "isThrow": false,
+                            "value": undefined,
+                          },
+                        ],
+                      },
+                      "title": "Title Card",
+                    }
+                  }
+                  wrappingComponentProps={null}
+                />,
+              },
+              "mode": 0,
+              "nextEffect": null,
+              "pendingProps": null,
+              "ref": null,
+              "return": null,
+              "selfBaseDuration": 0,
+              "sibling": null,
+              "stateNode": Object {
+                "containerInfo": <div>
+                  <div
+                    class="dashboard-card class"
+                  >
+                    <div
+                      class="title"
+                    >
+                      Title Card
+                    </div>
+                  </div>
+                </div>,
+                "context": Object {},
+                "current": [Circular],
+                "didError": false,
+                "earliestPendingTime": 0,
+                "earliestSuspendedTime": 0,
+                "expirationTime": 0,
+                "finishedWork": null,
+                "firstBatch": null,
+                "hydrate": false,
+                "interactionThreadID": 15,
+                "latestPendingTime": 0,
+                "latestPingedTime": 0,
+                "latestSuspendedTime": 0,
+                "memoizedInteractions": Set {},
+                "nextExpirationTimeToWorkOn": 0,
+                "nextScheduledRoot": null,
+                "pendingChildren": null,
+                "pendingCommitExpirationTime": 0,
+                "pendingContext": null,
+                "pendingInteractionMap": Map {},
+                "pingCache": null,
+                "timeoutHandle": -1,
+              },
+              "tag": 3,
+              "treeBaseDuration": 0,
+              "type": null,
+              "updateQueue": Object {
+                "baseState": Object {
+                  "element": <WrapperComponent
+                    Component={[Function]}
+                    context={null}
+                    props={
+                      Object {
+                        "classes": "class",
+                        "component": [MockFunction] {
+                          "calls": Array [
+                            Array [],
+                          ],
+                          "results": Array [
+                            Object {
+                              "isThrow": false,
+                              "value": undefined,
+                            },
+                          ],
+                        },
+                        "title": "Title Card",
+                      }
+                    }
+                    wrappingComponentProps={null}
+                  />,
+                },
+                "firstCapturedEffect": null,
+                "firstCapturedUpdate": null,
+                "firstEffect": null,
+                "firstUpdate": null,
+                "lastCapturedEffect": null,
+                "lastCapturedUpdate": null,
+                "lastEffect": null,
+                "lastUpdate": null,
+              },
+            },
+            "selfBaseDuration": 0,
+            "sibling": null,
+            "stateNode": WrapperComponent {
+              "_reactInternalFiber": [Circular],
+              "_reactInternalInstance": Object {},
+              "context": Object {},
+              "props": Object {
+                "Component": [Function],
+                "context": null,
+                "props": Object {
+                  "classes": "class",
+                  "component": [MockFunction] {
+                    "calls": Array [
+                      Array [],
+                    ],
+                    "results": Array [
+                      Object {
+                        "isThrow": false,
+                        "value": undefined,
+                      },
+                    ],
+                  },
+                  "title": "Title Card",
+                },
+                "wrappingComponentProps": null,
+              },
+              "refs": Object {},
+              "rootFinderInstance": null,
+              "state": Object {
+                "context": null,
+                "mount": true,
+                "props": Object {
+                  "classes": "class",
+                  "component": [MockFunction] {
+                    "calls": Array [
+                      Array [],
+                    ],
+                    "results": Array [
+                      Object {
+                        "isThrow": false,
+                        "value": undefined,
+                      },
+                    ],
+                  },
+                  "title": "Title Card",
+                },
+                "wrappingComponentProps": null,
+              },
+              "updater": Object {
+                "enqueueForceUpdate": [Function],
+                "enqueueReplaceState": [Function],
+                "enqueueSetState": [Function],
+                "isMounted": [Function],
+              },
+            },
+            "tag": 1,
+            "treeBaseDuration": 0,
+            "type": [Function],
+            "updateQueue": null,
+          },
+          "selfBaseDuration": 0,
+          "sibling": null,
+          "stateNode": [Circular],
+          "tag": 1,
+          "treeBaseDuration": 0,
+          "type": [Function],
+          "updateQueue": null,
+        },
+        "_reactInternalInstance": Object {},
+        "context": Object {},
+        "props": Object {
+          "classes": "class",
+          "component": [MockFunction] {
+            "calls": Array [
+              Array [],
+            ],
+            "results": Array [
+              Object {
+                "isThrow": false,
+                "value": undefined,
+              },
+            ],
+          },
+          "title": "Title Card",
+        },
+        "refs": Object {},
+        "state": null,
+        "updater": Object {
+          "enqueueForceUpdate": [Function],
+          "enqueueReplaceState": [Function],
+          "enqueueSetState": [Function],
+          "isMounted": [Function],
+        },
+      },
+      "key": undefined,
+      "nodeType": "class",
+      "props": Object {
+        "classes": "class",
+        "component": [MockFunction] {
+          "calls": Array [
+            Array [],
+          ],
+          "results": Array [
+            Object {
+              "isThrow": false,
+              "value": undefined,
+            },
+          ],
+        },
+        "title": "Title Card",
+      },
+      "ref": null,
+      "rendered": Object {
+        "instance": <div
+          class="dashboard-card class"
+        >
+          <div
+            class="title"
+          >
+            Title Card
+          </div>
+        </div>,
+        "key": undefined,
+        "nodeType": "host",
+        "props": Object {
+          "children": Array [
+            <div
+              className="title"
+            >
+              Title Card
+            </div>,
+            undefined,
+          ],
+          "className": "dashboard-card class",
+        },
+        "ref": null,
+        "rendered": Array [
+          Object {
+            "instance": <div
+              class="title"
+            >
+              Title Card
+            </div>,
+            "key": undefined,
+            "nodeType": "host",
+            "props": Object {
+              "children": "Title Card",
+              "className": "title",
+            },
+            "ref": null,
+            "rendered": Array [
+              "Title Card",
+            ],
+            "type": "div",
+          },
+        ],
+        "type": "div",
+      },
+      "type": [Function],
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+        "legacyContextMode": "parent",
+        "lifecycles": Object {
+          "componentDidUpdate": Object {
+            "onSetState": true,
+          },
+          "getChildContext": Object {
+            "calledByRenderer": false,
+          },
+          "getDerivedStateFromError": true,
+          "getDerivedStateFromProps": Object {
+            "hasShouldComponentUpdateBug": false,
+          },
+          "getSnapshotBeforeUpdate": true,
+          "setState": Object {
+            "skipsComponentDidUpdateOnNullish": true,
+          },
+        },
+      },
+    },
+  },
+}
+`;

--- a/src/__tests__/components/Dashboard/__snapshots__/index.test.js.snap
+++ b/src/__tests__/components/Dashboard/__snapshots__/index.test.js.snap
@@ -1,0 +1,18017 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`test dashboard renders a card 1`] = `
+ReactWrapper {
+  Symbol(enzyme.__unrendered__): <Dashboard />,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "getNode": [Function],
+    "getWrappingComponentRenderer": [Function],
+    "render": [Function],
+    "simulateError": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__node__): Object {
+    "instance": Dashboard {
+      "_reactInternalFiber": FiberNode {
+        "_debugHookTypes": null,
+        "_debugID": 63,
+        "_debugIsCurrentlyTiming": false,
+        "_debugOwner": FiberNode {
+          "_debugHookTypes": null,
+          "_debugID": 62,
+          "_debugIsCurrentlyTiming": false,
+          "_debugOwner": null,
+          "_debugSource": null,
+          "actualDuration": 0,
+          "actualStartTime": -1,
+          "alternate": null,
+          "child": [Circular],
+          "childExpirationTime": 0,
+          "contextDependencies": null,
+          "effectTag": 1,
+          "elementType": [Function],
+          "expirationTime": 0,
+          "firstEffect": null,
+          "index": 0,
+          "key": null,
+          "lastEffect": null,
+          "memoizedProps": Object {
+            "Component": [Function],
+            "context": null,
+            "props": Object {},
+            "wrappingComponentProps": null,
+          },
+          "memoizedState": Object {
+            "context": null,
+            "mount": true,
+            "props": Object {},
+            "wrappingComponentProps": null,
+          },
+          "mode": 0,
+          "nextEffect": FiberNode {
+            "_debugHookTypes": null,
+            "_debugID": 60,
+            "_debugIsCurrentlyTiming": false,
+            "_debugOwner": null,
+            "_debugSource": null,
+            "actualDuration": 0,
+            "actualStartTime": -1,
+            "alternate": FiberNode {
+              "_debugHookTypes": null,
+              "_debugID": 60,
+              "_debugIsCurrentlyTiming": false,
+              "_debugOwner": null,
+              "_debugSource": null,
+              "actualDuration": 0,
+              "actualStartTime": -1,
+              "alternate": [Circular],
+              "child": null,
+              "childExpirationTime": 0,
+              "contextDependencies": null,
+              "effectTag": 0,
+              "elementType": null,
+              "expirationTime": 1073741823,
+              "firstEffect": null,
+              "index": 0,
+              "key": null,
+              "lastEffect": null,
+              "memoizedProps": null,
+              "memoizedState": null,
+              "mode": 0,
+              "nextEffect": null,
+              "pendingProps": null,
+              "ref": null,
+              "return": null,
+              "selfBaseDuration": 0,
+              "sibling": null,
+              "stateNode": Object {
+                "containerInfo": <div>
+                  <div
+                    class="dashboard-card engagement"
+                  >
+                    <div
+                      class="title"
+                    >
+                      Engagement Trends
+                    </div>
+                  </div>
+                  <div
+                    class="dashboard-card upselling"
+                  >
+                    <div
+                      class="title"
+                    >
+                      Upselling Partners
+                    </div>
+                    <div>
+                      upselling component
+                    </div>
+                  </div>
+                </div>,
+                "context": Object {},
+                "current": [Circular],
+                "didError": false,
+                "earliestPendingTime": 0,
+                "earliestSuspendedTime": 0,
+                "expirationTime": 0,
+                "finishedWork": null,
+                "firstBatch": null,
+                "hydrate": false,
+                "interactionThreadID": 15,
+                "latestPendingTime": 0,
+                "latestPingedTime": 0,
+                "latestSuspendedTime": 0,
+                "memoizedInteractions": Set {},
+                "nextExpirationTimeToWorkOn": 0,
+                "nextScheduledRoot": null,
+                "pendingChildren": null,
+                "pendingCommitExpirationTime": 0,
+                "pendingContext": null,
+                "pendingInteractionMap": Map {},
+                "pingCache": null,
+                "timeoutHandle": -1,
+              },
+              "tag": 3,
+              "treeBaseDuration": 0,
+              "type": null,
+              "updateQueue": Object {
+                "baseState": null,
+                "firstCapturedEffect": null,
+                "firstCapturedUpdate": null,
+                "firstEffect": null,
+                "firstUpdate": Object {
+                  "callback": null,
+                  "expirationTime": 1073741823,
+                  "next": null,
+                  "nextEffect": null,
+                  "payload": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={Object {}}
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "tag": 0,
+                },
+                "lastCapturedEffect": null,
+                "lastCapturedUpdate": null,
+                "lastEffect": null,
+                "lastUpdate": Object {
+                  "callback": null,
+                  "expirationTime": 1073741823,
+                  "next": null,
+                  "nextEffect": null,
+                  "payload": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={Object {}}
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "tag": 0,
+                },
+              },
+            },
+            "child": [Circular],
+            "childExpirationTime": 0,
+            "contextDependencies": null,
+            "effectTag": 32,
+            "elementType": null,
+            "expirationTime": 0,
+            "firstEffect": [Circular],
+            "index": 0,
+            "key": null,
+            "lastEffect": [Circular],
+            "memoizedProps": null,
+            "memoizedState": Object {
+              "element": <WrapperComponent
+                Component={[Function]}
+                context={null}
+                props={Object {}}
+                wrappingComponentProps={null}
+              />,
+            },
+            "mode": 0,
+            "nextEffect": null,
+            "pendingProps": null,
+            "ref": null,
+            "return": null,
+            "selfBaseDuration": 0,
+            "sibling": null,
+            "stateNode": Object {
+              "containerInfo": <div>
+                <div
+                  class="dashboard-card engagement"
+                >
+                  <div
+                    class="title"
+                  >
+                    Engagement Trends
+                  </div>
+                </div>
+                <div
+                  class="dashboard-card upselling"
+                >
+                  <div
+                    class="title"
+                  >
+                    Upselling Partners
+                  </div>
+                  <div>
+                    upselling component
+                  </div>
+                </div>
+              </div>,
+              "context": Object {},
+              "current": [Circular],
+              "didError": false,
+              "earliestPendingTime": 0,
+              "earliestSuspendedTime": 0,
+              "expirationTime": 0,
+              "finishedWork": null,
+              "firstBatch": null,
+              "hydrate": false,
+              "interactionThreadID": 15,
+              "latestPendingTime": 0,
+              "latestPingedTime": 0,
+              "latestSuspendedTime": 0,
+              "memoizedInteractions": Set {},
+              "nextExpirationTimeToWorkOn": 0,
+              "nextScheduledRoot": null,
+              "pendingChildren": null,
+              "pendingCommitExpirationTime": 0,
+              "pendingContext": null,
+              "pendingInteractionMap": Map {},
+              "pingCache": null,
+              "timeoutHandle": -1,
+            },
+            "tag": 3,
+            "treeBaseDuration": 0,
+            "type": null,
+            "updateQueue": Object {
+              "baseState": Object {
+                "element": <WrapperComponent
+                  Component={[Function]}
+                  context={null}
+                  props={Object {}}
+                  wrappingComponentProps={null}
+                />,
+              },
+              "firstCapturedEffect": null,
+              "firstCapturedUpdate": null,
+              "firstEffect": null,
+              "firstUpdate": null,
+              "lastCapturedEffect": null,
+              "lastCapturedUpdate": null,
+              "lastEffect": null,
+              "lastUpdate": null,
+            },
+          },
+          "pendingProps": Object {
+            "Component": [Function],
+            "context": null,
+            "props": Object {},
+            "wrappingComponentProps": null,
+          },
+          "ref": null,
+          "return": FiberNode {
+            "_debugHookTypes": null,
+            "_debugID": 60,
+            "_debugIsCurrentlyTiming": false,
+            "_debugOwner": null,
+            "_debugSource": null,
+            "actualDuration": 0,
+            "actualStartTime": -1,
+            "alternate": FiberNode {
+              "_debugHookTypes": null,
+              "_debugID": 60,
+              "_debugIsCurrentlyTiming": false,
+              "_debugOwner": null,
+              "_debugSource": null,
+              "actualDuration": 0,
+              "actualStartTime": -1,
+              "alternate": [Circular],
+              "child": null,
+              "childExpirationTime": 0,
+              "contextDependencies": null,
+              "effectTag": 0,
+              "elementType": null,
+              "expirationTime": 1073741823,
+              "firstEffect": null,
+              "index": 0,
+              "key": null,
+              "lastEffect": null,
+              "memoizedProps": null,
+              "memoizedState": null,
+              "mode": 0,
+              "nextEffect": null,
+              "pendingProps": null,
+              "ref": null,
+              "return": null,
+              "selfBaseDuration": 0,
+              "sibling": null,
+              "stateNode": Object {
+                "containerInfo": <div>
+                  <div
+                    class="dashboard-card engagement"
+                  >
+                    <div
+                      class="title"
+                    >
+                      Engagement Trends
+                    </div>
+                  </div>
+                  <div
+                    class="dashboard-card upselling"
+                  >
+                    <div
+                      class="title"
+                    >
+                      Upselling Partners
+                    </div>
+                    <div>
+                      upselling component
+                    </div>
+                  </div>
+                </div>,
+                "context": Object {},
+                "current": [Circular],
+                "didError": false,
+                "earliestPendingTime": 0,
+                "earliestSuspendedTime": 0,
+                "expirationTime": 0,
+                "finishedWork": null,
+                "firstBatch": null,
+                "hydrate": false,
+                "interactionThreadID": 15,
+                "latestPendingTime": 0,
+                "latestPingedTime": 0,
+                "latestSuspendedTime": 0,
+                "memoizedInteractions": Set {},
+                "nextExpirationTimeToWorkOn": 0,
+                "nextScheduledRoot": null,
+                "pendingChildren": null,
+                "pendingCommitExpirationTime": 0,
+                "pendingContext": null,
+                "pendingInteractionMap": Map {},
+                "pingCache": null,
+                "timeoutHandle": -1,
+              },
+              "tag": 3,
+              "treeBaseDuration": 0,
+              "type": null,
+              "updateQueue": Object {
+                "baseState": null,
+                "firstCapturedEffect": null,
+                "firstCapturedUpdate": null,
+                "firstEffect": null,
+                "firstUpdate": Object {
+                  "callback": null,
+                  "expirationTime": 1073741823,
+                  "next": null,
+                  "nextEffect": null,
+                  "payload": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={Object {}}
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "tag": 0,
+                },
+                "lastCapturedEffect": null,
+                "lastCapturedUpdate": null,
+                "lastEffect": null,
+                "lastUpdate": Object {
+                  "callback": null,
+                  "expirationTime": 1073741823,
+                  "next": null,
+                  "nextEffect": null,
+                  "payload": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={Object {}}
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "tag": 0,
+                },
+              },
+            },
+            "child": [Circular],
+            "childExpirationTime": 0,
+            "contextDependencies": null,
+            "effectTag": 32,
+            "elementType": null,
+            "expirationTime": 0,
+            "firstEffect": [Circular],
+            "index": 0,
+            "key": null,
+            "lastEffect": [Circular],
+            "memoizedProps": null,
+            "memoizedState": Object {
+              "element": <WrapperComponent
+                Component={[Function]}
+                context={null}
+                props={Object {}}
+                wrappingComponentProps={null}
+              />,
+            },
+            "mode": 0,
+            "nextEffect": null,
+            "pendingProps": null,
+            "ref": null,
+            "return": null,
+            "selfBaseDuration": 0,
+            "sibling": null,
+            "stateNode": Object {
+              "containerInfo": <div>
+                <div
+                  class="dashboard-card engagement"
+                >
+                  <div
+                    class="title"
+                  >
+                    Engagement Trends
+                  </div>
+                </div>
+                <div
+                  class="dashboard-card upselling"
+                >
+                  <div
+                    class="title"
+                  >
+                    Upselling Partners
+                  </div>
+                  <div>
+                    upselling component
+                  </div>
+                </div>
+              </div>,
+              "context": Object {},
+              "current": [Circular],
+              "didError": false,
+              "earliestPendingTime": 0,
+              "earliestSuspendedTime": 0,
+              "expirationTime": 0,
+              "finishedWork": null,
+              "firstBatch": null,
+              "hydrate": false,
+              "interactionThreadID": 15,
+              "latestPendingTime": 0,
+              "latestPingedTime": 0,
+              "latestSuspendedTime": 0,
+              "memoizedInteractions": Set {},
+              "nextExpirationTimeToWorkOn": 0,
+              "nextScheduledRoot": null,
+              "pendingChildren": null,
+              "pendingCommitExpirationTime": 0,
+              "pendingContext": null,
+              "pendingInteractionMap": Map {},
+              "pingCache": null,
+              "timeoutHandle": -1,
+            },
+            "tag": 3,
+            "treeBaseDuration": 0,
+            "type": null,
+            "updateQueue": Object {
+              "baseState": Object {
+                "element": <WrapperComponent
+                  Component={[Function]}
+                  context={null}
+                  props={Object {}}
+                  wrappingComponentProps={null}
+                />,
+              },
+              "firstCapturedEffect": null,
+              "firstCapturedUpdate": null,
+              "firstEffect": null,
+              "firstUpdate": null,
+              "lastCapturedEffect": null,
+              "lastCapturedUpdate": null,
+              "lastEffect": null,
+              "lastUpdate": null,
+            },
+          },
+          "selfBaseDuration": 0,
+          "sibling": null,
+          "stateNode": WrapperComponent {
+            "_reactInternalFiber": [Circular],
+            "_reactInternalInstance": Object {},
+            "context": Object {},
+            "props": Object {
+              "Component": [Function],
+              "context": null,
+              "props": Object {},
+              "wrappingComponentProps": null,
+            },
+            "refs": Object {},
+            "rootFinderInstance": null,
+            "state": Object {
+              "context": null,
+              "mount": true,
+              "props": Object {},
+              "wrappingComponentProps": null,
+            },
+            "updater": Object {
+              "enqueueForceUpdate": [Function],
+              "enqueueReplaceState": [Function],
+              "enqueueSetState": [Function],
+              "isMounted": [Function],
+            },
+          },
+          "tag": 1,
+          "treeBaseDuration": 0,
+          "type": [Function],
+          "updateQueue": null,
+        },
+        "_debugSource": null,
+        "actualDuration": 0,
+        "actualStartTime": -1,
+        "alternate": null,
+        "child": FiberNode {
+          "_debugHookTypes": null,
+          "_debugID": 64,
+          "_debugIsCurrentlyTiming": false,
+          "_debugOwner": [Circular],
+          "_debugSource": Object {
+            "fileName": "/Users/kevinkoech/Documents/bp-esa-frontend/src/components/Dashboard/index.jsx",
+            "lineNumber": 23,
+          },
+          "actualDuration": 0,
+          "actualStartTime": -1,
+          "alternate": null,
+          "child": FiberNode {
+            "_debugHookTypes": null,
+            "_debugID": 66,
+            "_debugIsCurrentlyTiming": false,
+            "_debugOwner": [Circular],
+            "_debugSource": Object {
+              "fileName": "/Users/kevinkoech/Documents/bp-esa-frontend/src/components/Dashboard/Card.jsx",
+              "lineNumber": 20,
+            },
+            "actualDuration": 0,
+            "actualStartTime": -1,
+            "alternate": null,
+            "child": FiberNode {
+              "_debugHookTypes": null,
+              "_debugID": 67,
+              "_debugIsCurrentlyTiming": false,
+              "_debugOwner": [Circular],
+              "_debugSource": Object {
+                "fileName": "/Users/kevinkoech/Documents/bp-esa-frontend/src/components/Dashboard/Card.jsx",
+                "lineNumber": 21,
+              },
+              "actualDuration": 0,
+              "actualStartTime": -1,
+              "alternate": null,
+              "child": null,
+              "childExpirationTime": 0,
+              "contextDependencies": null,
+              "effectTag": 0,
+              "elementType": "div",
+              "expirationTime": 0,
+              "firstEffect": null,
+              "index": 0,
+              "key": null,
+              "lastEffect": null,
+              "memoizedProps": Object {
+                "children": "Engagement Trends",
+                "className": "title",
+              },
+              "memoizedState": null,
+              "mode": 0,
+              "nextEffect": null,
+              "pendingProps": Object {
+                "children": "Engagement Trends",
+                "className": "title",
+              },
+              "ref": null,
+              "return": [Circular],
+              "selfBaseDuration": 0,
+              "sibling": null,
+              "stateNode": <div
+                class="title"
+              >
+                Engagement Trends
+              </div>,
+              "tag": 5,
+              "treeBaseDuration": 0,
+              "type": "div",
+              "updateQueue": null,
+            },
+            "childExpirationTime": 0,
+            "contextDependencies": null,
+            "effectTag": 0,
+            "elementType": "div",
+            "expirationTime": 0,
+            "firstEffect": null,
+            "index": 0,
+            "key": null,
+            "lastEffect": null,
+            "memoizedProps": Object {
+              "children": Array [
+                <div
+                  className="title"
+                >
+                  Engagement Trends
+                </div>,
+                undefined,
+              ],
+              "className": "dashboard-card engagement",
+            },
+            "memoizedState": null,
+            "mode": 0,
+            "nextEffect": null,
+            "pendingProps": Object {
+              "children": Array [
+                <div
+                  className="title"
+                >
+                  Engagement Trends
+                </div>,
+                undefined,
+              ],
+              "className": "dashboard-card engagement",
+            },
+            "ref": null,
+            "return": [Circular],
+            "selfBaseDuration": 0,
+            "sibling": null,
+            "stateNode": <div
+              class="dashboard-card engagement"
+            >
+              <div
+                class="title"
+              >
+                Engagement Trends
+              </div>
+            </div>,
+            "tag": 5,
+            "treeBaseDuration": 0,
+            "type": "div",
+            "updateQueue": null,
+          },
+          "childExpirationTime": 0,
+          "contextDependencies": null,
+          "effectTag": 1,
+          "elementType": [Function],
+          "expirationTime": 0,
+          "firstEffect": null,
+          "index": 0,
+          "key": null,
+          "lastEffect": null,
+          "memoizedProps": Object {
+            "classes": "engagement",
+            "component": [Function],
+            "title": "Engagement Trends",
+          },
+          "memoizedState": null,
+          "mode": 0,
+          "nextEffect": null,
+          "pendingProps": Object {
+            "classes": "engagement",
+            "component": [Function],
+            "title": "Engagement Trends",
+          },
+          "ref": null,
+          "return": [Circular],
+          "selfBaseDuration": 0,
+          "sibling": FiberNode {
+            "_debugHookTypes": null,
+            "_debugID": 65,
+            "_debugIsCurrentlyTiming": false,
+            "_debugOwner": [Circular],
+            "_debugSource": Object {
+              "fileName": "/Users/kevinkoech/Documents/bp-esa-frontend/src/components/Dashboard/index.jsx",
+              "lineNumber": 28,
+            },
+            "actualDuration": 0,
+            "actualStartTime": -1,
+            "alternate": null,
+            "child": FiberNode {
+              "_debugHookTypes": null,
+              "_debugID": 68,
+              "_debugIsCurrentlyTiming": false,
+              "_debugOwner": [Circular],
+              "_debugSource": Object {
+                "fileName": "/Users/kevinkoech/Documents/bp-esa-frontend/src/components/Dashboard/Card.jsx",
+                "lineNumber": 20,
+              },
+              "actualDuration": 0,
+              "actualStartTime": -1,
+              "alternate": null,
+              "child": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 69,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": [Circular],
+                "_debugSource": Object {
+                  "fileName": "/Users/kevinkoech/Documents/bp-esa-frontend/src/components/Dashboard/Card.jsx",
+                  "lineNumber": 21,
+                },
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": null,
+                "child": null,
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 0,
+                "elementType": "div",
+                "expirationTime": 0,
+                "firstEffect": null,
+                "index": 0,
+                "key": null,
+                "lastEffect": null,
+                "memoizedProps": Object {
+                  "children": "Upselling Partners",
+                  "className": "title",
+                },
+                "memoizedState": null,
+                "mode": 0,
+                "nextEffect": null,
+                "pendingProps": Object {
+                  "children": "Upselling Partners",
+                  "className": "title",
+                },
+                "ref": null,
+                "return": [Circular],
+                "selfBaseDuration": 0,
+                "sibling": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 70,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": [Circular],
+                  "_debugSource": Object {
+                    "fileName": "/Users/kevinkoech/Documents/bp-esa-frontend/src/components/Dashboard/index.jsx",
+                    "lineNumber": 15,
+                  },
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": null,
+                  "child": null,
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 0,
+                  "elementType": "div",
+                  "expirationTime": 0,
+                  "firstEffect": null,
+                  "index": 1,
+                  "key": null,
+                  "lastEffect": null,
+                  "memoizedProps": Object {
+                    "children": "upselling component",
+                  },
+                  "memoizedState": null,
+                  "mode": 0,
+                  "nextEffect": null,
+                  "pendingProps": Object {
+                    "children": "upselling component",
+                  },
+                  "ref": null,
+                  "return": [Circular],
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": <div>
+                    upselling component
+                  </div>,
+                  "tag": 5,
+                  "treeBaseDuration": 0,
+                  "type": "div",
+                  "updateQueue": null,
+                },
+                "stateNode": <div
+                  class="title"
+                >
+                  Upselling Partners
+                </div>,
+                "tag": 5,
+                "treeBaseDuration": 0,
+                "type": "div",
+                "updateQueue": null,
+              },
+              "childExpirationTime": 0,
+              "contextDependencies": null,
+              "effectTag": 0,
+              "elementType": "div",
+              "expirationTime": 0,
+              "firstEffect": null,
+              "index": 0,
+              "key": null,
+              "lastEffect": null,
+              "memoizedProps": Object {
+                "children": Array [
+                  <div
+                    className="title"
+                  >
+                    Upselling Partners
+                  </div>,
+                  <div>
+                    upselling component
+                  </div>,
+                ],
+                "className": "dashboard-card upselling",
+              },
+              "memoizedState": null,
+              "mode": 0,
+              "nextEffect": null,
+              "pendingProps": Object {
+                "children": Array [
+                  <div
+                    className="title"
+                  >
+                    Upselling Partners
+                  </div>,
+                  <div>
+                    upselling component
+                  </div>,
+                ],
+                "className": "dashboard-card upselling",
+              },
+              "ref": null,
+              "return": [Circular],
+              "selfBaseDuration": 0,
+              "sibling": null,
+              "stateNode": <div
+                class="dashboard-card upselling"
+              >
+                <div
+                  class="title"
+                >
+                  Upselling Partners
+                </div>
+                <div>
+                  upselling component
+                </div>
+              </div>,
+              "tag": 5,
+              "treeBaseDuration": 0,
+              "type": "div",
+              "updateQueue": null,
+            },
+            "childExpirationTime": 0,
+            "contextDependencies": null,
+            "effectTag": 1,
+            "elementType": [Function],
+            "expirationTime": 0,
+            "firstEffect": null,
+            "index": 1,
+            "key": null,
+            "lastEffect": null,
+            "memoizedProps": Object {
+              "classes": "upselling",
+              "component": [Function],
+              "title": "Upselling Partners",
+            },
+            "memoizedState": null,
+            "mode": 0,
+            "nextEffect": null,
+            "pendingProps": Object {
+              "classes": "upselling",
+              "component": [Function],
+              "title": "Upselling Partners",
+            },
+            "ref": null,
+            "return": [Circular],
+            "selfBaseDuration": 0,
+            "sibling": null,
+            "stateNode": Card {
+              "_reactInternalFiber": [Circular],
+              "_reactInternalInstance": Object {},
+              "context": Object {},
+              "props": Object {
+                "classes": "upselling",
+                "component": [Function],
+                "title": "Upselling Partners",
+              },
+              "refs": Object {},
+              "state": null,
+              "updater": Object {
+                "enqueueForceUpdate": [Function],
+                "enqueueReplaceState": [Function],
+                "enqueueSetState": [Function],
+                "isMounted": [Function],
+              },
+            },
+            "tag": 1,
+            "treeBaseDuration": 0,
+            "type": [Function],
+            "updateQueue": null,
+          },
+          "stateNode": Card {
+            "_reactInternalFiber": [Circular],
+            "_reactInternalInstance": Object {},
+            "context": Object {},
+            "props": Object {
+              "classes": "engagement",
+              "component": [Function],
+              "title": "Engagement Trends",
+            },
+            "refs": Object {},
+            "state": null,
+            "updater": Object {
+              "enqueueForceUpdate": [Function],
+              "enqueueReplaceState": [Function],
+              "enqueueSetState": [Function],
+              "isMounted": [Function],
+            },
+          },
+          "tag": 1,
+          "treeBaseDuration": 0,
+          "type": [Function],
+          "updateQueue": null,
+        },
+        "childExpirationTime": 0,
+        "contextDependencies": null,
+        "effectTag": 1,
+        "elementType": [Function],
+        "expirationTime": 0,
+        "firstEffect": null,
+        "index": 0,
+        "key": null,
+        "lastEffect": null,
+        "memoizedProps": Object {},
+        "memoizedState": null,
+        "mode": 0,
+        "nextEffect": null,
+        "pendingProps": Object {},
+        "ref": null,
+        "return": FiberNode {
+          "_debugHookTypes": null,
+          "_debugID": 62,
+          "_debugIsCurrentlyTiming": false,
+          "_debugOwner": null,
+          "_debugSource": null,
+          "actualDuration": 0,
+          "actualStartTime": -1,
+          "alternate": null,
+          "child": [Circular],
+          "childExpirationTime": 0,
+          "contextDependencies": null,
+          "effectTag": 1,
+          "elementType": [Function],
+          "expirationTime": 0,
+          "firstEffect": null,
+          "index": 0,
+          "key": null,
+          "lastEffect": null,
+          "memoizedProps": Object {
+            "Component": [Function],
+            "context": null,
+            "props": Object {},
+            "wrappingComponentProps": null,
+          },
+          "memoizedState": Object {
+            "context": null,
+            "mount": true,
+            "props": Object {},
+            "wrappingComponentProps": null,
+          },
+          "mode": 0,
+          "nextEffect": FiberNode {
+            "_debugHookTypes": null,
+            "_debugID": 60,
+            "_debugIsCurrentlyTiming": false,
+            "_debugOwner": null,
+            "_debugSource": null,
+            "actualDuration": 0,
+            "actualStartTime": -1,
+            "alternate": FiberNode {
+              "_debugHookTypes": null,
+              "_debugID": 60,
+              "_debugIsCurrentlyTiming": false,
+              "_debugOwner": null,
+              "_debugSource": null,
+              "actualDuration": 0,
+              "actualStartTime": -1,
+              "alternate": [Circular],
+              "child": null,
+              "childExpirationTime": 0,
+              "contextDependencies": null,
+              "effectTag": 0,
+              "elementType": null,
+              "expirationTime": 1073741823,
+              "firstEffect": null,
+              "index": 0,
+              "key": null,
+              "lastEffect": null,
+              "memoizedProps": null,
+              "memoizedState": null,
+              "mode": 0,
+              "nextEffect": null,
+              "pendingProps": null,
+              "ref": null,
+              "return": null,
+              "selfBaseDuration": 0,
+              "sibling": null,
+              "stateNode": Object {
+                "containerInfo": <div>
+                  <div
+                    class="dashboard-card engagement"
+                  >
+                    <div
+                      class="title"
+                    >
+                      Engagement Trends
+                    </div>
+                  </div>
+                  <div
+                    class="dashboard-card upselling"
+                  >
+                    <div
+                      class="title"
+                    >
+                      Upselling Partners
+                    </div>
+                    <div>
+                      upselling component
+                    </div>
+                  </div>
+                </div>,
+                "context": Object {},
+                "current": [Circular],
+                "didError": false,
+                "earliestPendingTime": 0,
+                "earliestSuspendedTime": 0,
+                "expirationTime": 0,
+                "finishedWork": null,
+                "firstBatch": null,
+                "hydrate": false,
+                "interactionThreadID": 15,
+                "latestPendingTime": 0,
+                "latestPingedTime": 0,
+                "latestSuspendedTime": 0,
+                "memoizedInteractions": Set {},
+                "nextExpirationTimeToWorkOn": 0,
+                "nextScheduledRoot": null,
+                "pendingChildren": null,
+                "pendingCommitExpirationTime": 0,
+                "pendingContext": null,
+                "pendingInteractionMap": Map {},
+                "pingCache": null,
+                "timeoutHandle": -1,
+              },
+              "tag": 3,
+              "treeBaseDuration": 0,
+              "type": null,
+              "updateQueue": Object {
+                "baseState": null,
+                "firstCapturedEffect": null,
+                "firstCapturedUpdate": null,
+                "firstEffect": null,
+                "firstUpdate": Object {
+                  "callback": null,
+                  "expirationTime": 1073741823,
+                  "next": null,
+                  "nextEffect": null,
+                  "payload": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={Object {}}
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "tag": 0,
+                },
+                "lastCapturedEffect": null,
+                "lastCapturedUpdate": null,
+                "lastEffect": null,
+                "lastUpdate": Object {
+                  "callback": null,
+                  "expirationTime": 1073741823,
+                  "next": null,
+                  "nextEffect": null,
+                  "payload": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={Object {}}
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "tag": 0,
+                },
+              },
+            },
+            "child": [Circular],
+            "childExpirationTime": 0,
+            "contextDependencies": null,
+            "effectTag": 32,
+            "elementType": null,
+            "expirationTime": 0,
+            "firstEffect": [Circular],
+            "index": 0,
+            "key": null,
+            "lastEffect": [Circular],
+            "memoizedProps": null,
+            "memoizedState": Object {
+              "element": <WrapperComponent
+                Component={[Function]}
+                context={null}
+                props={Object {}}
+                wrappingComponentProps={null}
+              />,
+            },
+            "mode": 0,
+            "nextEffect": null,
+            "pendingProps": null,
+            "ref": null,
+            "return": null,
+            "selfBaseDuration": 0,
+            "sibling": null,
+            "stateNode": Object {
+              "containerInfo": <div>
+                <div
+                  class="dashboard-card engagement"
+                >
+                  <div
+                    class="title"
+                  >
+                    Engagement Trends
+                  </div>
+                </div>
+                <div
+                  class="dashboard-card upselling"
+                >
+                  <div
+                    class="title"
+                  >
+                    Upselling Partners
+                  </div>
+                  <div>
+                    upselling component
+                  </div>
+                </div>
+              </div>,
+              "context": Object {},
+              "current": [Circular],
+              "didError": false,
+              "earliestPendingTime": 0,
+              "earliestSuspendedTime": 0,
+              "expirationTime": 0,
+              "finishedWork": null,
+              "firstBatch": null,
+              "hydrate": false,
+              "interactionThreadID": 15,
+              "latestPendingTime": 0,
+              "latestPingedTime": 0,
+              "latestSuspendedTime": 0,
+              "memoizedInteractions": Set {},
+              "nextExpirationTimeToWorkOn": 0,
+              "nextScheduledRoot": null,
+              "pendingChildren": null,
+              "pendingCommitExpirationTime": 0,
+              "pendingContext": null,
+              "pendingInteractionMap": Map {},
+              "pingCache": null,
+              "timeoutHandle": -1,
+            },
+            "tag": 3,
+            "treeBaseDuration": 0,
+            "type": null,
+            "updateQueue": Object {
+              "baseState": Object {
+                "element": <WrapperComponent
+                  Component={[Function]}
+                  context={null}
+                  props={Object {}}
+                  wrappingComponentProps={null}
+                />,
+              },
+              "firstCapturedEffect": null,
+              "firstCapturedUpdate": null,
+              "firstEffect": null,
+              "firstUpdate": null,
+              "lastCapturedEffect": null,
+              "lastCapturedUpdate": null,
+              "lastEffect": null,
+              "lastUpdate": null,
+            },
+          },
+          "pendingProps": Object {
+            "Component": [Function],
+            "context": null,
+            "props": Object {},
+            "wrappingComponentProps": null,
+          },
+          "ref": null,
+          "return": FiberNode {
+            "_debugHookTypes": null,
+            "_debugID": 60,
+            "_debugIsCurrentlyTiming": false,
+            "_debugOwner": null,
+            "_debugSource": null,
+            "actualDuration": 0,
+            "actualStartTime": -1,
+            "alternate": FiberNode {
+              "_debugHookTypes": null,
+              "_debugID": 60,
+              "_debugIsCurrentlyTiming": false,
+              "_debugOwner": null,
+              "_debugSource": null,
+              "actualDuration": 0,
+              "actualStartTime": -1,
+              "alternate": [Circular],
+              "child": null,
+              "childExpirationTime": 0,
+              "contextDependencies": null,
+              "effectTag": 0,
+              "elementType": null,
+              "expirationTime": 1073741823,
+              "firstEffect": null,
+              "index": 0,
+              "key": null,
+              "lastEffect": null,
+              "memoizedProps": null,
+              "memoizedState": null,
+              "mode": 0,
+              "nextEffect": null,
+              "pendingProps": null,
+              "ref": null,
+              "return": null,
+              "selfBaseDuration": 0,
+              "sibling": null,
+              "stateNode": Object {
+                "containerInfo": <div>
+                  <div
+                    class="dashboard-card engagement"
+                  >
+                    <div
+                      class="title"
+                    >
+                      Engagement Trends
+                    </div>
+                  </div>
+                  <div
+                    class="dashboard-card upselling"
+                  >
+                    <div
+                      class="title"
+                    >
+                      Upselling Partners
+                    </div>
+                    <div>
+                      upselling component
+                    </div>
+                  </div>
+                </div>,
+                "context": Object {},
+                "current": [Circular],
+                "didError": false,
+                "earliestPendingTime": 0,
+                "earliestSuspendedTime": 0,
+                "expirationTime": 0,
+                "finishedWork": null,
+                "firstBatch": null,
+                "hydrate": false,
+                "interactionThreadID": 15,
+                "latestPendingTime": 0,
+                "latestPingedTime": 0,
+                "latestSuspendedTime": 0,
+                "memoizedInteractions": Set {},
+                "nextExpirationTimeToWorkOn": 0,
+                "nextScheduledRoot": null,
+                "pendingChildren": null,
+                "pendingCommitExpirationTime": 0,
+                "pendingContext": null,
+                "pendingInteractionMap": Map {},
+                "pingCache": null,
+                "timeoutHandle": -1,
+              },
+              "tag": 3,
+              "treeBaseDuration": 0,
+              "type": null,
+              "updateQueue": Object {
+                "baseState": null,
+                "firstCapturedEffect": null,
+                "firstCapturedUpdate": null,
+                "firstEffect": null,
+                "firstUpdate": Object {
+                  "callback": null,
+                  "expirationTime": 1073741823,
+                  "next": null,
+                  "nextEffect": null,
+                  "payload": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={Object {}}
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "tag": 0,
+                },
+                "lastCapturedEffect": null,
+                "lastCapturedUpdate": null,
+                "lastEffect": null,
+                "lastUpdate": Object {
+                  "callback": null,
+                  "expirationTime": 1073741823,
+                  "next": null,
+                  "nextEffect": null,
+                  "payload": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={Object {}}
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "tag": 0,
+                },
+              },
+            },
+            "child": [Circular],
+            "childExpirationTime": 0,
+            "contextDependencies": null,
+            "effectTag": 32,
+            "elementType": null,
+            "expirationTime": 0,
+            "firstEffect": [Circular],
+            "index": 0,
+            "key": null,
+            "lastEffect": [Circular],
+            "memoizedProps": null,
+            "memoizedState": Object {
+              "element": <WrapperComponent
+                Component={[Function]}
+                context={null}
+                props={Object {}}
+                wrappingComponentProps={null}
+              />,
+            },
+            "mode": 0,
+            "nextEffect": null,
+            "pendingProps": null,
+            "ref": null,
+            "return": null,
+            "selfBaseDuration": 0,
+            "sibling": null,
+            "stateNode": Object {
+              "containerInfo": <div>
+                <div
+                  class="dashboard-card engagement"
+                >
+                  <div
+                    class="title"
+                  >
+                    Engagement Trends
+                  </div>
+                </div>
+                <div
+                  class="dashboard-card upselling"
+                >
+                  <div
+                    class="title"
+                  >
+                    Upselling Partners
+                  </div>
+                  <div>
+                    upselling component
+                  </div>
+                </div>
+              </div>,
+              "context": Object {},
+              "current": [Circular],
+              "didError": false,
+              "earliestPendingTime": 0,
+              "earliestSuspendedTime": 0,
+              "expirationTime": 0,
+              "finishedWork": null,
+              "firstBatch": null,
+              "hydrate": false,
+              "interactionThreadID": 15,
+              "latestPendingTime": 0,
+              "latestPingedTime": 0,
+              "latestSuspendedTime": 0,
+              "memoizedInteractions": Set {},
+              "nextExpirationTimeToWorkOn": 0,
+              "nextScheduledRoot": null,
+              "pendingChildren": null,
+              "pendingCommitExpirationTime": 0,
+              "pendingContext": null,
+              "pendingInteractionMap": Map {},
+              "pingCache": null,
+              "timeoutHandle": -1,
+            },
+            "tag": 3,
+            "treeBaseDuration": 0,
+            "type": null,
+            "updateQueue": Object {
+              "baseState": Object {
+                "element": <WrapperComponent
+                  Component={[Function]}
+                  context={null}
+                  props={Object {}}
+                  wrappingComponentProps={null}
+                />,
+              },
+              "firstCapturedEffect": null,
+              "firstCapturedUpdate": null,
+              "firstEffect": null,
+              "firstUpdate": null,
+              "lastCapturedEffect": null,
+              "lastCapturedUpdate": null,
+              "lastEffect": null,
+              "lastUpdate": null,
+            },
+          },
+          "selfBaseDuration": 0,
+          "sibling": null,
+          "stateNode": WrapperComponent {
+            "_reactInternalFiber": [Circular],
+            "_reactInternalInstance": Object {},
+            "context": Object {},
+            "props": Object {
+              "Component": [Function],
+              "context": null,
+              "props": Object {},
+              "wrappingComponentProps": null,
+            },
+            "refs": Object {},
+            "rootFinderInstance": null,
+            "state": Object {
+              "context": null,
+              "mount": true,
+              "props": Object {},
+              "wrappingComponentProps": null,
+            },
+            "updater": Object {
+              "enqueueForceUpdate": [Function],
+              "enqueueReplaceState": [Function],
+              "enqueueSetState": [Function],
+              "isMounted": [Function],
+            },
+          },
+          "tag": 1,
+          "treeBaseDuration": 0,
+          "type": [Function],
+          "updateQueue": null,
+        },
+        "selfBaseDuration": 0,
+        "sibling": null,
+        "stateNode": [Circular],
+        "tag": 1,
+        "treeBaseDuration": 0,
+        "type": [Function],
+        "updateQueue": null,
+      },
+      "_reactInternalInstance": Object {},
+      "context": Object {},
+      "props": Object {},
+      "refs": Object {},
+      "renderUpselling": [Function],
+      "state": null,
+      "updater": Object {
+        "enqueueForceUpdate": [Function],
+        "enqueueReplaceState": [Function],
+        "enqueueSetState": [Function],
+        "isMounted": [Function],
+      },
+    },
+    "key": undefined,
+    "nodeType": "class",
+    "props": Object {},
+    "ref": null,
+    "rendered": Array [
+      Object {
+        "instance": Card {
+          "_reactInternalFiber": FiberNode {
+            "_debugHookTypes": null,
+            "_debugID": 64,
+            "_debugIsCurrentlyTiming": false,
+            "_debugOwner": FiberNode {
+              "_debugHookTypes": null,
+              "_debugID": 63,
+              "_debugIsCurrentlyTiming": false,
+              "_debugOwner": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 62,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": null,
+                "_debugSource": null,
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": null,
+                "child": [Circular],
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 1,
+                "elementType": [Function],
+                "expirationTime": 0,
+                "firstEffect": null,
+                "index": 0,
+                "key": null,
+                "lastEffect": null,
+                "memoizedProps": Object {
+                  "Component": [Function],
+                  "context": null,
+                  "props": Object {},
+                  "wrappingComponentProps": null,
+                },
+                "memoizedState": Object {
+                  "context": null,
+                  "mount": true,
+                  "props": Object {},
+                  "wrappingComponentProps": null,
+                },
+                "mode": 0,
+                "nextEffect": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 60,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": null,
+                  "_debugSource": null,
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 60,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": null,
+                    "_debugSource": null,
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": [Circular],
+                    "child": null,
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 0,
+                    "elementType": null,
+                    "expirationTime": 1073741823,
+                    "firstEffect": null,
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": null,
+                    "memoizedProps": null,
+                    "memoizedState": null,
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": null,
+                    "ref": null,
+                    "return": null,
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": Object {
+                      "containerInfo": <div>
+                        <div
+                          class="dashboard-card engagement"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Engagement Trends
+                          </div>
+                        </div>
+                        <div
+                          class="dashboard-card upselling"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Upselling Partners
+                          </div>
+                          <div>
+                            upselling component
+                          </div>
+                        </div>
+                      </div>,
+                      "context": Object {},
+                      "current": [Circular],
+                      "didError": false,
+                      "earliestPendingTime": 0,
+                      "earliestSuspendedTime": 0,
+                      "expirationTime": 0,
+                      "finishedWork": null,
+                      "firstBatch": null,
+                      "hydrate": false,
+                      "interactionThreadID": 15,
+                      "latestPendingTime": 0,
+                      "latestPingedTime": 0,
+                      "latestSuspendedTime": 0,
+                      "memoizedInteractions": Set {},
+                      "nextExpirationTimeToWorkOn": 0,
+                      "nextScheduledRoot": null,
+                      "pendingChildren": null,
+                      "pendingCommitExpirationTime": 0,
+                      "pendingContext": null,
+                      "pendingInteractionMap": Map {},
+                      "pingCache": null,
+                      "timeoutHandle": -1,
+                    },
+                    "tag": 3,
+                    "treeBaseDuration": 0,
+                    "type": null,
+                    "updateQueue": Object {
+                      "baseState": null,
+                      "firstCapturedEffect": null,
+                      "firstCapturedUpdate": null,
+                      "firstEffect": null,
+                      "firstUpdate": Object {
+                        "callback": null,
+                        "expirationTime": 1073741823,
+                        "next": null,
+                        "nextEffect": null,
+                        "payload": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={Object {}}
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "tag": 0,
+                      },
+                      "lastCapturedEffect": null,
+                      "lastCapturedUpdate": null,
+                      "lastEffect": null,
+                      "lastUpdate": Object {
+                        "callback": null,
+                        "expirationTime": 1073741823,
+                        "next": null,
+                        "nextEffect": null,
+                        "payload": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={Object {}}
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "tag": 0,
+                      },
+                    },
+                  },
+                  "child": [Circular],
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 32,
+                  "elementType": null,
+                  "expirationTime": 0,
+                  "firstEffect": [Circular],
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": [Circular],
+                  "memoizedProps": null,
+                  "memoizedState": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={Object {}}
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "mode": 0,
+                  "nextEffect": null,
+                  "pendingProps": null,
+                  "ref": null,
+                  "return": null,
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": Object {
+                    "containerInfo": <div>
+                      <div
+                        class="dashboard-card engagement"
+                      >
+                        <div
+                          class="title"
+                        >
+                          Engagement Trends
+                        </div>
+                      </div>
+                      <div
+                        class="dashboard-card upselling"
+                      >
+                        <div
+                          class="title"
+                        >
+                          Upselling Partners
+                        </div>
+                        <div>
+                          upselling component
+                        </div>
+                      </div>
+                    </div>,
+                    "context": Object {},
+                    "current": [Circular],
+                    "didError": false,
+                    "earliestPendingTime": 0,
+                    "earliestSuspendedTime": 0,
+                    "expirationTime": 0,
+                    "finishedWork": null,
+                    "firstBatch": null,
+                    "hydrate": false,
+                    "interactionThreadID": 15,
+                    "latestPendingTime": 0,
+                    "latestPingedTime": 0,
+                    "latestSuspendedTime": 0,
+                    "memoizedInteractions": Set {},
+                    "nextExpirationTimeToWorkOn": 0,
+                    "nextScheduledRoot": null,
+                    "pendingChildren": null,
+                    "pendingCommitExpirationTime": 0,
+                    "pendingContext": null,
+                    "pendingInteractionMap": Map {},
+                    "pingCache": null,
+                    "timeoutHandle": -1,
+                  },
+                  "tag": 3,
+                  "treeBaseDuration": 0,
+                  "type": null,
+                  "updateQueue": Object {
+                    "baseState": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={Object {}}
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "firstCapturedEffect": null,
+                    "firstCapturedUpdate": null,
+                    "firstEffect": null,
+                    "firstUpdate": null,
+                    "lastCapturedEffect": null,
+                    "lastCapturedUpdate": null,
+                    "lastEffect": null,
+                    "lastUpdate": null,
+                  },
+                },
+                "pendingProps": Object {
+                  "Component": [Function],
+                  "context": null,
+                  "props": Object {},
+                  "wrappingComponentProps": null,
+                },
+                "ref": null,
+                "return": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 60,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": null,
+                  "_debugSource": null,
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 60,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": null,
+                    "_debugSource": null,
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": [Circular],
+                    "child": null,
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 0,
+                    "elementType": null,
+                    "expirationTime": 1073741823,
+                    "firstEffect": null,
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": null,
+                    "memoizedProps": null,
+                    "memoizedState": null,
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": null,
+                    "ref": null,
+                    "return": null,
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": Object {
+                      "containerInfo": <div>
+                        <div
+                          class="dashboard-card engagement"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Engagement Trends
+                          </div>
+                        </div>
+                        <div
+                          class="dashboard-card upselling"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Upselling Partners
+                          </div>
+                          <div>
+                            upselling component
+                          </div>
+                        </div>
+                      </div>,
+                      "context": Object {},
+                      "current": [Circular],
+                      "didError": false,
+                      "earliestPendingTime": 0,
+                      "earliestSuspendedTime": 0,
+                      "expirationTime": 0,
+                      "finishedWork": null,
+                      "firstBatch": null,
+                      "hydrate": false,
+                      "interactionThreadID": 15,
+                      "latestPendingTime": 0,
+                      "latestPingedTime": 0,
+                      "latestSuspendedTime": 0,
+                      "memoizedInteractions": Set {},
+                      "nextExpirationTimeToWorkOn": 0,
+                      "nextScheduledRoot": null,
+                      "pendingChildren": null,
+                      "pendingCommitExpirationTime": 0,
+                      "pendingContext": null,
+                      "pendingInteractionMap": Map {},
+                      "pingCache": null,
+                      "timeoutHandle": -1,
+                    },
+                    "tag": 3,
+                    "treeBaseDuration": 0,
+                    "type": null,
+                    "updateQueue": Object {
+                      "baseState": null,
+                      "firstCapturedEffect": null,
+                      "firstCapturedUpdate": null,
+                      "firstEffect": null,
+                      "firstUpdate": Object {
+                        "callback": null,
+                        "expirationTime": 1073741823,
+                        "next": null,
+                        "nextEffect": null,
+                        "payload": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={Object {}}
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "tag": 0,
+                      },
+                      "lastCapturedEffect": null,
+                      "lastCapturedUpdate": null,
+                      "lastEffect": null,
+                      "lastUpdate": Object {
+                        "callback": null,
+                        "expirationTime": 1073741823,
+                        "next": null,
+                        "nextEffect": null,
+                        "payload": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={Object {}}
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "tag": 0,
+                      },
+                    },
+                  },
+                  "child": [Circular],
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 32,
+                  "elementType": null,
+                  "expirationTime": 0,
+                  "firstEffect": [Circular],
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": [Circular],
+                  "memoizedProps": null,
+                  "memoizedState": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={Object {}}
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "mode": 0,
+                  "nextEffect": null,
+                  "pendingProps": null,
+                  "ref": null,
+                  "return": null,
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": Object {
+                    "containerInfo": <div>
+                      <div
+                        class="dashboard-card engagement"
+                      >
+                        <div
+                          class="title"
+                        >
+                          Engagement Trends
+                        </div>
+                      </div>
+                      <div
+                        class="dashboard-card upselling"
+                      >
+                        <div
+                          class="title"
+                        >
+                          Upselling Partners
+                        </div>
+                        <div>
+                          upselling component
+                        </div>
+                      </div>
+                    </div>,
+                    "context": Object {},
+                    "current": [Circular],
+                    "didError": false,
+                    "earliestPendingTime": 0,
+                    "earliestSuspendedTime": 0,
+                    "expirationTime": 0,
+                    "finishedWork": null,
+                    "firstBatch": null,
+                    "hydrate": false,
+                    "interactionThreadID": 15,
+                    "latestPendingTime": 0,
+                    "latestPingedTime": 0,
+                    "latestSuspendedTime": 0,
+                    "memoizedInteractions": Set {},
+                    "nextExpirationTimeToWorkOn": 0,
+                    "nextScheduledRoot": null,
+                    "pendingChildren": null,
+                    "pendingCommitExpirationTime": 0,
+                    "pendingContext": null,
+                    "pendingInteractionMap": Map {},
+                    "pingCache": null,
+                    "timeoutHandle": -1,
+                  },
+                  "tag": 3,
+                  "treeBaseDuration": 0,
+                  "type": null,
+                  "updateQueue": Object {
+                    "baseState": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={Object {}}
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "firstCapturedEffect": null,
+                    "firstCapturedUpdate": null,
+                    "firstEffect": null,
+                    "firstUpdate": null,
+                    "lastCapturedEffect": null,
+                    "lastCapturedUpdate": null,
+                    "lastEffect": null,
+                    "lastUpdate": null,
+                  },
+                },
+                "selfBaseDuration": 0,
+                "sibling": null,
+                "stateNode": WrapperComponent {
+                  "_reactInternalFiber": [Circular],
+                  "_reactInternalInstance": Object {},
+                  "context": Object {},
+                  "props": Object {
+                    "Component": [Function],
+                    "context": null,
+                    "props": Object {},
+                    "wrappingComponentProps": null,
+                  },
+                  "refs": Object {},
+                  "rootFinderInstance": null,
+                  "state": Object {
+                    "context": null,
+                    "mount": true,
+                    "props": Object {},
+                    "wrappingComponentProps": null,
+                  },
+                  "updater": Object {
+                    "enqueueForceUpdate": [Function],
+                    "enqueueReplaceState": [Function],
+                    "enqueueSetState": [Function],
+                    "isMounted": [Function],
+                  },
+                },
+                "tag": 1,
+                "treeBaseDuration": 0,
+                "type": [Function],
+                "updateQueue": null,
+              },
+              "_debugSource": null,
+              "actualDuration": 0,
+              "actualStartTime": -1,
+              "alternate": null,
+              "child": [Circular],
+              "childExpirationTime": 0,
+              "contextDependencies": null,
+              "effectTag": 1,
+              "elementType": [Function],
+              "expirationTime": 0,
+              "firstEffect": null,
+              "index": 0,
+              "key": null,
+              "lastEffect": null,
+              "memoizedProps": Object {},
+              "memoizedState": null,
+              "mode": 0,
+              "nextEffect": null,
+              "pendingProps": Object {},
+              "ref": null,
+              "return": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 62,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": null,
+                "_debugSource": null,
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": null,
+                "child": [Circular],
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 1,
+                "elementType": [Function],
+                "expirationTime": 0,
+                "firstEffect": null,
+                "index": 0,
+                "key": null,
+                "lastEffect": null,
+                "memoizedProps": Object {
+                  "Component": [Function],
+                  "context": null,
+                  "props": Object {},
+                  "wrappingComponentProps": null,
+                },
+                "memoizedState": Object {
+                  "context": null,
+                  "mount": true,
+                  "props": Object {},
+                  "wrappingComponentProps": null,
+                },
+                "mode": 0,
+                "nextEffect": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 60,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": null,
+                  "_debugSource": null,
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 60,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": null,
+                    "_debugSource": null,
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": [Circular],
+                    "child": null,
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 0,
+                    "elementType": null,
+                    "expirationTime": 1073741823,
+                    "firstEffect": null,
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": null,
+                    "memoizedProps": null,
+                    "memoizedState": null,
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": null,
+                    "ref": null,
+                    "return": null,
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": Object {
+                      "containerInfo": <div>
+                        <div
+                          class="dashboard-card engagement"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Engagement Trends
+                          </div>
+                        </div>
+                        <div
+                          class="dashboard-card upselling"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Upselling Partners
+                          </div>
+                          <div>
+                            upselling component
+                          </div>
+                        </div>
+                      </div>,
+                      "context": Object {},
+                      "current": [Circular],
+                      "didError": false,
+                      "earliestPendingTime": 0,
+                      "earliestSuspendedTime": 0,
+                      "expirationTime": 0,
+                      "finishedWork": null,
+                      "firstBatch": null,
+                      "hydrate": false,
+                      "interactionThreadID": 15,
+                      "latestPendingTime": 0,
+                      "latestPingedTime": 0,
+                      "latestSuspendedTime": 0,
+                      "memoizedInteractions": Set {},
+                      "nextExpirationTimeToWorkOn": 0,
+                      "nextScheduledRoot": null,
+                      "pendingChildren": null,
+                      "pendingCommitExpirationTime": 0,
+                      "pendingContext": null,
+                      "pendingInteractionMap": Map {},
+                      "pingCache": null,
+                      "timeoutHandle": -1,
+                    },
+                    "tag": 3,
+                    "treeBaseDuration": 0,
+                    "type": null,
+                    "updateQueue": Object {
+                      "baseState": null,
+                      "firstCapturedEffect": null,
+                      "firstCapturedUpdate": null,
+                      "firstEffect": null,
+                      "firstUpdate": Object {
+                        "callback": null,
+                        "expirationTime": 1073741823,
+                        "next": null,
+                        "nextEffect": null,
+                        "payload": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={Object {}}
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "tag": 0,
+                      },
+                      "lastCapturedEffect": null,
+                      "lastCapturedUpdate": null,
+                      "lastEffect": null,
+                      "lastUpdate": Object {
+                        "callback": null,
+                        "expirationTime": 1073741823,
+                        "next": null,
+                        "nextEffect": null,
+                        "payload": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={Object {}}
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "tag": 0,
+                      },
+                    },
+                  },
+                  "child": [Circular],
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 32,
+                  "elementType": null,
+                  "expirationTime": 0,
+                  "firstEffect": [Circular],
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": [Circular],
+                  "memoizedProps": null,
+                  "memoizedState": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={Object {}}
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "mode": 0,
+                  "nextEffect": null,
+                  "pendingProps": null,
+                  "ref": null,
+                  "return": null,
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": Object {
+                    "containerInfo": <div>
+                      <div
+                        class="dashboard-card engagement"
+                      >
+                        <div
+                          class="title"
+                        >
+                          Engagement Trends
+                        </div>
+                      </div>
+                      <div
+                        class="dashboard-card upselling"
+                      >
+                        <div
+                          class="title"
+                        >
+                          Upselling Partners
+                        </div>
+                        <div>
+                          upselling component
+                        </div>
+                      </div>
+                    </div>,
+                    "context": Object {},
+                    "current": [Circular],
+                    "didError": false,
+                    "earliestPendingTime": 0,
+                    "earliestSuspendedTime": 0,
+                    "expirationTime": 0,
+                    "finishedWork": null,
+                    "firstBatch": null,
+                    "hydrate": false,
+                    "interactionThreadID": 15,
+                    "latestPendingTime": 0,
+                    "latestPingedTime": 0,
+                    "latestSuspendedTime": 0,
+                    "memoizedInteractions": Set {},
+                    "nextExpirationTimeToWorkOn": 0,
+                    "nextScheduledRoot": null,
+                    "pendingChildren": null,
+                    "pendingCommitExpirationTime": 0,
+                    "pendingContext": null,
+                    "pendingInteractionMap": Map {},
+                    "pingCache": null,
+                    "timeoutHandle": -1,
+                  },
+                  "tag": 3,
+                  "treeBaseDuration": 0,
+                  "type": null,
+                  "updateQueue": Object {
+                    "baseState": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={Object {}}
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "firstCapturedEffect": null,
+                    "firstCapturedUpdate": null,
+                    "firstEffect": null,
+                    "firstUpdate": null,
+                    "lastCapturedEffect": null,
+                    "lastCapturedUpdate": null,
+                    "lastEffect": null,
+                    "lastUpdate": null,
+                  },
+                },
+                "pendingProps": Object {
+                  "Component": [Function],
+                  "context": null,
+                  "props": Object {},
+                  "wrappingComponentProps": null,
+                },
+                "ref": null,
+                "return": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 60,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": null,
+                  "_debugSource": null,
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 60,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": null,
+                    "_debugSource": null,
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": [Circular],
+                    "child": null,
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 0,
+                    "elementType": null,
+                    "expirationTime": 1073741823,
+                    "firstEffect": null,
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": null,
+                    "memoizedProps": null,
+                    "memoizedState": null,
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": null,
+                    "ref": null,
+                    "return": null,
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": Object {
+                      "containerInfo": <div>
+                        <div
+                          class="dashboard-card engagement"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Engagement Trends
+                          </div>
+                        </div>
+                        <div
+                          class="dashboard-card upselling"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Upselling Partners
+                          </div>
+                          <div>
+                            upselling component
+                          </div>
+                        </div>
+                      </div>,
+                      "context": Object {},
+                      "current": [Circular],
+                      "didError": false,
+                      "earliestPendingTime": 0,
+                      "earliestSuspendedTime": 0,
+                      "expirationTime": 0,
+                      "finishedWork": null,
+                      "firstBatch": null,
+                      "hydrate": false,
+                      "interactionThreadID": 15,
+                      "latestPendingTime": 0,
+                      "latestPingedTime": 0,
+                      "latestSuspendedTime": 0,
+                      "memoizedInteractions": Set {},
+                      "nextExpirationTimeToWorkOn": 0,
+                      "nextScheduledRoot": null,
+                      "pendingChildren": null,
+                      "pendingCommitExpirationTime": 0,
+                      "pendingContext": null,
+                      "pendingInteractionMap": Map {},
+                      "pingCache": null,
+                      "timeoutHandle": -1,
+                    },
+                    "tag": 3,
+                    "treeBaseDuration": 0,
+                    "type": null,
+                    "updateQueue": Object {
+                      "baseState": null,
+                      "firstCapturedEffect": null,
+                      "firstCapturedUpdate": null,
+                      "firstEffect": null,
+                      "firstUpdate": Object {
+                        "callback": null,
+                        "expirationTime": 1073741823,
+                        "next": null,
+                        "nextEffect": null,
+                        "payload": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={Object {}}
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "tag": 0,
+                      },
+                      "lastCapturedEffect": null,
+                      "lastCapturedUpdate": null,
+                      "lastEffect": null,
+                      "lastUpdate": Object {
+                        "callback": null,
+                        "expirationTime": 1073741823,
+                        "next": null,
+                        "nextEffect": null,
+                        "payload": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={Object {}}
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "tag": 0,
+                      },
+                    },
+                  },
+                  "child": [Circular],
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 32,
+                  "elementType": null,
+                  "expirationTime": 0,
+                  "firstEffect": [Circular],
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": [Circular],
+                  "memoizedProps": null,
+                  "memoizedState": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={Object {}}
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "mode": 0,
+                  "nextEffect": null,
+                  "pendingProps": null,
+                  "ref": null,
+                  "return": null,
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": Object {
+                    "containerInfo": <div>
+                      <div
+                        class="dashboard-card engagement"
+                      >
+                        <div
+                          class="title"
+                        >
+                          Engagement Trends
+                        </div>
+                      </div>
+                      <div
+                        class="dashboard-card upselling"
+                      >
+                        <div
+                          class="title"
+                        >
+                          Upselling Partners
+                        </div>
+                        <div>
+                          upselling component
+                        </div>
+                      </div>
+                    </div>,
+                    "context": Object {},
+                    "current": [Circular],
+                    "didError": false,
+                    "earliestPendingTime": 0,
+                    "earliestSuspendedTime": 0,
+                    "expirationTime": 0,
+                    "finishedWork": null,
+                    "firstBatch": null,
+                    "hydrate": false,
+                    "interactionThreadID": 15,
+                    "latestPendingTime": 0,
+                    "latestPingedTime": 0,
+                    "latestSuspendedTime": 0,
+                    "memoizedInteractions": Set {},
+                    "nextExpirationTimeToWorkOn": 0,
+                    "nextScheduledRoot": null,
+                    "pendingChildren": null,
+                    "pendingCommitExpirationTime": 0,
+                    "pendingContext": null,
+                    "pendingInteractionMap": Map {},
+                    "pingCache": null,
+                    "timeoutHandle": -1,
+                  },
+                  "tag": 3,
+                  "treeBaseDuration": 0,
+                  "type": null,
+                  "updateQueue": Object {
+                    "baseState": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={Object {}}
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "firstCapturedEffect": null,
+                    "firstCapturedUpdate": null,
+                    "firstEffect": null,
+                    "firstUpdate": null,
+                    "lastCapturedEffect": null,
+                    "lastCapturedUpdate": null,
+                    "lastEffect": null,
+                    "lastUpdate": null,
+                  },
+                },
+                "selfBaseDuration": 0,
+                "sibling": null,
+                "stateNode": WrapperComponent {
+                  "_reactInternalFiber": [Circular],
+                  "_reactInternalInstance": Object {},
+                  "context": Object {},
+                  "props": Object {
+                    "Component": [Function],
+                    "context": null,
+                    "props": Object {},
+                    "wrappingComponentProps": null,
+                  },
+                  "refs": Object {},
+                  "rootFinderInstance": null,
+                  "state": Object {
+                    "context": null,
+                    "mount": true,
+                    "props": Object {},
+                    "wrappingComponentProps": null,
+                  },
+                  "updater": Object {
+                    "enqueueForceUpdate": [Function],
+                    "enqueueReplaceState": [Function],
+                    "enqueueSetState": [Function],
+                    "isMounted": [Function],
+                  },
+                },
+                "tag": 1,
+                "treeBaseDuration": 0,
+                "type": [Function],
+                "updateQueue": null,
+              },
+              "selfBaseDuration": 0,
+              "sibling": null,
+              "stateNode": Dashboard {
+                "_reactInternalFiber": [Circular],
+                "_reactInternalInstance": Object {},
+                "context": Object {},
+                "props": Object {},
+                "refs": Object {},
+                "renderUpselling": [Function],
+                "state": null,
+                "updater": Object {
+                  "enqueueForceUpdate": [Function],
+                  "enqueueReplaceState": [Function],
+                  "enqueueSetState": [Function],
+                  "isMounted": [Function],
+                },
+              },
+              "tag": 1,
+              "treeBaseDuration": 0,
+              "type": [Function],
+              "updateQueue": null,
+            },
+            "_debugSource": Object {
+              "fileName": "/Users/kevinkoech/Documents/bp-esa-frontend/src/components/Dashboard/index.jsx",
+              "lineNumber": 23,
+            },
+            "actualDuration": 0,
+            "actualStartTime": -1,
+            "alternate": null,
+            "child": FiberNode {
+              "_debugHookTypes": null,
+              "_debugID": 66,
+              "_debugIsCurrentlyTiming": false,
+              "_debugOwner": [Circular],
+              "_debugSource": Object {
+                "fileName": "/Users/kevinkoech/Documents/bp-esa-frontend/src/components/Dashboard/Card.jsx",
+                "lineNumber": 20,
+              },
+              "actualDuration": 0,
+              "actualStartTime": -1,
+              "alternate": null,
+              "child": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 67,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": [Circular],
+                "_debugSource": Object {
+                  "fileName": "/Users/kevinkoech/Documents/bp-esa-frontend/src/components/Dashboard/Card.jsx",
+                  "lineNumber": 21,
+                },
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": null,
+                "child": null,
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 0,
+                "elementType": "div",
+                "expirationTime": 0,
+                "firstEffect": null,
+                "index": 0,
+                "key": null,
+                "lastEffect": null,
+                "memoizedProps": Object {
+                  "children": "Engagement Trends",
+                  "className": "title",
+                },
+                "memoizedState": null,
+                "mode": 0,
+                "nextEffect": null,
+                "pendingProps": Object {
+                  "children": "Engagement Trends",
+                  "className": "title",
+                },
+                "ref": null,
+                "return": [Circular],
+                "selfBaseDuration": 0,
+                "sibling": null,
+                "stateNode": <div
+                  class="title"
+                >
+                  Engagement Trends
+                </div>,
+                "tag": 5,
+                "treeBaseDuration": 0,
+                "type": "div",
+                "updateQueue": null,
+              },
+              "childExpirationTime": 0,
+              "contextDependencies": null,
+              "effectTag": 0,
+              "elementType": "div",
+              "expirationTime": 0,
+              "firstEffect": null,
+              "index": 0,
+              "key": null,
+              "lastEffect": null,
+              "memoizedProps": Object {
+                "children": Array [
+                  <div
+                    className="title"
+                  >
+                    Engagement Trends
+                  </div>,
+                  undefined,
+                ],
+                "className": "dashboard-card engagement",
+              },
+              "memoizedState": null,
+              "mode": 0,
+              "nextEffect": null,
+              "pendingProps": Object {
+                "children": Array [
+                  <div
+                    className="title"
+                  >
+                    Engagement Trends
+                  </div>,
+                  undefined,
+                ],
+                "className": "dashboard-card engagement",
+              },
+              "ref": null,
+              "return": [Circular],
+              "selfBaseDuration": 0,
+              "sibling": null,
+              "stateNode": <div
+                class="dashboard-card engagement"
+              >
+                <div
+                  class="title"
+                >
+                  Engagement Trends
+                </div>
+              </div>,
+              "tag": 5,
+              "treeBaseDuration": 0,
+              "type": "div",
+              "updateQueue": null,
+            },
+            "childExpirationTime": 0,
+            "contextDependencies": null,
+            "effectTag": 1,
+            "elementType": [Function],
+            "expirationTime": 0,
+            "firstEffect": null,
+            "index": 0,
+            "key": null,
+            "lastEffect": null,
+            "memoizedProps": Object {
+              "classes": "engagement",
+              "component": [Function],
+              "title": "Engagement Trends",
+            },
+            "memoizedState": null,
+            "mode": 0,
+            "nextEffect": null,
+            "pendingProps": Object {
+              "classes": "engagement",
+              "component": [Function],
+              "title": "Engagement Trends",
+            },
+            "ref": null,
+            "return": FiberNode {
+              "_debugHookTypes": null,
+              "_debugID": 63,
+              "_debugIsCurrentlyTiming": false,
+              "_debugOwner": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 62,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": null,
+                "_debugSource": null,
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": null,
+                "child": [Circular],
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 1,
+                "elementType": [Function],
+                "expirationTime": 0,
+                "firstEffect": null,
+                "index": 0,
+                "key": null,
+                "lastEffect": null,
+                "memoizedProps": Object {
+                  "Component": [Function],
+                  "context": null,
+                  "props": Object {},
+                  "wrappingComponentProps": null,
+                },
+                "memoizedState": Object {
+                  "context": null,
+                  "mount": true,
+                  "props": Object {},
+                  "wrappingComponentProps": null,
+                },
+                "mode": 0,
+                "nextEffect": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 60,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": null,
+                  "_debugSource": null,
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 60,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": null,
+                    "_debugSource": null,
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": [Circular],
+                    "child": null,
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 0,
+                    "elementType": null,
+                    "expirationTime": 1073741823,
+                    "firstEffect": null,
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": null,
+                    "memoizedProps": null,
+                    "memoizedState": null,
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": null,
+                    "ref": null,
+                    "return": null,
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": Object {
+                      "containerInfo": <div>
+                        <div
+                          class="dashboard-card engagement"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Engagement Trends
+                          </div>
+                        </div>
+                        <div
+                          class="dashboard-card upselling"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Upselling Partners
+                          </div>
+                          <div>
+                            upselling component
+                          </div>
+                        </div>
+                      </div>,
+                      "context": Object {},
+                      "current": [Circular],
+                      "didError": false,
+                      "earliestPendingTime": 0,
+                      "earliestSuspendedTime": 0,
+                      "expirationTime": 0,
+                      "finishedWork": null,
+                      "firstBatch": null,
+                      "hydrate": false,
+                      "interactionThreadID": 15,
+                      "latestPendingTime": 0,
+                      "latestPingedTime": 0,
+                      "latestSuspendedTime": 0,
+                      "memoizedInteractions": Set {},
+                      "nextExpirationTimeToWorkOn": 0,
+                      "nextScheduledRoot": null,
+                      "pendingChildren": null,
+                      "pendingCommitExpirationTime": 0,
+                      "pendingContext": null,
+                      "pendingInteractionMap": Map {},
+                      "pingCache": null,
+                      "timeoutHandle": -1,
+                    },
+                    "tag": 3,
+                    "treeBaseDuration": 0,
+                    "type": null,
+                    "updateQueue": Object {
+                      "baseState": null,
+                      "firstCapturedEffect": null,
+                      "firstCapturedUpdate": null,
+                      "firstEffect": null,
+                      "firstUpdate": Object {
+                        "callback": null,
+                        "expirationTime": 1073741823,
+                        "next": null,
+                        "nextEffect": null,
+                        "payload": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={Object {}}
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "tag": 0,
+                      },
+                      "lastCapturedEffect": null,
+                      "lastCapturedUpdate": null,
+                      "lastEffect": null,
+                      "lastUpdate": Object {
+                        "callback": null,
+                        "expirationTime": 1073741823,
+                        "next": null,
+                        "nextEffect": null,
+                        "payload": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={Object {}}
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "tag": 0,
+                      },
+                    },
+                  },
+                  "child": [Circular],
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 32,
+                  "elementType": null,
+                  "expirationTime": 0,
+                  "firstEffect": [Circular],
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": [Circular],
+                  "memoizedProps": null,
+                  "memoizedState": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={Object {}}
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "mode": 0,
+                  "nextEffect": null,
+                  "pendingProps": null,
+                  "ref": null,
+                  "return": null,
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": Object {
+                    "containerInfo": <div>
+                      <div
+                        class="dashboard-card engagement"
+                      >
+                        <div
+                          class="title"
+                        >
+                          Engagement Trends
+                        </div>
+                      </div>
+                      <div
+                        class="dashboard-card upselling"
+                      >
+                        <div
+                          class="title"
+                        >
+                          Upselling Partners
+                        </div>
+                        <div>
+                          upselling component
+                        </div>
+                      </div>
+                    </div>,
+                    "context": Object {},
+                    "current": [Circular],
+                    "didError": false,
+                    "earliestPendingTime": 0,
+                    "earliestSuspendedTime": 0,
+                    "expirationTime": 0,
+                    "finishedWork": null,
+                    "firstBatch": null,
+                    "hydrate": false,
+                    "interactionThreadID": 15,
+                    "latestPendingTime": 0,
+                    "latestPingedTime": 0,
+                    "latestSuspendedTime": 0,
+                    "memoizedInteractions": Set {},
+                    "nextExpirationTimeToWorkOn": 0,
+                    "nextScheduledRoot": null,
+                    "pendingChildren": null,
+                    "pendingCommitExpirationTime": 0,
+                    "pendingContext": null,
+                    "pendingInteractionMap": Map {},
+                    "pingCache": null,
+                    "timeoutHandle": -1,
+                  },
+                  "tag": 3,
+                  "treeBaseDuration": 0,
+                  "type": null,
+                  "updateQueue": Object {
+                    "baseState": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={Object {}}
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "firstCapturedEffect": null,
+                    "firstCapturedUpdate": null,
+                    "firstEffect": null,
+                    "firstUpdate": null,
+                    "lastCapturedEffect": null,
+                    "lastCapturedUpdate": null,
+                    "lastEffect": null,
+                    "lastUpdate": null,
+                  },
+                },
+                "pendingProps": Object {
+                  "Component": [Function],
+                  "context": null,
+                  "props": Object {},
+                  "wrappingComponentProps": null,
+                },
+                "ref": null,
+                "return": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 60,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": null,
+                  "_debugSource": null,
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 60,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": null,
+                    "_debugSource": null,
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": [Circular],
+                    "child": null,
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 0,
+                    "elementType": null,
+                    "expirationTime": 1073741823,
+                    "firstEffect": null,
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": null,
+                    "memoizedProps": null,
+                    "memoizedState": null,
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": null,
+                    "ref": null,
+                    "return": null,
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": Object {
+                      "containerInfo": <div>
+                        <div
+                          class="dashboard-card engagement"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Engagement Trends
+                          </div>
+                        </div>
+                        <div
+                          class="dashboard-card upselling"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Upselling Partners
+                          </div>
+                          <div>
+                            upselling component
+                          </div>
+                        </div>
+                      </div>,
+                      "context": Object {},
+                      "current": [Circular],
+                      "didError": false,
+                      "earliestPendingTime": 0,
+                      "earliestSuspendedTime": 0,
+                      "expirationTime": 0,
+                      "finishedWork": null,
+                      "firstBatch": null,
+                      "hydrate": false,
+                      "interactionThreadID": 15,
+                      "latestPendingTime": 0,
+                      "latestPingedTime": 0,
+                      "latestSuspendedTime": 0,
+                      "memoizedInteractions": Set {},
+                      "nextExpirationTimeToWorkOn": 0,
+                      "nextScheduledRoot": null,
+                      "pendingChildren": null,
+                      "pendingCommitExpirationTime": 0,
+                      "pendingContext": null,
+                      "pendingInteractionMap": Map {},
+                      "pingCache": null,
+                      "timeoutHandle": -1,
+                    },
+                    "tag": 3,
+                    "treeBaseDuration": 0,
+                    "type": null,
+                    "updateQueue": Object {
+                      "baseState": null,
+                      "firstCapturedEffect": null,
+                      "firstCapturedUpdate": null,
+                      "firstEffect": null,
+                      "firstUpdate": Object {
+                        "callback": null,
+                        "expirationTime": 1073741823,
+                        "next": null,
+                        "nextEffect": null,
+                        "payload": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={Object {}}
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "tag": 0,
+                      },
+                      "lastCapturedEffect": null,
+                      "lastCapturedUpdate": null,
+                      "lastEffect": null,
+                      "lastUpdate": Object {
+                        "callback": null,
+                        "expirationTime": 1073741823,
+                        "next": null,
+                        "nextEffect": null,
+                        "payload": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={Object {}}
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "tag": 0,
+                      },
+                    },
+                  },
+                  "child": [Circular],
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 32,
+                  "elementType": null,
+                  "expirationTime": 0,
+                  "firstEffect": [Circular],
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": [Circular],
+                  "memoizedProps": null,
+                  "memoizedState": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={Object {}}
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "mode": 0,
+                  "nextEffect": null,
+                  "pendingProps": null,
+                  "ref": null,
+                  "return": null,
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": Object {
+                    "containerInfo": <div>
+                      <div
+                        class="dashboard-card engagement"
+                      >
+                        <div
+                          class="title"
+                        >
+                          Engagement Trends
+                        </div>
+                      </div>
+                      <div
+                        class="dashboard-card upselling"
+                      >
+                        <div
+                          class="title"
+                        >
+                          Upselling Partners
+                        </div>
+                        <div>
+                          upselling component
+                        </div>
+                      </div>
+                    </div>,
+                    "context": Object {},
+                    "current": [Circular],
+                    "didError": false,
+                    "earliestPendingTime": 0,
+                    "earliestSuspendedTime": 0,
+                    "expirationTime": 0,
+                    "finishedWork": null,
+                    "firstBatch": null,
+                    "hydrate": false,
+                    "interactionThreadID": 15,
+                    "latestPendingTime": 0,
+                    "latestPingedTime": 0,
+                    "latestSuspendedTime": 0,
+                    "memoizedInteractions": Set {},
+                    "nextExpirationTimeToWorkOn": 0,
+                    "nextScheduledRoot": null,
+                    "pendingChildren": null,
+                    "pendingCommitExpirationTime": 0,
+                    "pendingContext": null,
+                    "pendingInteractionMap": Map {},
+                    "pingCache": null,
+                    "timeoutHandle": -1,
+                  },
+                  "tag": 3,
+                  "treeBaseDuration": 0,
+                  "type": null,
+                  "updateQueue": Object {
+                    "baseState": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={Object {}}
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "firstCapturedEffect": null,
+                    "firstCapturedUpdate": null,
+                    "firstEffect": null,
+                    "firstUpdate": null,
+                    "lastCapturedEffect": null,
+                    "lastCapturedUpdate": null,
+                    "lastEffect": null,
+                    "lastUpdate": null,
+                  },
+                },
+                "selfBaseDuration": 0,
+                "sibling": null,
+                "stateNode": WrapperComponent {
+                  "_reactInternalFiber": [Circular],
+                  "_reactInternalInstance": Object {},
+                  "context": Object {},
+                  "props": Object {
+                    "Component": [Function],
+                    "context": null,
+                    "props": Object {},
+                    "wrappingComponentProps": null,
+                  },
+                  "refs": Object {},
+                  "rootFinderInstance": null,
+                  "state": Object {
+                    "context": null,
+                    "mount": true,
+                    "props": Object {},
+                    "wrappingComponentProps": null,
+                  },
+                  "updater": Object {
+                    "enqueueForceUpdate": [Function],
+                    "enqueueReplaceState": [Function],
+                    "enqueueSetState": [Function],
+                    "isMounted": [Function],
+                  },
+                },
+                "tag": 1,
+                "treeBaseDuration": 0,
+                "type": [Function],
+                "updateQueue": null,
+              },
+              "_debugSource": null,
+              "actualDuration": 0,
+              "actualStartTime": -1,
+              "alternate": null,
+              "child": [Circular],
+              "childExpirationTime": 0,
+              "contextDependencies": null,
+              "effectTag": 1,
+              "elementType": [Function],
+              "expirationTime": 0,
+              "firstEffect": null,
+              "index": 0,
+              "key": null,
+              "lastEffect": null,
+              "memoizedProps": Object {},
+              "memoizedState": null,
+              "mode": 0,
+              "nextEffect": null,
+              "pendingProps": Object {},
+              "ref": null,
+              "return": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 62,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": null,
+                "_debugSource": null,
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": null,
+                "child": [Circular],
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 1,
+                "elementType": [Function],
+                "expirationTime": 0,
+                "firstEffect": null,
+                "index": 0,
+                "key": null,
+                "lastEffect": null,
+                "memoizedProps": Object {
+                  "Component": [Function],
+                  "context": null,
+                  "props": Object {},
+                  "wrappingComponentProps": null,
+                },
+                "memoizedState": Object {
+                  "context": null,
+                  "mount": true,
+                  "props": Object {},
+                  "wrappingComponentProps": null,
+                },
+                "mode": 0,
+                "nextEffect": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 60,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": null,
+                  "_debugSource": null,
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 60,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": null,
+                    "_debugSource": null,
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": [Circular],
+                    "child": null,
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 0,
+                    "elementType": null,
+                    "expirationTime": 1073741823,
+                    "firstEffect": null,
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": null,
+                    "memoizedProps": null,
+                    "memoizedState": null,
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": null,
+                    "ref": null,
+                    "return": null,
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": Object {
+                      "containerInfo": <div>
+                        <div
+                          class="dashboard-card engagement"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Engagement Trends
+                          </div>
+                        </div>
+                        <div
+                          class="dashboard-card upselling"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Upselling Partners
+                          </div>
+                          <div>
+                            upselling component
+                          </div>
+                        </div>
+                      </div>,
+                      "context": Object {},
+                      "current": [Circular],
+                      "didError": false,
+                      "earliestPendingTime": 0,
+                      "earliestSuspendedTime": 0,
+                      "expirationTime": 0,
+                      "finishedWork": null,
+                      "firstBatch": null,
+                      "hydrate": false,
+                      "interactionThreadID": 15,
+                      "latestPendingTime": 0,
+                      "latestPingedTime": 0,
+                      "latestSuspendedTime": 0,
+                      "memoizedInteractions": Set {},
+                      "nextExpirationTimeToWorkOn": 0,
+                      "nextScheduledRoot": null,
+                      "pendingChildren": null,
+                      "pendingCommitExpirationTime": 0,
+                      "pendingContext": null,
+                      "pendingInteractionMap": Map {},
+                      "pingCache": null,
+                      "timeoutHandle": -1,
+                    },
+                    "tag": 3,
+                    "treeBaseDuration": 0,
+                    "type": null,
+                    "updateQueue": Object {
+                      "baseState": null,
+                      "firstCapturedEffect": null,
+                      "firstCapturedUpdate": null,
+                      "firstEffect": null,
+                      "firstUpdate": Object {
+                        "callback": null,
+                        "expirationTime": 1073741823,
+                        "next": null,
+                        "nextEffect": null,
+                        "payload": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={Object {}}
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "tag": 0,
+                      },
+                      "lastCapturedEffect": null,
+                      "lastCapturedUpdate": null,
+                      "lastEffect": null,
+                      "lastUpdate": Object {
+                        "callback": null,
+                        "expirationTime": 1073741823,
+                        "next": null,
+                        "nextEffect": null,
+                        "payload": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={Object {}}
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "tag": 0,
+                      },
+                    },
+                  },
+                  "child": [Circular],
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 32,
+                  "elementType": null,
+                  "expirationTime": 0,
+                  "firstEffect": [Circular],
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": [Circular],
+                  "memoizedProps": null,
+                  "memoizedState": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={Object {}}
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "mode": 0,
+                  "nextEffect": null,
+                  "pendingProps": null,
+                  "ref": null,
+                  "return": null,
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": Object {
+                    "containerInfo": <div>
+                      <div
+                        class="dashboard-card engagement"
+                      >
+                        <div
+                          class="title"
+                        >
+                          Engagement Trends
+                        </div>
+                      </div>
+                      <div
+                        class="dashboard-card upselling"
+                      >
+                        <div
+                          class="title"
+                        >
+                          Upselling Partners
+                        </div>
+                        <div>
+                          upselling component
+                        </div>
+                      </div>
+                    </div>,
+                    "context": Object {},
+                    "current": [Circular],
+                    "didError": false,
+                    "earliestPendingTime": 0,
+                    "earliestSuspendedTime": 0,
+                    "expirationTime": 0,
+                    "finishedWork": null,
+                    "firstBatch": null,
+                    "hydrate": false,
+                    "interactionThreadID": 15,
+                    "latestPendingTime": 0,
+                    "latestPingedTime": 0,
+                    "latestSuspendedTime": 0,
+                    "memoizedInteractions": Set {},
+                    "nextExpirationTimeToWorkOn": 0,
+                    "nextScheduledRoot": null,
+                    "pendingChildren": null,
+                    "pendingCommitExpirationTime": 0,
+                    "pendingContext": null,
+                    "pendingInteractionMap": Map {},
+                    "pingCache": null,
+                    "timeoutHandle": -1,
+                  },
+                  "tag": 3,
+                  "treeBaseDuration": 0,
+                  "type": null,
+                  "updateQueue": Object {
+                    "baseState": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={Object {}}
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "firstCapturedEffect": null,
+                    "firstCapturedUpdate": null,
+                    "firstEffect": null,
+                    "firstUpdate": null,
+                    "lastCapturedEffect": null,
+                    "lastCapturedUpdate": null,
+                    "lastEffect": null,
+                    "lastUpdate": null,
+                  },
+                },
+                "pendingProps": Object {
+                  "Component": [Function],
+                  "context": null,
+                  "props": Object {},
+                  "wrappingComponentProps": null,
+                },
+                "ref": null,
+                "return": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 60,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": null,
+                  "_debugSource": null,
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 60,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": null,
+                    "_debugSource": null,
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": [Circular],
+                    "child": null,
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 0,
+                    "elementType": null,
+                    "expirationTime": 1073741823,
+                    "firstEffect": null,
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": null,
+                    "memoizedProps": null,
+                    "memoizedState": null,
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": null,
+                    "ref": null,
+                    "return": null,
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": Object {
+                      "containerInfo": <div>
+                        <div
+                          class="dashboard-card engagement"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Engagement Trends
+                          </div>
+                        </div>
+                        <div
+                          class="dashboard-card upselling"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Upselling Partners
+                          </div>
+                          <div>
+                            upselling component
+                          </div>
+                        </div>
+                      </div>,
+                      "context": Object {},
+                      "current": [Circular],
+                      "didError": false,
+                      "earliestPendingTime": 0,
+                      "earliestSuspendedTime": 0,
+                      "expirationTime": 0,
+                      "finishedWork": null,
+                      "firstBatch": null,
+                      "hydrate": false,
+                      "interactionThreadID": 15,
+                      "latestPendingTime": 0,
+                      "latestPingedTime": 0,
+                      "latestSuspendedTime": 0,
+                      "memoizedInteractions": Set {},
+                      "nextExpirationTimeToWorkOn": 0,
+                      "nextScheduledRoot": null,
+                      "pendingChildren": null,
+                      "pendingCommitExpirationTime": 0,
+                      "pendingContext": null,
+                      "pendingInteractionMap": Map {},
+                      "pingCache": null,
+                      "timeoutHandle": -1,
+                    },
+                    "tag": 3,
+                    "treeBaseDuration": 0,
+                    "type": null,
+                    "updateQueue": Object {
+                      "baseState": null,
+                      "firstCapturedEffect": null,
+                      "firstCapturedUpdate": null,
+                      "firstEffect": null,
+                      "firstUpdate": Object {
+                        "callback": null,
+                        "expirationTime": 1073741823,
+                        "next": null,
+                        "nextEffect": null,
+                        "payload": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={Object {}}
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "tag": 0,
+                      },
+                      "lastCapturedEffect": null,
+                      "lastCapturedUpdate": null,
+                      "lastEffect": null,
+                      "lastUpdate": Object {
+                        "callback": null,
+                        "expirationTime": 1073741823,
+                        "next": null,
+                        "nextEffect": null,
+                        "payload": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={Object {}}
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "tag": 0,
+                      },
+                    },
+                  },
+                  "child": [Circular],
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 32,
+                  "elementType": null,
+                  "expirationTime": 0,
+                  "firstEffect": [Circular],
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": [Circular],
+                  "memoizedProps": null,
+                  "memoizedState": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={Object {}}
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "mode": 0,
+                  "nextEffect": null,
+                  "pendingProps": null,
+                  "ref": null,
+                  "return": null,
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": Object {
+                    "containerInfo": <div>
+                      <div
+                        class="dashboard-card engagement"
+                      >
+                        <div
+                          class="title"
+                        >
+                          Engagement Trends
+                        </div>
+                      </div>
+                      <div
+                        class="dashboard-card upselling"
+                      >
+                        <div
+                          class="title"
+                        >
+                          Upselling Partners
+                        </div>
+                        <div>
+                          upselling component
+                        </div>
+                      </div>
+                    </div>,
+                    "context": Object {},
+                    "current": [Circular],
+                    "didError": false,
+                    "earliestPendingTime": 0,
+                    "earliestSuspendedTime": 0,
+                    "expirationTime": 0,
+                    "finishedWork": null,
+                    "firstBatch": null,
+                    "hydrate": false,
+                    "interactionThreadID": 15,
+                    "latestPendingTime": 0,
+                    "latestPingedTime": 0,
+                    "latestSuspendedTime": 0,
+                    "memoizedInteractions": Set {},
+                    "nextExpirationTimeToWorkOn": 0,
+                    "nextScheduledRoot": null,
+                    "pendingChildren": null,
+                    "pendingCommitExpirationTime": 0,
+                    "pendingContext": null,
+                    "pendingInteractionMap": Map {},
+                    "pingCache": null,
+                    "timeoutHandle": -1,
+                  },
+                  "tag": 3,
+                  "treeBaseDuration": 0,
+                  "type": null,
+                  "updateQueue": Object {
+                    "baseState": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={Object {}}
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "firstCapturedEffect": null,
+                    "firstCapturedUpdate": null,
+                    "firstEffect": null,
+                    "firstUpdate": null,
+                    "lastCapturedEffect": null,
+                    "lastCapturedUpdate": null,
+                    "lastEffect": null,
+                    "lastUpdate": null,
+                  },
+                },
+                "selfBaseDuration": 0,
+                "sibling": null,
+                "stateNode": WrapperComponent {
+                  "_reactInternalFiber": [Circular],
+                  "_reactInternalInstance": Object {},
+                  "context": Object {},
+                  "props": Object {
+                    "Component": [Function],
+                    "context": null,
+                    "props": Object {},
+                    "wrappingComponentProps": null,
+                  },
+                  "refs": Object {},
+                  "rootFinderInstance": null,
+                  "state": Object {
+                    "context": null,
+                    "mount": true,
+                    "props": Object {},
+                    "wrappingComponentProps": null,
+                  },
+                  "updater": Object {
+                    "enqueueForceUpdate": [Function],
+                    "enqueueReplaceState": [Function],
+                    "enqueueSetState": [Function],
+                    "isMounted": [Function],
+                  },
+                },
+                "tag": 1,
+                "treeBaseDuration": 0,
+                "type": [Function],
+                "updateQueue": null,
+              },
+              "selfBaseDuration": 0,
+              "sibling": null,
+              "stateNode": Dashboard {
+                "_reactInternalFiber": [Circular],
+                "_reactInternalInstance": Object {},
+                "context": Object {},
+                "props": Object {},
+                "refs": Object {},
+                "renderUpselling": [Function],
+                "state": null,
+                "updater": Object {
+                  "enqueueForceUpdate": [Function],
+                  "enqueueReplaceState": [Function],
+                  "enqueueSetState": [Function],
+                  "isMounted": [Function],
+                },
+              },
+              "tag": 1,
+              "treeBaseDuration": 0,
+              "type": [Function],
+              "updateQueue": null,
+            },
+            "selfBaseDuration": 0,
+            "sibling": FiberNode {
+              "_debugHookTypes": null,
+              "_debugID": 65,
+              "_debugIsCurrentlyTiming": false,
+              "_debugOwner": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 63,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 62,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": null,
+                  "_debugSource": null,
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": null,
+                  "child": [Circular],
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 1,
+                  "elementType": [Function],
+                  "expirationTime": 0,
+                  "firstEffect": null,
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": null,
+                  "memoizedProps": Object {
+                    "Component": [Function],
+                    "context": null,
+                    "props": Object {},
+                    "wrappingComponentProps": null,
+                  },
+                  "memoizedState": Object {
+                    "context": null,
+                    "mount": true,
+                    "props": Object {},
+                    "wrappingComponentProps": null,
+                  },
+                  "mode": 0,
+                  "nextEffect": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 60,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": null,
+                    "_debugSource": null,
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": FiberNode {
+                      "_debugHookTypes": null,
+                      "_debugID": 60,
+                      "_debugIsCurrentlyTiming": false,
+                      "_debugOwner": null,
+                      "_debugSource": null,
+                      "actualDuration": 0,
+                      "actualStartTime": -1,
+                      "alternate": [Circular],
+                      "child": null,
+                      "childExpirationTime": 0,
+                      "contextDependencies": null,
+                      "effectTag": 0,
+                      "elementType": null,
+                      "expirationTime": 1073741823,
+                      "firstEffect": null,
+                      "index": 0,
+                      "key": null,
+                      "lastEffect": null,
+                      "memoizedProps": null,
+                      "memoizedState": null,
+                      "mode": 0,
+                      "nextEffect": null,
+                      "pendingProps": null,
+                      "ref": null,
+                      "return": null,
+                      "selfBaseDuration": 0,
+                      "sibling": null,
+                      "stateNode": Object {
+                        "containerInfo": <div>
+                          <div
+                            class="dashboard-card engagement"
+                          >
+                            <div
+                              class="title"
+                            >
+                              Engagement Trends
+                            </div>
+                          </div>
+                          <div
+                            class="dashboard-card upselling"
+                          >
+                            <div
+                              class="title"
+                            >
+                              Upselling Partners
+                            </div>
+                            <div>
+                              upselling component
+                            </div>
+                          </div>
+                        </div>,
+                        "context": Object {},
+                        "current": [Circular],
+                        "didError": false,
+                        "earliestPendingTime": 0,
+                        "earliestSuspendedTime": 0,
+                        "expirationTime": 0,
+                        "finishedWork": null,
+                        "firstBatch": null,
+                        "hydrate": false,
+                        "interactionThreadID": 15,
+                        "latestPendingTime": 0,
+                        "latestPingedTime": 0,
+                        "latestSuspendedTime": 0,
+                        "memoizedInteractions": Set {},
+                        "nextExpirationTimeToWorkOn": 0,
+                        "nextScheduledRoot": null,
+                        "pendingChildren": null,
+                        "pendingCommitExpirationTime": 0,
+                        "pendingContext": null,
+                        "pendingInteractionMap": Map {},
+                        "pingCache": null,
+                        "timeoutHandle": -1,
+                      },
+                      "tag": 3,
+                      "treeBaseDuration": 0,
+                      "type": null,
+                      "updateQueue": Object {
+                        "baseState": null,
+                        "firstCapturedEffect": null,
+                        "firstCapturedUpdate": null,
+                        "firstEffect": null,
+                        "firstUpdate": Object {
+                          "callback": null,
+                          "expirationTime": 1073741823,
+                          "next": null,
+                          "nextEffect": null,
+                          "payload": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={Object {}}
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "tag": 0,
+                        },
+                        "lastCapturedEffect": null,
+                        "lastCapturedUpdate": null,
+                        "lastEffect": null,
+                        "lastUpdate": Object {
+                          "callback": null,
+                          "expirationTime": 1073741823,
+                          "next": null,
+                          "nextEffect": null,
+                          "payload": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={Object {}}
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "tag": 0,
+                        },
+                      },
+                    },
+                    "child": [Circular],
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 32,
+                    "elementType": null,
+                    "expirationTime": 0,
+                    "firstEffect": [Circular],
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": [Circular],
+                    "memoizedProps": null,
+                    "memoizedState": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={Object {}}
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": null,
+                    "ref": null,
+                    "return": null,
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": Object {
+                      "containerInfo": <div>
+                        <div
+                          class="dashboard-card engagement"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Engagement Trends
+                          </div>
+                        </div>
+                        <div
+                          class="dashboard-card upselling"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Upselling Partners
+                          </div>
+                          <div>
+                            upselling component
+                          </div>
+                        </div>
+                      </div>,
+                      "context": Object {},
+                      "current": [Circular],
+                      "didError": false,
+                      "earliestPendingTime": 0,
+                      "earliestSuspendedTime": 0,
+                      "expirationTime": 0,
+                      "finishedWork": null,
+                      "firstBatch": null,
+                      "hydrate": false,
+                      "interactionThreadID": 15,
+                      "latestPendingTime": 0,
+                      "latestPingedTime": 0,
+                      "latestSuspendedTime": 0,
+                      "memoizedInteractions": Set {},
+                      "nextExpirationTimeToWorkOn": 0,
+                      "nextScheduledRoot": null,
+                      "pendingChildren": null,
+                      "pendingCommitExpirationTime": 0,
+                      "pendingContext": null,
+                      "pendingInteractionMap": Map {},
+                      "pingCache": null,
+                      "timeoutHandle": -1,
+                    },
+                    "tag": 3,
+                    "treeBaseDuration": 0,
+                    "type": null,
+                    "updateQueue": Object {
+                      "baseState": Object {
+                        "element": <WrapperComponent
+                          Component={[Function]}
+                          context={null}
+                          props={Object {}}
+                          wrappingComponentProps={null}
+                        />,
+                      },
+                      "firstCapturedEffect": null,
+                      "firstCapturedUpdate": null,
+                      "firstEffect": null,
+                      "firstUpdate": null,
+                      "lastCapturedEffect": null,
+                      "lastCapturedUpdate": null,
+                      "lastEffect": null,
+                      "lastUpdate": null,
+                    },
+                  },
+                  "pendingProps": Object {
+                    "Component": [Function],
+                    "context": null,
+                    "props": Object {},
+                    "wrappingComponentProps": null,
+                  },
+                  "ref": null,
+                  "return": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 60,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": null,
+                    "_debugSource": null,
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": FiberNode {
+                      "_debugHookTypes": null,
+                      "_debugID": 60,
+                      "_debugIsCurrentlyTiming": false,
+                      "_debugOwner": null,
+                      "_debugSource": null,
+                      "actualDuration": 0,
+                      "actualStartTime": -1,
+                      "alternate": [Circular],
+                      "child": null,
+                      "childExpirationTime": 0,
+                      "contextDependencies": null,
+                      "effectTag": 0,
+                      "elementType": null,
+                      "expirationTime": 1073741823,
+                      "firstEffect": null,
+                      "index": 0,
+                      "key": null,
+                      "lastEffect": null,
+                      "memoizedProps": null,
+                      "memoizedState": null,
+                      "mode": 0,
+                      "nextEffect": null,
+                      "pendingProps": null,
+                      "ref": null,
+                      "return": null,
+                      "selfBaseDuration": 0,
+                      "sibling": null,
+                      "stateNode": Object {
+                        "containerInfo": <div>
+                          <div
+                            class="dashboard-card engagement"
+                          >
+                            <div
+                              class="title"
+                            >
+                              Engagement Trends
+                            </div>
+                          </div>
+                          <div
+                            class="dashboard-card upselling"
+                          >
+                            <div
+                              class="title"
+                            >
+                              Upselling Partners
+                            </div>
+                            <div>
+                              upselling component
+                            </div>
+                          </div>
+                        </div>,
+                        "context": Object {},
+                        "current": [Circular],
+                        "didError": false,
+                        "earliestPendingTime": 0,
+                        "earliestSuspendedTime": 0,
+                        "expirationTime": 0,
+                        "finishedWork": null,
+                        "firstBatch": null,
+                        "hydrate": false,
+                        "interactionThreadID": 15,
+                        "latestPendingTime": 0,
+                        "latestPingedTime": 0,
+                        "latestSuspendedTime": 0,
+                        "memoizedInteractions": Set {},
+                        "nextExpirationTimeToWorkOn": 0,
+                        "nextScheduledRoot": null,
+                        "pendingChildren": null,
+                        "pendingCommitExpirationTime": 0,
+                        "pendingContext": null,
+                        "pendingInteractionMap": Map {},
+                        "pingCache": null,
+                        "timeoutHandle": -1,
+                      },
+                      "tag": 3,
+                      "treeBaseDuration": 0,
+                      "type": null,
+                      "updateQueue": Object {
+                        "baseState": null,
+                        "firstCapturedEffect": null,
+                        "firstCapturedUpdate": null,
+                        "firstEffect": null,
+                        "firstUpdate": Object {
+                          "callback": null,
+                          "expirationTime": 1073741823,
+                          "next": null,
+                          "nextEffect": null,
+                          "payload": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={Object {}}
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "tag": 0,
+                        },
+                        "lastCapturedEffect": null,
+                        "lastCapturedUpdate": null,
+                        "lastEffect": null,
+                        "lastUpdate": Object {
+                          "callback": null,
+                          "expirationTime": 1073741823,
+                          "next": null,
+                          "nextEffect": null,
+                          "payload": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={Object {}}
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "tag": 0,
+                        },
+                      },
+                    },
+                    "child": [Circular],
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 32,
+                    "elementType": null,
+                    "expirationTime": 0,
+                    "firstEffect": [Circular],
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": [Circular],
+                    "memoizedProps": null,
+                    "memoizedState": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={Object {}}
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": null,
+                    "ref": null,
+                    "return": null,
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": Object {
+                      "containerInfo": <div>
+                        <div
+                          class="dashboard-card engagement"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Engagement Trends
+                          </div>
+                        </div>
+                        <div
+                          class="dashboard-card upselling"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Upselling Partners
+                          </div>
+                          <div>
+                            upselling component
+                          </div>
+                        </div>
+                      </div>,
+                      "context": Object {},
+                      "current": [Circular],
+                      "didError": false,
+                      "earliestPendingTime": 0,
+                      "earliestSuspendedTime": 0,
+                      "expirationTime": 0,
+                      "finishedWork": null,
+                      "firstBatch": null,
+                      "hydrate": false,
+                      "interactionThreadID": 15,
+                      "latestPendingTime": 0,
+                      "latestPingedTime": 0,
+                      "latestSuspendedTime": 0,
+                      "memoizedInteractions": Set {},
+                      "nextExpirationTimeToWorkOn": 0,
+                      "nextScheduledRoot": null,
+                      "pendingChildren": null,
+                      "pendingCommitExpirationTime": 0,
+                      "pendingContext": null,
+                      "pendingInteractionMap": Map {},
+                      "pingCache": null,
+                      "timeoutHandle": -1,
+                    },
+                    "tag": 3,
+                    "treeBaseDuration": 0,
+                    "type": null,
+                    "updateQueue": Object {
+                      "baseState": Object {
+                        "element": <WrapperComponent
+                          Component={[Function]}
+                          context={null}
+                          props={Object {}}
+                          wrappingComponentProps={null}
+                        />,
+                      },
+                      "firstCapturedEffect": null,
+                      "firstCapturedUpdate": null,
+                      "firstEffect": null,
+                      "firstUpdate": null,
+                      "lastCapturedEffect": null,
+                      "lastCapturedUpdate": null,
+                      "lastEffect": null,
+                      "lastUpdate": null,
+                    },
+                  },
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": WrapperComponent {
+                    "_reactInternalFiber": [Circular],
+                    "_reactInternalInstance": Object {},
+                    "context": Object {},
+                    "props": Object {
+                      "Component": [Function],
+                      "context": null,
+                      "props": Object {},
+                      "wrappingComponentProps": null,
+                    },
+                    "refs": Object {},
+                    "rootFinderInstance": null,
+                    "state": Object {
+                      "context": null,
+                      "mount": true,
+                      "props": Object {},
+                      "wrappingComponentProps": null,
+                    },
+                    "updater": Object {
+                      "enqueueForceUpdate": [Function],
+                      "enqueueReplaceState": [Function],
+                      "enqueueSetState": [Function],
+                      "isMounted": [Function],
+                    },
+                  },
+                  "tag": 1,
+                  "treeBaseDuration": 0,
+                  "type": [Function],
+                  "updateQueue": null,
+                },
+                "_debugSource": null,
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": null,
+                "child": [Circular],
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 1,
+                "elementType": [Function],
+                "expirationTime": 0,
+                "firstEffect": null,
+                "index": 0,
+                "key": null,
+                "lastEffect": null,
+                "memoizedProps": Object {},
+                "memoizedState": null,
+                "mode": 0,
+                "nextEffect": null,
+                "pendingProps": Object {},
+                "ref": null,
+                "return": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 62,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": null,
+                  "_debugSource": null,
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": null,
+                  "child": [Circular],
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 1,
+                  "elementType": [Function],
+                  "expirationTime": 0,
+                  "firstEffect": null,
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": null,
+                  "memoizedProps": Object {
+                    "Component": [Function],
+                    "context": null,
+                    "props": Object {},
+                    "wrappingComponentProps": null,
+                  },
+                  "memoizedState": Object {
+                    "context": null,
+                    "mount": true,
+                    "props": Object {},
+                    "wrappingComponentProps": null,
+                  },
+                  "mode": 0,
+                  "nextEffect": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 60,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": null,
+                    "_debugSource": null,
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": FiberNode {
+                      "_debugHookTypes": null,
+                      "_debugID": 60,
+                      "_debugIsCurrentlyTiming": false,
+                      "_debugOwner": null,
+                      "_debugSource": null,
+                      "actualDuration": 0,
+                      "actualStartTime": -1,
+                      "alternate": [Circular],
+                      "child": null,
+                      "childExpirationTime": 0,
+                      "contextDependencies": null,
+                      "effectTag": 0,
+                      "elementType": null,
+                      "expirationTime": 1073741823,
+                      "firstEffect": null,
+                      "index": 0,
+                      "key": null,
+                      "lastEffect": null,
+                      "memoizedProps": null,
+                      "memoizedState": null,
+                      "mode": 0,
+                      "nextEffect": null,
+                      "pendingProps": null,
+                      "ref": null,
+                      "return": null,
+                      "selfBaseDuration": 0,
+                      "sibling": null,
+                      "stateNode": Object {
+                        "containerInfo": <div>
+                          <div
+                            class="dashboard-card engagement"
+                          >
+                            <div
+                              class="title"
+                            >
+                              Engagement Trends
+                            </div>
+                          </div>
+                          <div
+                            class="dashboard-card upselling"
+                          >
+                            <div
+                              class="title"
+                            >
+                              Upselling Partners
+                            </div>
+                            <div>
+                              upselling component
+                            </div>
+                          </div>
+                        </div>,
+                        "context": Object {},
+                        "current": [Circular],
+                        "didError": false,
+                        "earliestPendingTime": 0,
+                        "earliestSuspendedTime": 0,
+                        "expirationTime": 0,
+                        "finishedWork": null,
+                        "firstBatch": null,
+                        "hydrate": false,
+                        "interactionThreadID": 15,
+                        "latestPendingTime": 0,
+                        "latestPingedTime": 0,
+                        "latestSuspendedTime": 0,
+                        "memoizedInteractions": Set {},
+                        "nextExpirationTimeToWorkOn": 0,
+                        "nextScheduledRoot": null,
+                        "pendingChildren": null,
+                        "pendingCommitExpirationTime": 0,
+                        "pendingContext": null,
+                        "pendingInteractionMap": Map {},
+                        "pingCache": null,
+                        "timeoutHandle": -1,
+                      },
+                      "tag": 3,
+                      "treeBaseDuration": 0,
+                      "type": null,
+                      "updateQueue": Object {
+                        "baseState": null,
+                        "firstCapturedEffect": null,
+                        "firstCapturedUpdate": null,
+                        "firstEffect": null,
+                        "firstUpdate": Object {
+                          "callback": null,
+                          "expirationTime": 1073741823,
+                          "next": null,
+                          "nextEffect": null,
+                          "payload": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={Object {}}
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "tag": 0,
+                        },
+                        "lastCapturedEffect": null,
+                        "lastCapturedUpdate": null,
+                        "lastEffect": null,
+                        "lastUpdate": Object {
+                          "callback": null,
+                          "expirationTime": 1073741823,
+                          "next": null,
+                          "nextEffect": null,
+                          "payload": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={Object {}}
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "tag": 0,
+                        },
+                      },
+                    },
+                    "child": [Circular],
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 32,
+                    "elementType": null,
+                    "expirationTime": 0,
+                    "firstEffect": [Circular],
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": [Circular],
+                    "memoizedProps": null,
+                    "memoizedState": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={Object {}}
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": null,
+                    "ref": null,
+                    "return": null,
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": Object {
+                      "containerInfo": <div>
+                        <div
+                          class="dashboard-card engagement"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Engagement Trends
+                          </div>
+                        </div>
+                        <div
+                          class="dashboard-card upselling"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Upselling Partners
+                          </div>
+                          <div>
+                            upselling component
+                          </div>
+                        </div>
+                      </div>,
+                      "context": Object {},
+                      "current": [Circular],
+                      "didError": false,
+                      "earliestPendingTime": 0,
+                      "earliestSuspendedTime": 0,
+                      "expirationTime": 0,
+                      "finishedWork": null,
+                      "firstBatch": null,
+                      "hydrate": false,
+                      "interactionThreadID": 15,
+                      "latestPendingTime": 0,
+                      "latestPingedTime": 0,
+                      "latestSuspendedTime": 0,
+                      "memoizedInteractions": Set {},
+                      "nextExpirationTimeToWorkOn": 0,
+                      "nextScheduledRoot": null,
+                      "pendingChildren": null,
+                      "pendingCommitExpirationTime": 0,
+                      "pendingContext": null,
+                      "pendingInteractionMap": Map {},
+                      "pingCache": null,
+                      "timeoutHandle": -1,
+                    },
+                    "tag": 3,
+                    "treeBaseDuration": 0,
+                    "type": null,
+                    "updateQueue": Object {
+                      "baseState": Object {
+                        "element": <WrapperComponent
+                          Component={[Function]}
+                          context={null}
+                          props={Object {}}
+                          wrappingComponentProps={null}
+                        />,
+                      },
+                      "firstCapturedEffect": null,
+                      "firstCapturedUpdate": null,
+                      "firstEffect": null,
+                      "firstUpdate": null,
+                      "lastCapturedEffect": null,
+                      "lastCapturedUpdate": null,
+                      "lastEffect": null,
+                      "lastUpdate": null,
+                    },
+                  },
+                  "pendingProps": Object {
+                    "Component": [Function],
+                    "context": null,
+                    "props": Object {},
+                    "wrappingComponentProps": null,
+                  },
+                  "ref": null,
+                  "return": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 60,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": null,
+                    "_debugSource": null,
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": FiberNode {
+                      "_debugHookTypes": null,
+                      "_debugID": 60,
+                      "_debugIsCurrentlyTiming": false,
+                      "_debugOwner": null,
+                      "_debugSource": null,
+                      "actualDuration": 0,
+                      "actualStartTime": -1,
+                      "alternate": [Circular],
+                      "child": null,
+                      "childExpirationTime": 0,
+                      "contextDependencies": null,
+                      "effectTag": 0,
+                      "elementType": null,
+                      "expirationTime": 1073741823,
+                      "firstEffect": null,
+                      "index": 0,
+                      "key": null,
+                      "lastEffect": null,
+                      "memoizedProps": null,
+                      "memoizedState": null,
+                      "mode": 0,
+                      "nextEffect": null,
+                      "pendingProps": null,
+                      "ref": null,
+                      "return": null,
+                      "selfBaseDuration": 0,
+                      "sibling": null,
+                      "stateNode": Object {
+                        "containerInfo": <div>
+                          <div
+                            class="dashboard-card engagement"
+                          >
+                            <div
+                              class="title"
+                            >
+                              Engagement Trends
+                            </div>
+                          </div>
+                          <div
+                            class="dashboard-card upselling"
+                          >
+                            <div
+                              class="title"
+                            >
+                              Upselling Partners
+                            </div>
+                            <div>
+                              upselling component
+                            </div>
+                          </div>
+                        </div>,
+                        "context": Object {},
+                        "current": [Circular],
+                        "didError": false,
+                        "earliestPendingTime": 0,
+                        "earliestSuspendedTime": 0,
+                        "expirationTime": 0,
+                        "finishedWork": null,
+                        "firstBatch": null,
+                        "hydrate": false,
+                        "interactionThreadID": 15,
+                        "latestPendingTime": 0,
+                        "latestPingedTime": 0,
+                        "latestSuspendedTime": 0,
+                        "memoizedInteractions": Set {},
+                        "nextExpirationTimeToWorkOn": 0,
+                        "nextScheduledRoot": null,
+                        "pendingChildren": null,
+                        "pendingCommitExpirationTime": 0,
+                        "pendingContext": null,
+                        "pendingInteractionMap": Map {},
+                        "pingCache": null,
+                        "timeoutHandle": -1,
+                      },
+                      "tag": 3,
+                      "treeBaseDuration": 0,
+                      "type": null,
+                      "updateQueue": Object {
+                        "baseState": null,
+                        "firstCapturedEffect": null,
+                        "firstCapturedUpdate": null,
+                        "firstEffect": null,
+                        "firstUpdate": Object {
+                          "callback": null,
+                          "expirationTime": 1073741823,
+                          "next": null,
+                          "nextEffect": null,
+                          "payload": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={Object {}}
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "tag": 0,
+                        },
+                        "lastCapturedEffect": null,
+                        "lastCapturedUpdate": null,
+                        "lastEffect": null,
+                        "lastUpdate": Object {
+                          "callback": null,
+                          "expirationTime": 1073741823,
+                          "next": null,
+                          "nextEffect": null,
+                          "payload": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={Object {}}
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "tag": 0,
+                        },
+                      },
+                    },
+                    "child": [Circular],
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 32,
+                    "elementType": null,
+                    "expirationTime": 0,
+                    "firstEffect": [Circular],
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": [Circular],
+                    "memoizedProps": null,
+                    "memoizedState": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={Object {}}
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": null,
+                    "ref": null,
+                    "return": null,
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": Object {
+                      "containerInfo": <div>
+                        <div
+                          class="dashboard-card engagement"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Engagement Trends
+                          </div>
+                        </div>
+                        <div
+                          class="dashboard-card upselling"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Upselling Partners
+                          </div>
+                          <div>
+                            upselling component
+                          </div>
+                        </div>
+                      </div>,
+                      "context": Object {},
+                      "current": [Circular],
+                      "didError": false,
+                      "earliestPendingTime": 0,
+                      "earliestSuspendedTime": 0,
+                      "expirationTime": 0,
+                      "finishedWork": null,
+                      "firstBatch": null,
+                      "hydrate": false,
+                      "interactionThreadID": 15,
+                      "latestPendingTime": 0,
+                      "latestPingedTime": 0,
+                      "latestSuspendedTime": 0,
+                      "memoizedInteractions": Set {},
+                      "nextExpirationTimeToWorkOn": 0,
+                      "nextScheduledRoot": null,
+                      "pendingChildren": null,
+                      "pendingCommitExpirationTime": 0,
+                      "pendingContext": null,
+                      "pendingInteractionMap": Map {},
+                      "pingCache": null,
+                      "timeoutHandle": -1,
+                    },
+                    "tag": 3,
+                    "treeBaseDuration": 0,
+                    "type": null,
+                    "updateQueue": Object {
+                      "baseState": Object {
+                        "element": <WrapperComponent
+                          Component={[Function]}
+                          context={null}
+                          props={Object {}}
+                          wrappingComponentProps={null}
+                        />,
+                      },
+                      "firstCapturedEffect": null,
+                      "firstCapturedUpdate": null,
+                      "firstEffect": null,
+                      "firstUpdate": null,
+                      "lastCapturedEffect": null,
+                      "lastCapturedUpdate": null,
+                      "lastEffect": null,
+                      "lastUpdate": null,
+                    },
+                  },
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": WrapperComponent {
+                    "_reactInternalFiber": [Circular],
+                    "_reactInternalInstance": Object {},
+                    "context": Object {},
+                    "props": Object {
+                      "Component": [Function],
+                      "context": null,
+                      "props": Object {},
+                      "wrappingComponentProps": null,
+                    },
+                    "refs": Object {},
+                    "rootFinderInstance": null,
+                    "state": Object {
+                      "context": null,
+                      "mount": true,
+                      "props": Object {},
+                      "wrappingComponentProps": null,
+                    },
+                    "updater": Object {
+                      "enqueueForceUpdate": [Function],
+                      "enqueueReplaceState": [Function],
+                      "enqueueSetState": [Function],
+                      "isMounted": [Function],
+                    },
+                  },
+                  "tag": 1,
+                  "treeBaseDuration": 0,
+                  "type": [Function],
+                  "updateQueue": null,
+                },
+                "selfBaseDuration": 0,
+                "sibling": null,
+                "stateNode": Dashboard {
+                  "_reactInternalFiber": [Circular],
+                  "_reactInternalInstance": Object {},
+                  "context": Object {},
+                  "props": Object {},
+                  "refs": Object {},
+                  "renderUpselling": [Function],
+                  "state": null,
+                  "updater": Object {
+                    "enqueueForceUpdate": [Function],
+                    "enqueueReplaceState": [Function],
+                    "enqueueSetState": [Function],
+                    "isMounted": [Function],
+                  },
+                },
+                "tag": 1,
+                "treeBaseDuration": 0,
+                "type": [Function],
+                "updateQueue": null,
+              },
+              "_debugSource": Object {
+                "fileName": "/Users/kevinkoech/Documents/bp-esa-frontend/src/components/Dashboard/index.jsx",
+                "lineNumber": 28,
+              },
+              "actualDuration": 0,
+              "actualStartTime": -1,
+              "alternate": null,
+              "child": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 68,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": [Circular],
+                "_debugSource": Object {
+                  "fileName": "/Users/kevinkoech/Documents/bp-esa-frontend/src/components/Dashboard/Card.jsx",
+                  "lineNumber": 20,
+                },
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": null,
+                "child": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 69,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": [Circular],
+                  "_debugSource": Object {
+                    "fileName": "/Users/kevinkoech/Documents/bp-esa-frontend/src/components/Dashboard/Card.jsx",
+                    "lineNumber": 21,
+                  },
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": null,
+                  "child": null,
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 0,
+                  "elementType": "div",
+                  "expirationTime": 0,
+                  "firstEffect": null,
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": null,
+                  "memoizedProps": Object {
+                    "children": "Upselling Partners",
+                    "className": "title",
+                  },
+                  "memoizedState": null,
+                  "mode": 0,
+                  "nextEffect": null,
+                  "pendingProps": Object {
+                    "children": "Upselling Partners",
+                    "className": "title",
+                  },
+                  "ref": null,
+                  "return": [Circular],
+                  "selfBaseDuration": 0,
+                  "sibling": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 70,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": [Circular],
+                    "_debugSource": Object {
+                      "fileName": "/Users/kevinkoech/Documents/bp-esa-frontend/src/components/Dashboard/index.jsx",
+                      "lineNumber": 15,
+                    },
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": null,
+                    "child": null,
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 0,
+                    "elementType": "div",
+                    "expirationTime": 0,
+                    "firstEffect": null,
+                    "index": 1,
+                    "key": null,
+                    "lastEffect": null,
+                    "memoizedProps": Object {
+                      "children": "upselling component",
+                    },
+                    "memoizedState": null,
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": Object {
+                      "children": "upselling component",
+                    },
+                    "ref": null,
+                    "return": [Circular],
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": <div>
+                      upselling component
+                    </div>,
+                    "tag": 5,
+                    "treeBaseDuration": 0,
+                    "type": "div",
+                    "updateQueue": null,
+                  },
+                  "stateNode": <div
+                    class="title"
+                  >
+                    Upselling Partners
+                  </div>,
+                  "tag": 5,
+                  "treeBaseDuration": 0,
+                  "type": "div",
+                  "updateQueue": null,
+                },
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 0,
+                "elementType": "div",
+                "expirationTime": 0,
+                "firstEffect": null,
+                "index": 0,
+                "key": null,
+                "lastEffect": null,
+                "memoizedProps": Object {
+                  "children": Array [
+                    <div
+                      className="title"
+                    >
+                      Upselling Partners
+                    </div>,
+                    <div>
+                      upselling component
+                    </div>,
+                  ],
+                  "className": "dashboard-card upselling",
+                },
+                "memoizedState": null,
+                "mode": 0,
+                "nextEffect": null,
+                "pendingProps": Object {
+                  "children": Array [
+                    <div
+                      className="title"
+                    >
+                      Upselling Partners
+                    </div>,
+                    <div>
+                      upselling component
+                    </div>,
+                  ],
+                  "className": "dashboard-card upselling",
+                },
+                "ref": null,
+                "return": [Circular],
+                "selfBaseDuration": 0,
+                "sibling": null,
+                "stateNode": <div
+                  class="dashboard-card upselling"
+                >
+                  <div
+                    class="title"
+                  >
+                    Upselling Partners
+                  </div>
+                  <div>
+                    upselling component
+                  </div>
+                </div>,
+                "tag": 5,
+                "treeBaseDuration": 0,
+                "type": "div",
+                "updateQueue": null,
+              },
+              "childExpirationTime": 0,
+              "contextDependencies": null,
+              "effectTag": 1,
+              "elementType": [Function],
+              "expirationTime": 0,
+              "firstEffect": null,
+              "index": 1,
+              "key": null,
+              "lastEffect": null,
+              "memoizedProps": Object {
+                "classes": "upselling",
+                "component": [Function],
+                "title": "Upselling Partners",
+              },
+              "memoizedState": null,
+              "mode": 0,
+              "nextEffect": null,
+              "pendingProps": Object {
+                "classes": "upselling",
+                "component": [Function],
+                "title": "Upselling Partners",
+              },
+              "ref": null,
+              "return": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 63,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 62,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": null,
+                  "_debugSource": null,
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": null,
+                  "child": [Circular],
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 1,
+                  "elementType": [Function],
+                  "expirationTime": 0,
+                  "firstEffect": null,
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": null,
+                  "memoizedProps": Object {
+                    "Component": [Function],
+                    "context": null,
+                    "props": Object {},
+                    "wrappingComponentProps": null,
+                  },
+                  "memoizedState": Object {
+                    "context": null,
+                    "mount": true,
+                    "props": Object {},
+                    "wrappingComponentProps": null,
+                  },
+                  "mode": 0,
+                  "nextEffect": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 60,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": null,
+                    "_debugSource": null,
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": FiberNode {
+                      "_debugHookTypes": null,
+                      "_debugID": 60,
+                      "_debugIsCurrentlyTiming": false,
+                      "_debugOwner": null,
+                      "_debugSource": null,
+                      "actualDuration": 0,
+                      "actualStartTime": -1,
+                      "alternate": [Circular],
+                      "child": null,
+                      "childExpirationTime": 0,
+                      "contextDependencies": null,
+                      "effectTag": 0,
+                      "elementType": null,
+                      "expirationTime": 1073741823,
+                      "firstEffect": null,
+                      "index": 0,
+                      "key": null,
+                      "lastEffect": null,
+                      "memoizedProps": null,
+                      "memoizedState": null,
+                      "mode": 0,
+                      "nextEffect": null,
+                      "pendingProps": null,
+                      "ref": null,
+                      "return": null,
+                      "selfBaseDuration": 0,
+                      "sibling": null,
+                      "stateNode": Object {
+                        "containerInfo": <div>
+                          <div
+                            class="dashboard-card engagement"
+                          >
+                            <div
+                              class="title"
+                            >
+                              Engagement Trends
+                            </div>
+                          </div>
+                          <div
+                            class="dashboard-card upselling"
+                          >
+                            <div
+                              class="title"
+                            >
+                              Upselling Partners
+                            </div>
+                            <div>
+                              upselling component
+                            </div>
+                          </div>
+                        </div>,
+                        "context": Object {},
+                        "current": [Circular],
+                        "didError": false,
+                        "earliestPendingTime": 0,
+                        "earliestSuspendedTime": 0,
+                        "expirationTime": 0,
+                        "finishedWork": null,
+                        "firstBatch": null,
+                        "hydrate": false,
+                        "interactionThreadID": 15,
+                        "latestPendingTime": 0,
+                        "latestPingedTime": 0,
+                        "latestSuspendedTime": 0,
+                        "memoizedInteractions": Set {},
+                        "nextExpirationTimeToWorkOn": 0,
+                        "nextScheduledRoot": null,
+                        "pendingChildren": null,
+                        "pendingCommitExpirationTime": 0,
+                        "pendingContext": null,
+                        "pendingInteractionMap": Map {},
+                        "pingCache": null,
+                        "timeoutHandle": -1,
+                      },
+                      "tag": 3,
+                      "treeBaseDuration": 0,
+                      "type": null,
+                      "updateQueue": Object {
+                        "baseState": null,
+                        "firstCapturedEffect": null,
+                        "firstCapturedUpdate": null,
+                        "firstEffect": null,
+                        "firstUpdate": Object {
+                          "callback": null,
+                          "expirationTime": 1073741823,
+                          "next": null,
+                          "nextEffect": null,
+                          "payload": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={Object {}}
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "tag": 0,
+                        },
+                        "lastCapturedEffect": null,
+                        "lastCapturedUpdate": null,
+                        "lastEffect": null,
+                        "lastUpdate": Object {
+                          "callback": null,
+                          "expirationTime": 1073741823,
+                          "next": null,
+                          "nextEffect": null,
+                          "payload": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={Object {}}
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "tag": 0,
+                        },
+                      },
+                    },
+                    "child": [Circular],
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 32,
+                    "elementType": null,
+                    "expirationTime": 0,
+                    "firstEffect": [Circular],
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": [Circular],
+                    "memoizedProps": null,
+                    "memoizedState": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={Object {}}
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": null,
+                    "ref": null,
+                    "return": null,
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": Object {
+                      "containerInfo": <div>
+                        <div
+                          class="dashboard-card engagement"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Engagement Trends
+                          </div>
+                        </div>
+                        <div
+                          class="dashboard-card upselling"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Upselling Partners
+                          </div>
+                          <div>
+                            upselling component
+                          </div>
+                        </div>
+                      </div>,
+                      "context": Object {},
+                      "current": [Circular],
+                      "didError": false,
+                      "earliestPendingTime": 0,
+                      "earliestSuspendedTime": 0,
+                      "expirationTime": 0,
+                      "finishedWork": null,
+                      "firstBatch": null,
+                      "hydrate": false,
+                      "interactionThreadID": 15,
+                      "latestPendingTime": 0,
+                      "latestPingedTime": 0,
+                      "latestSuspendedTime": 0,
+                      "memoizedInteractions": Set {},
+                      "nextExpirationTimeToWorkOn": 0,
+                      "nextScheduledRoot": null,
+                      "pendingChildren": null,
+                      "pendingCommitExpirationTime": 0,
+                      "pendingContext": null,
+                      "pendingInteractionMap": Map {},
+                      "pingCache": null,
+                      "timeoutHandle": -1,
+                    },
+                    "tag": 3,
+                    "treeBaseDuration": 0,
+                    "type": null,
+                    "updateQueue": Object {
+                      "baseState": Object {
+                        "element": <WrapperComponent
+                          Component={[Function]}
+                          context={null}
+                          props={Object {}}
+                          wrappingComponentProps={null}
+                        />,
+                      },
+                      "firstCapturedEffect": null,
+                      "firstCapturedUpdate": null,
+                      "firstEffect": null,
+                      "firstUpdate": null,
+                      "lastCapturedEffect": null,
+                      "lastCapturedUpdate": null,
+                      "lastEffect": null,
+                      "lastUpdate": null,
+                    },
+                  },
+                  "pendingProps": Object {
+                    "Component": [Function],
+                    "context": null,
+                    "props": Object {},
+                    "wrappingComponentProps": null,
+                  },
+                  "ref": null,
+                  "return": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 60,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": null,
+                    "_debugSource": null,
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": FiberNode {
+                      "_debugHookTypes": null,
+                      "_debugID": 60,
+                      "_debugIsCurrentlyTiming": false,
+                      "_debugOwner": null,
+                      "_debugSource": null,
+                      "actualDuration": 0,
+                      "actualStartTime": -1,
+                      "alternate": [Circular],
+                      "child": null,
+                      "childExpirationTime": 0,
+                      "contextDependencies": null,
+                      "effectTag": 0,
+                      "elementType": null,
+                      "expirationTime": 1073741823,
+                      "firstEffect": null,
+                      "index": 0,
+                      "key": null,
+                      "lastEffect": null,
+                      "memoizedProps": null,
+                      "memoizedState": null,
+                      "mode": 0,
+                      "nextEffect": null,
+                      "pendingProps": null,
+                      "ref": null,
+                      "return": null,
+                      "selfBaseDuration": 0,
+                      "sibling": null,
+                      "stateNode": Object {
+                        "containerInfo": <div>
+                          <div
+                            class="dashboard-card engagement"
+                          >
+                            <div
+                              class="title"
+                            >
+                              Engagement Trends
+                            </div>
+                          </div>
+                          <div
+                            class="dashboard-card upselling"
+                          >
+                            <div
+                              class="title"
+                            >
+                              Upselling Partners
+                            </div>
+                            <div>
+                              upselling component
+                            </div>
+                          </div>
+                        </div>,
+                        "context": Object {},
+                        "current": [Circular],
+                        "didError": false,
+                        "earliestPendingTime": 0,
+                        "earliestSuspendedTime": 0,
+                        "expirationTime": 0,
+                        "finishedWork": null,
+                        "firstBatch": null,
+                        "hydrate": false,
+                        "interactionThreadID": 15,
+                        "latestPendingTime": 0,
+                        "latestPingedTime": 0,
+                        "latestSuspendedTime": 0,
+                        "memoizedInteractions": Set {},
+                        "nextExpirationTimeToWorkOn": 0,
+                        "nextScheduledRoot": null,
+                        "pendingChildren": null,
+                        "pendingCommitExpirationTime": 0,
+                        "pendingContext": null,
+                        "pendingInteractionMap": Map {},
+                        "pingCache": null,
+                        "timeoutHandle": -1,
+                      },
+                      "tag": 3,
+                      "treeBaseDuration": 0,
+                      "type": null,
+                      "updateQueue": Object {
+                        "baseState": null,
+                        "firstCapturedEffect": null,
+                        "firstCapturedUpdate": null,
+                        "firstEffect": null,
+                        "firstUpdate": Object {
+                          "callback": null,
+                          "expirationTime": 1073741823,
+                          "next": null,
+                          "nextEffect": null,
+                          "payload": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={Object {}}
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "tag": 0,
+                        },
+                        "lastCapturedEffect": null,
+                        "lastCapturedUpdate": null,
+                        "lastEffect": null,
+                        "lastUpdate": Object {
+                          "callback": null,
+                          "expirationTime": 1073741823,
+                          "next": null,
+                          "nextEffect": null,
+                          "payload": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={Object {}}
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "tag": 0,
+                        },
+                      },
+                    },
+                    "child": [Circular],
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 32,
+                    "elementType": null,
+                    "expirationTime": 0,
+                    "firstEffect": [Circular],
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": [Circular],
+                    "memoizedProps": null,
+                    "memoizedState": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={Object {}}
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": null,
+                    "ref": null,
+                    "return": null,
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": Object {
+                      "containerInfo": <div>
+                        <div
+                          class="dashboard-card engagement"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Engagement Trends
+                          </div>
+                        </div>
+                        <div
+                          class="dashboard-card upselling"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Upselling Partners
+                          </div>
+                          <div>
+                            upselling component
+                          </div>
+                        </div>
+                      </div>,
+                      "context": Object {},
+                      "current": [Circular],
+                      "didError": false,
+                      "earliestPendingTime": 0,
+                      "earliestSuspendedTime": 0,
+                      "expirationTime": 0,
+                      "finishedWork": null,
+                      "firstBatch": null,
+                      "hydrate": false,
+                      "interactionThreadID": 15,
+                      "latestPendingTime": 0,
+                      "latestPingedTime": 0,
+                      "latestSuspendedTime": 0,
+                      "memoizedInteractions": Set {},
+                      "nextExpirationTimeToWorkOn": 0,
+                      "nextScheduledRoot": null,
+                      "pendingChildren": null,
+                      "pendingCommitExpirationTime": 0,
+                      "pendingContext": null,
+                      "pendingInteractionMap": Map {},
+                      "pingCache": null,
+                      "timeoutHandle": -1,
+                    },
+                    "tag": 3,
+                    "treeBaseDuration": 0,
+                    "type": null,
+                    "updateQueue": Object {
+                      "baseState": Object {
+                        "element": <WrapperComponent
+                          Component={[Function]}
+                          context={null}
+                          props={Object {}}
+                          wrappingComponentProps={null}
+                        />,
+                      },
+                      "firstCapturedEffect": null,
+                      "firstCapturedUpdate": null,
+                      "firstEffect": null,
+                      "firstUpdate": null,
+                      "lastCapturedEffect": null,
+                      "lastCapturedUpdate": null,
+                      "lastEffect": null,
+                      "lastUpdate": null,
+                    },
+                  },
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": WrapperComponent {
+                    "_reactInternalFiber": [Circular],
+                    "_reactInternalInstance": Object {},
+                    "context": Object {},
+                    "props": Object {
+                      "Component": [Function],
+                      "context": null,
+                      "props": Object {},
+                      "wrappingComponentProps": null,
+                    },
+                    "refs": Object {},
+                    "rootFinderInstance": null,
+                    "state": Object {
+                      "context": null,
+                      "mount": true,
+                      "props": Object {},
+                      "wrappingComponentProps": null,
+                    },
+                    "updater": Object {
+                      "enqueueForceUpdate": [Function],
+                      "enqueueReplaceState": [Function],
+                      "enqueueSetState": [Function],
+                      "isMounted": [Function],
+                    },
+                  },
+                  "tag": 1,
+                  "treeBaseDuration": 0,
+                  "type": [Function],
+                  "updateQueue": null,
+                },
+                "_debugSource": null,
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": null,
+                "child": [Circular],
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 1,
+                "elementType": [Function],
+                "expirationTime": 0,
+                "firstEffect": null,
+                "index": 0,
+                "key": null,
+                "lastEffect": null,
+                "memoizedProps": Object {},
+                "memoizedState": null,
+                "mode": 0,
+                "nextEffect": null,
+                "pendingProps": Object {},
+                "ref": null,
+                "return": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 62,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": null,
+                  "_debugSource": null,
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": null,
+                  "child": [Circular],
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 1,
+                  "elementType": [Function],
+                  "expirationTime": 0,
+                  "firstEffect": null,
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": null,
+                  "memoizedProps": Object {
+                    "Component": [Function],
+                    "context": null,
+                    "props": Object {},
+                    "wrappingComponentProps": null,
+                  },
+                  "memoizedState": Object {
+                    "context": null,
+                    "mount": true,
+                    "props": Object {},
+                    "wrappingComponentProps": null,
+                  },
+                  "mode": 0,
+                  "nextEffect": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 60,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": null,
+                    "_debugSource": null,
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": FiberNode {
+                      "_debugHookTypes": null,
+                      "_debugID": 60,
+                      "_debugIsCurrentlyTiming": false,
+                      "_debugOwner": null,
+                      "_debugSource": null,
+                      "actualDuration": 0,
+                      "actualStartTime": -1,
+                      "alternate": [Circular],
+                      "child": null,
+                      "childExpirationTime": 0,
+                      "contextDependencies": null,
+                      "effectTag": 0,
+                      "elementType": null,
+                      "expirationTime": 1073741823,
+                      "firstEffect": null,
+                      "index": 0,
+                      "key": null,
+                      "lastEffect": null,
+                      "memoizedProps": null,
+                      "memoizedState": null,
+                      "mode": 0,
+                      "nextEffect": null,
+                      "pendingProps": null,
+                      "ref": null,
+                      "return": null,
+                      "selfBaseDuration": 0,
+                      "sibling": null,
+                      "stateNode": Object {
+                        "containerInfo": <div>
+                          <div
+                            class="dashboard-card engagement"
+                          >
+                            <div
+                              class="title"
+                            >
+                              Engagement Trends
+                            </div>
+                          </div>
+                          <div
+                            class="dashboard-card upselling"
+                          >
+                            <div
+                              class="title"
+                            >
+                              Upselling Partners
+                            </div>
+                            <div>
+                              upselling component
+                            </div>
+                          </div>
+                        </div>,
+                        "context": Object {},
+                        "current": [Circular],
+                        "didError": false,
+                        "earliestPendingTime": 0,
+                        "earliestSuspendedTime": 0,
+                        "expirationTime": 0,
+                        "finishedWork": null,
+                        "firstBatch": null,
+                        "hydrate": false,
+                        "interactionThreadID": 15,
+                        "latestPendingTime": 0,
+                        "latestPingedTime": 0,
+                        "latestSuspendedTime": 0,
+                        "memoizedInteractions": Set {},
+                        "nextExpirationTimeToWorkOn": 0,
+                        "nextScheduledRoot": null,
+                        "pendingChildren": null,
+                        "pendingCommitExpirationTime": 0,
+                        "pendingContext": null,
+                        "pendingInteractionMap": Map {},
+                        "pingCache": null,
+                        "timeoutHandle": -1,
+                      },
+                      "tag": 3,
+                      "treeBaseDuration": 0,
+                      "type": null,
+                      "updateQueue": Object {
+                        "baseState": null,
+                        "firstCapturedEffect": null,
+                        "firstCapturedUpdate": null,
+                        "firstEffect": null,
+                        "firstUpdate": Object {
+                          "callback": null,
+                          "expirationTime": 1073741823,
+                          "next": null,
+                          "nextEffect": null,
+                          "payload": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={Object {}}
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "tag": 0,
+                        },
+                        "lastCapturedEffect": null,
+                        "lastCapturedUpdate": null,
+                        "lastEffect": null,
+                        "lastUpdate": Object {
+                          "callback": null,
+                          "expirationTime": 1073741823,
+                          "next": null,
+                          "nextEffect": null,
+                          "payload": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={Object {}}
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "tag": 0,
+                        },
+                      },
+                    },
+                    "child": [Circular],
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 32,
+                    "elementType": null,
+                    "expirationTime": 0,
+                    "firstEffect": [Circular],
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": [Circular],
+                    "memoizedProps": null,
+                    "memoizedState": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={Object {}}
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": null,
+                    "ref": null,
+                    "return": null,
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": Object {
+                      "containerInfo": <div>
+                        <div
+                          class="dashboard-card engagement"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Engagement Trends
+                          </div>
+                        </div>
+                        <div
+                          class="dashboard-card upselling"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Upselling Partners
+                          </div>
+                          <div>
+                            upselling component
+                          </div>
+                        </div>
+                      </div>,
+                      "context": Object {},
+                      "current": [Circular],
+                      "didError": false,
+                      "earliestPendingTime": 0,
+                      "earliestSuspendedTime": 0,
+                      "expirationTime": 0,
+                      "finishedWork": null,
+                      "firstBatch": null,
+                      "hydrate": false,
+                      "interactionThreadID": 15,
+                      "latestPendingTime": 0,
+                      "latestPingedTime": 0,
+                      "latestSuspendedTime": 0,
+                      "memoizedInteractions": Set {},
+                      "nextExpirationTimeToWorkOn": 0,
+                      "nextScheduledRoot": null,
+                      "pendingChildren": null,
+                      "pendingCommitExpirationTime": 0,
+                      "pendingContext": null,
+                      "pendingInteractionMap": Map {},
+                      "pingCache": null,
+                      "timeoutHandle": -1,
+                    },
+                    "tag": 3,
+                    "treeBaseDuration": 0,
+                    "type": null,
+                    "updateQueue": Object {
+                      "baseState": Object {
+                        "element": <WrapperComponent
+                          Component={[Function]}
+                          context={null}
+                          props={Object {}}
+                          wrappingComponentProps={null}
+                        />,
+                      },
+                      "firstCapturedEffect": null,
+                      "firstCapturedUpdate": null,
+                      "firstEffect": null,
+                      "firstUpdate": null,
+                      "lastCapturedEffect": null,
+                      "lastCapturedUpdate": null,
+                      "lastEffect": null,
+                      "lastUpdate": null,
+                    },
+                  },
+                  "pendingProps": Object {
+                    "Component": [Function],
+                    "context": null,
+                    "props": Object {},
+                    "wrappingComponentProps": null,
+                  },
+                  "ref": null,
+                  "return": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 60,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": null,
+                    "_debugSource": null,
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": FiberNode {
+                      "_debugHookTypes": null,
+                      "_debugID": 60,
+                      "_debugIsCurrentlyTiming": false,
+                      "_debugOwner": null,
+                      "_debugSource": null,
+                      "actualDuration": 0,
+                      "actualStartTime": -1,
+                      "alternate": [Circular],
+                      "child": null,
+                      "childExpirationTime": 0,
+                      "contextDependencies": null,
+                      "effectTag": 0,
+                      "elementType": null,
+                      "expirationTime": 1073741823,
+                      "firstEffect": null,
+                      "index": 0,
+                      "key": null,
+                      "lastEffect": null,
+                      "memoizedProps": null,
+                      "memoizedState": null,
+                      "mode": 0,
+                      "nextEffect": null,
+                      "pendingProps": null,
+                      "ref": null,
+                      "return": null,
+                      "selfBaseDuration": 0,
+                      "sibling": null,
+                      "stateNode": Object {
+                        "containerInfo": <div>
+                          <div
+                            class="dashboard-card engagement"
+                          >
+                            <div
+                              class="title"
+                            >
+                              Engagement Trends
+                            </div>
+                          </div>
+                          <div
+                            class="dashboard-card upselling"
+                          >
+                            <div
+                              class="title"
+                            >
+                              Upselling Partners
+                            </div>
+                            <div>
+                              upselling component
+                            </div>
+                          </div>
+                        </div>,
+                        "context": Object {},
+                        "current": [Circular],
+                        "didError": false,
+                        "earliestPendingTime": 0,
+                        "earliestSuspendedTime": 0,
+                        "expirationTime": 0,
+                        "finishedWork": null,
+                        "firstBatch": null,
+                        "hydrate": false,
+                        "interactionThreadID": 15,
+                        "latestPendingTime": 0,
+                        "latestPingedTime": 0,
+                        "latestSuspendedTime": 0,
+                        "memoizedInteractions": Set {},
+                        "nextExpirationTimeToWorkOn": 0,
+                        "nextScheduledRoot": null,
+                        "pendingChildren": null,
+                        "pendingCommitExpirationTime": 0,
+                        "pendingContext": null,
+                        "pendingInteractionMap": Map {},
+                        "pingCache": null,
+                        "timeoutHandle": -1,
+                      },
+                      "tag": 3,
+                      "treeBaseDuration": 0,
+                      "type": null,
+                      "updateQueue": Object {
+                        "baseState": null,
+                        "firstCapturedEffect": null,
+                        "firstCapturedUpdate": null,
+                        "firstEffect": null,
+                        "firstUpdate": Object {
+                          "callback": null,
+                          "expirationTime": 1073741823,
+                          "next": null,
+                          "nextEffect": null,
+                          "payload": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={Object {}}
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "tag": 0,
+                        },
+                        "lastCapturedEffect": null,
+                        "lastCapturedUpdate": null,
+                        "lastEffect": null,
+                        "lastUpdate": Object {
+                          "callback": null,
+                          "expirationTime": 1073741823,
+                          "next": null,
+                          "nextEffect": null,
+                          "payload": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={Object {}}
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "tag": 0,
+                        },
+                      },
+                    },
+                    "child": [Circular],
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 32,
+                    "elementType": null,
+                    "expirationTime": 0,
+                    "firstEffect": [Circular],
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": [Circular],
+                    "memoizedProps": null,
+                    "memoizedState": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={Object {}}
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": null,
+                    "ref": null,
+                    "return": null,
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": Object {
+                      "containerInfo": <div>
+                        <div
+                          class="dashboard-card engagement"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Engagement Trends
+                          </div>
+                        </div>
+                        <div
+                          class="dashboard-card upselling"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Upselling Partners
+                          </div>
+                          <div>
+                            upselling component
+                          </div>
+                        </div>
+                      </div>,
+                      "context": Object {},
+                      "current": [Circular],
+                      "didError": false,
+                      "earliestPendingTime": 0,
+                      "earliestSuspendedTime": 0,
+                      "expirationTime": 0,
+                      "finishedWork": null,
+                      "firstBatch": null,
+                      "hydrate": false,
+                      "interactionThreadID": 15,
+                      "latestPendingTime": 0,
+                      "latestPingedTime": 0,
+                      "latestSuspendedTime": 0,
+                      "memoizedInteractions": Set {},
+                      "nextExpirationTimeToWorkOn": 0,
+                      "nextScheduledRoot": null,
+                      "pendingChildren": null,
+                      "pendingCommitExpirationTime": 0,
+                      "pendingContext": null,
+                      "pendingInteractionMap": Map {},
+                      "pingCache": null,
+                      "timeoutHandle": -1,
+                    },
+                    "tag": 3,
+                    "treeBaseDuration": 0,
+                    "type": null,
+                    "updateQueue": Object {
+                      "baseState": Object {
+                        "element": <WrapperComponent
+                          Component={[Function]}
+                          context={null}
+                          props={Object {}}
+                          wrappingComponentProps={null}
+                        />,
+                      },
+                      "firstCapturedEffect": null,
+                      "firstCapturedUpdate": null,
+                      "firstEffect": null,
+                      "firstUpdate": null,
+                      "lastCapturedEffect": null,
+                      "lastCapturedUpdate": null,
+                      "lastEffect": null,
+                      "lastUpdate": null,
+                    },
+                  },
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": WrapperComponent {
+                    "_reactInternalFiber": [Circular],
+                    "_reactInternalInstance": Object {},
+                    "context": Object {},
+                    "props": Object {
+                      "Component": [Function],
+                      "context": null,
+                      "props": Object {},
+                      "wrappingComponentProps": null,
+                    },
+                    "refs": Object {},
+                    "rootFinderInstance": null,
+                    "state": Object {
+                      "context": null,
+                      "mount": true,
+                      "props": Object {},
+                      "wrappingComponentProps": null,
+                    },
+                    "updater": Object {
+                      "enqueueForceUpdate": [Function],
+                      "enqueueReplaceState": [Function],
+                      "enqueueSetState": [Function],
+                      "isMounted": [Function],
+                    },
+                  },
+                  "tag": 1,
+                  "treeBaseDuration": 0,
+                  "type": [Function],
+                  "updateQueue": null,
+                },
+                "selfBaseDuration": 0,
+                "sibling": null,
+                "stateNode": Dashboard {
+                  "_reactInternalFiber": [Circular],
+                  "_reactInternalInstance": Object {},
+                  "context": Object {},
+                  "props": Object {},
+                  "refs": Object {},
+                  "renderUpselling": [Function],
+                  "state": null,
+                  "updater": Object {
+                    "enqueueForceUpdate": [Function],
+                    "enqueueReplaceState": [Function],
+                    "enqueueSetState": [Function],
+                    "isMounted": [Function],
+                  },
+                },
+                "tag": 1,
+                "treeBaseDuration": 0,
+                "type": [Function],
+                "updateQueue": null,
+              },
+              "selfBaseDuration": 0,
+              "sibling": null,
+              "stateNode": Card {
+                "_reactInternalFiber": [Circular],
+                "_reactInternalInstance": Object {},
+                "context": Object {},
+                "props": Object {
+                  "classes": "upselling",
+                  "component": [Function],
+                  "title": "Upselling Partners",
+                },
+                "refs": Object {},
+                "state": null,
+                "updater": Object {
+                  "enqueueForceUpdate": [Function],
+                  "enqueueReplaceState": [Function],
+                  "enqueueSetState": [Function],
+                  "isMounted": [Function],
+                },
+              },
+              "tag": 1,
+              "treeBaseDuration": 0,
+              "type": [Function],
+              "updateQueue": null,
+            },
+            "stateNode": [Circular],
+            "tag": 1,
+            "treeBaseDuration": 0,
+            "type": [Function],
+            "updateQueue": null,
+          },
+          "_reactInternalInstance": Object {},
+          "context": Object {},
+          "props": Object {
+            "classes": "engagement",
+            "component": [Function],
+            "title": "Engagement Trends",
+          },
+          "refs": Object {},
+          "state": null,
+          "updater": Object {
+            "enqueueForceUpdate": [Function],
+            "enqueueReplaceState": [Function],
+            "enqueueSetState": [Function],
+            "isMounted": [Function],
+          },
+        },
+        "key": undefined,
+        "nodeType": "class",
+        "props": Object {
+          "classes": "engagement",
+          "component": [Function],
+          "title": "Engagement Trends",
+        },
+        "ref": null,
+        "rendered": Object {
+          "instance": <div
+            class="dashboard-card engagement"
+          >
+            <div
+              class="title"
+            >
+              Engagement Trends
+            </div>
+          </div>,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": Array [
+              <div
+                className="title"
+              >
+                Engagement Trends
+              </div>,
+              undefined,
+            ],
+            "className": "dashboard-card engagement",
+          },
+          "ref": null,
+          "rendered": Array [
+            Object {
+              "instance": <div
+                class="title"
+              >
+                Engagement Trends
+              </div>,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "children": "Engagement Trends",
+                "className": "title",
+              },
+              "ref": null,
+              "rendered": Array [
+                "Engagement Trends",
+              ],
+              "type": "div",
+            },
+          ],
+          "type": "div",
+        },
+        "type": [Function],
+      },
+      Object {
+        "instance": Card {
+          "_reactInternalFiber": FiberNode {
+            "_debugHookTypes": null,
+            "_debugID": 65,
+            "_debugIsCurrentlyTiming": false,
+            "_debugOwner": FiberNode {
+              "_debugHookTypes": null,
+              "_debugID": 63,
+              "_debugIsCurrentlyTiming": false,
+              "_debugOwner": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 62,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": null,
+                "_debugSource": null,
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": null,
+                "child": [Circular],
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 1,
+                "elementType": [Function],
+                "expirationTime": 0,
+                "firstEffect": null,
+                "index": 0,
+                "key": null,
+                "lastEffect": null,
+                "memoizedProps": Object {
+                  "Component": [Function],
+                  "context": null,
+                  "props": Object {},
+                  "wrappingComponentProps": null,
+                },
+                "memoizedState": Object {
+                  "context": null,
+                  "mount": true,
+                  "props": Object {},
+                  "wrappingComponentProps": null,
+                },
+                "mode": 0,
+                "nextEffect": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 60,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": null,
+                  "_debugSource": null,
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 60,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": null,
+                    "_debugSource": null,
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": [Circular],
+                    "child": null,
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 0,
+                    "elementType": null,
+                    "expirationTime": 1073741823,
+                    "firstEffect": null,
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": null,
+                    "memoizedProps": null,
+                    "memoizedState": null,
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": null,
+                    "ref": null,
+                    "return": null,
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": Object {
+                      "containerInfo": <div>
+                        <div
+                          class="dashboard-card engagement"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Engagement Trends
+                          </div>
+                        </div>
+                        <div
+                          class="dashboard-card upselling"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Upselling Partners
+                          </div>
+                          <div>
+                            upselling component
+                          </div>
+                        </div>
+                      </div>,
+                      "context": Object {},
+                      "current": [Circular],
+                      "didError": false,
+                      "earliestPendingTime": 0,
+                      "earliestSuspendedTime": 0,
+                      "expirationTime": 0,
+                      "finishedWork": null,
+                      "firstBatch": null,
+                      "hydrate": false,
+                      "interactionThreadID": 15,
+                      "latestPendingTime": 0,
+                      "latestPingedTime": 0,
+                      "latestSuspendedTime": 0,
+                      "memoizedInteractions": Set {},
+                      "nextExpirationTimeToWorkOn": 0,
+                      "nextScheduledRoot": null,
+                      "pendingChildren": null,
+                      "pendingCommitExpirationTime": 0,
+                      "pendingContext": null,
+                      "pendingInteractionMap": Map {},
+                      "pingCache": null,
+                      "timeoutHandle": -1,
+                    },
+                    "tag": 3,
+                    "treeBaseDuration": 0,
+                    "type": null,
+                    "updateQueue": Object {
+                      "baseState": null,
+                      "firstCapturedEffect": null,
+                      "firstCapturedUpdate": null,
+                      "firstEffect": null,
+                      "firstUpdate": Object {
+                        "callback": null,
+                        "expirationTime": 1073741823,
+                        "next": null,
+                        "nextEffect": null,
+                        "payload": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={Object {}}
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "tag": 0,
+                      },
+                      "lastCapturedEffect": null,
+                      "lastCapturedUpdate": null,
+                      "lastEffect": null,
+                      "lastUpdate": Object {
+                        "callback": null,
+                        "expirationTime": 1073741823,
+                        "next": null,
+                        "nextEffect": null,
+                        "payload": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={Object {}}
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "tag": 0,
+                      },
+                    },
+                  },
+                  "child": [Circular],
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 32,
+                  "elementType": null,
+                  "expirationTime": 0,
+                  "firstEffect": [Circular],
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": [Circular],
+                  "memoizedProps": null,
+                  "memoizedState": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={Object {}}
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "mode": 0,
+                  "nextEffect": null,
+                  "pendingProps": null,
+                  "ref": null,
+                  "return": null,
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": Object {
+                    "containerInfo": <div>
+                      <div
+                        class="dashboard-card engagement"
+                      >
+                        <div
+                          class="title"
+                        >
+                          Engagement Trends
+                        </div>
+                      </div>
+                      <div
+                        class="dashboard-card upselling"
+                      >
+                        <div
+                          class="title"
+                        >
+                          Upselling Partners
+                        </div>
+                        <div>
+                          upselling component
+                        </div>
+                      </div>
+                    </div>,
+                    "context": Object {},
+                    "current": [Circular],
+                    "didError": false,
+                    "earliestPendingTime": 0,
+                    "earliestSuspendedTime": 0,
+                    "expirationTime": 0,
+                    "finishedWork": null,
+                    "firstBatch": null,
+                    "hydrate": false,
+                    "interactionThreadID": 15,
+                    "latestPendingTime": 0,
+                    "latestPingedTime": 0,
+                    "latestSuspendedTime": 0,
+                    "memoizedInteractions": Set {},
+                    "nextExpirationTimeToWorkOn": 0,
+                    "nextScheduledRoot": null,
+                    "pendingChildren": null,
+                    "pendingCommitExpirationTime": 0,
+                    "pendingContext": null,
+                    "pendingInteractionMap": Map {},
+                    "pingCache": null,
+                    "timeoutHandle": -1,
+                  },
+                  "tag": 3,
+                  "treeBaseDuration": 0,
+                  "type": null,
+                  "updateQueue": Object {
+                    "baseState": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={Object {}}
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "firstCapturedEffect": null,
+                    "firstCapturedUpdate": null,
+                    "firstEffect": null,
+                    "firstUpdate": null,
+                    "lastCapturedEffect": null,
+                    "lastCapturedUpdate": null,
+                    "lastEffect": null,
+                    "lastUpdate": null,
+                  },
+                },
+                "pendingProps": Object {
+                  "Component": [Function],
+                  "context": null,
+                  "props": Object {},
+                  "wrappingComponentProps": null,
+                },
+                "ref": null,
+                "return": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 60,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": null,
+                  "_debugSource": null,
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 60,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": null,
+                    "_debugSource": null,
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": [Circular],
+                    "child": null,
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 0,
+                    "elementType": null,
+                    "expirationTime": 1073741823,
+                    "firstEffect": null,
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": null,
+                    "memoizedProps": null,
+                    "memoizedState": null,
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": null,
+                    "ref": null,
+                    "return": null,
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": Object {
+                      "containerInfo": <div>
+                        <div
+                          class="dashboard-card engagement"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Engagement Trends
+                          </div>
+                        </div>
+                        <div
+                          class="dashboard-card upselling"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Upselling Partners
+                          </div>
+                          <div>
+                            upselling component
+                          </div>
+                        </div>
+                      </div>,
+                      "context": Object {},
+                      "current": [Circular],
+                      "didError": false,
+                      "earliestPendingTime": 0,
+                      "earliestSuspendedTime": 0,
+                      "expirationTime": 0,
+                      "finishedWork": null,
+                      "firstBatch": null,
+                      "hydrate": false,
+                      "interactionThreadID": 15,
+                      "latestPendingTime": 0,
+                      "latestPingedTime": 0,
+                      "latestSuspendedTime": 0,
+                      "memoizedInteractions": Set {},
+                      "nextExpirationTimeToWorkOn": 0,
+                      "nextScheduledRoot": null,
+                      "pendingChildren": null,
+                      "pendingCommitExpirationTime": 0,
+                      "pendingContext": null,
+                      "pendingInteractionMap": Map {},
+                      "pingCache": null,
+                      "timeoutHandle": -1,
+                    },
+                    "tag": 3,
+                    "treeBaseDuration": 0,
+                    "type": null,
+                    "updateQueue": Object {
+                      "baseState": null,
+                      "firstCapturedEffect": null,
+                      "firstCapturedUpdate": null,
+                      "firstEffect": null,
+                      "firstUpdate": Object {
+                        "callback": null,
+                        "expirationTime": 1073741823,
+                        "next": null,
+                        "nextEffect": null,
+                        "payload": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={Object {}}
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "tag": 0,
+                      },
+                      "lastCapturedEffect": null,
+                      "lastCapturedUpdate": null,
+                      "lastEffect": null,
+                      "lastUpdate": Object {
+                        "callback": null,
+                        "expirationTime": 1073741823,
+                        "next": null,
+                        "nextEffect": null,
+                        "payload": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={Object {}}
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "tag": 0,
+                      },
+                    },
+                  },
+                  "child": [Circular],
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 32,
+                  "elementType": null,
+                  "expirationTime": 0,
+                  "firstEffect": [Circular],
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": [Circular],
+                  "memoizedProps": null,
+                  "memoizedState": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={Object {}}
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "mode": 0,
+                  "nextEffect": null,
+                  "pendingProps": null,
+                  "ref": null,
+                  "return": null,
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": Object {
+                    "containerInfo": <div>
+                      <div
+                        class="dashboard-card engagement"
+                      >
+                        <div
+                          class="title"
+                        >
+                          Engagement Trends
+                        </div>
+                      </div>
+                      <div
+                        class="dashboard-card upselling"
+                      >
+                        <div
+                          class="title"
+                        >
+                          Upselling Partners
+                        </div>
+                        <div>
+                          upselling component
+                        </div>
+                      </div>
+                    </div>,
+                    "context": Object {},
+                    "current": [Circular],
+                    "didError": false,
+                    "earliestPendingTime": 0,
+                    "earliestSuspendedTime": 0,
+                    "expirationTime": 0,
+                    "finishedWork": null,
+                    "firstBatch": null,
+                    "hydrate": false,
+                    "interactionThreadID": 15,
+                    "latestPendingTime": 0,
+                    "latestPingedTime": 0,
+                    "latestSuspendedTime": 0,
+                    "memoizedInteractions": Set {},
+                    "nextExpirationTimeToWorkOn": 0,
+                    "nextScheduledRoot": null,
+                    "pendingChildren": null,
+                    "pendingCommitExpirationTime": 0,
+                    "pendingContext": null,
+                    "pendingInteractionMap": Map {},
+                    "pingCache": null,
+                    "timeoutHandle": -1,
+                  },
+                  "tag": 3,
+                  "treeBaseDuration": 0,
+                  "type": null,
+                  "updateQueue": Object {
+                    "baseState": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={Object {}}
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "firstCapturedEffect": null,
+                    "firstCapturedUpdate": null,
+                    "firstEffect": null,
+                    "firstUpdate": null,
+                    "lastCapturedEffect": null,
+                    "lastCapturedUpdate": null,
+                    "lastEffect": null,
+                    "lastUpdate": null,
+                  },
+                },
+                "selfBaseDuration": 0,
+                "sibling": null,
+                "stateNode": WrapperComponent {
+                  "_reactInternalFiber": [Circular],
+                  "_reactInternalInstance": Object {},
+                  "context": Object {},
+                  "props": Object {
+                    "Component": [Function],
+                    "context": null,
+                    "props": Object {},
+                    "wrappingComponentProps": null,
+                  },
+                  "refs": Object {},
+                  "rootFinderInstance": null,
+                  "state": Object {
+                    "context": null,
+                    "mount": true,
+                    "props": Object {},
+                    "wrappingComponentProps": null,
+                  },
+                  "updater": Object {
+                    "enqueueForceUpdate": [Function],
+                    "enqueueReplaceState": [Function],
+                    "enqueueSetState": [Function],
+                    "isMounted": [Function],
+                  },
+                },
+                "tag": 1,
+                "treeBaseDuration": 0,
+                "type": [Function],
+                "updateQueue": null,
+              },
+              "_debugSource": null,
+              "actualDuration": 0,
+              "actualStartTime": -1,
+              "alternate": null,
+              "child": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 64,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": [Circular],
+                "_debugSource": Object {
+                  "fileName": "/Users/kevinkoech/Documents/bp-esa-frontend/src/components/Dashboard/index.jsx",
+                  "lineNumber": 23,
+                },
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": null,
+                "child": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 66,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": [Circular],
+                  "_debugSource": Object {
+                    "fileName": "/Users/kevinkoech/Documents/bp-esa-frontend/src/components/Dashboard/Card.jsx",
+                    "lineNumber": 20,
+                  },
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": null,
+                  "child": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 67,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": [Circular],
+                    "_debugSource": Object {
+                      "fileName": "/Users/kevinkoech/Documents/bp-esa-frontend/src/components/Dashboard/Card.jsx",
+                      "lineNumber": 21,
+                    },
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": null,
+                    "child": null,
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 0,
+                    "elementType": "div",
+                    "expirationTime": 0,
+                    "firstEffect": null,
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": null,
+                    "memoizedProps": Object {
+                      "children": "Engagement Trends",
+                      "className": "title",
+                    },
+                    "memoizedState": null,
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": Object {
+                      "children": "Engagement Trends",
+                      "className": "title",
+                    },
+                    "ref": null,
+                    "return": [Circular],
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": <div
+                      class="title"
+                    >
+                      Engagement Trends
+                    </div>,
+                    "tag": 5,
+                    "treeBaseDuration": 0,
+                    "type": "div",
+                    "updateQueue": null,
+                  },
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 0,
+                  "elementType": "div",
+                  "expirationTime": 0,
+                  "firstEffect": null,
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": null,
+                  "memoizedProps": Object {
+                    "children": Array [
+                      <div
+                        className="title"
+                      >
+                        Engagement Trends
+                      </div>,
+                      undefined,
+                    ],
+                    "className": "dashboard-card engagement",
+                  },
+                  "memoizedState": null,
+                  "mode": 0,
+                  "nextEffect": null,
+                  "pendingProps": Object {
+                    "children": Array [
+                      <div
+                        className="title"
+                      >
+                        Engagement Trends
+                      </div>,
+                      undefined,
+                    ],
+                    "className": "dashboard-card engagement",
+                  },
+                  "ref": null,
+                  "return": [Circular],
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": <div
+                    class="dashboard-card engagement"
+                  >
+                    <div
+                      class="title"
+                    >
+                      Engagement Trends
+                    </div>
+                  </div>,
+                  "tag": 5,
+                  "treeBaseDuration": 0,
+                  "type": "div",
+                  "updateQueue": null,
+                },
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 1,
+                "elementType": [Function],
+                "expirationTime": 0,
+                "firstEffect": null,
+                "index": 0,
+                "key": null,
+                "lastEffect": null,
+                "memoizedProps": Object {
+                  "classes": "engagement",
+                  "component": [Function],
+                  "title": "Engagement Trends",
+                },
+                "memoizedState": null,
+                "mode": 0,
+                "nextEffect": null,
+                "pendingProps": Object {
+                  "classes": "engagement",
+                  "component": [Function],
+                  "title": "Engagement Trends",
+                },
+                "ref": null,
+                "return": [Circular],
+                "selfBaseDuration": 0,
+                "sibling": [Circular],
+                "stateNode": Card {
+                  "_reactInternalFiber": [Circular],
+                  "_reactInternalInstance": Object {},
+                  "context": Object {},
+                  "props": Object {
+                    "classes": "engagement",
+                    "component": [Function],
+                    "title": "Engagement Trends",
+                  },
+                  "refs": Object {},
+                  "state": null,
+                  "updater": Object {
+                    "enqueueForceUpdate": [Function],
+                    "enqueueReplaceState": [Function],
+                    "enqueueSetState": [Function],
+                    "isMounted": [Function],
+                  },
+                },
+                "tag": 1,
+                "treeBaseDuration": 0,
+                "type": [Function],
+                "updateQueue": null,
+              },
+              "childExpirationTime": 0,
+              "contextDependencies": null,
+              "effectTag": 1,
+              "elementType": [Function],
+              "expirationTime": 0,
+              "firstEffect": null,
+              "index": 0,
+              "key": null,
+              "lastEffect": null,
+              "memoizedProps": Object {},
+              "memoizedState": null,
+              "mode": 0,
+              "nextEffect": null,
+              "pendingProps": Object {},
+              "ref": null,
+              "return": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 62,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": null,
+                "_debugSource": null,
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": null,
+                "child": [Circular],
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 1,
+                "elementType": [Function],
+                "expirationTime": 0,
+                "firstEffect": null,
+                "index": 0,
+                "key": null,
+                "lastEffect": null,
+                "memoizedProps": Object {
+                  "Component": [Function],
+                  "context": null,
+                  "props": Object {},
+                  "wrappingComponentProps": null,
+                },
+                "memoizedState": Object {
+                  "context": null,
+                  "mount": true,
+                  "props": Object {},
+                  "wrappingComponentProps": null,
+                },
+                "mode": 0,
+                "nextEffect": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 60,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": null,
+                  "_debugSource": null,
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 60,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": null,
+                    "_debugSource": null,
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": [Circular],
+                    "child": null,
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 0,
+                    "elementType": null,
+                    "expirationTime": 1073741823,
+                    "firstEffect": null,
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": null,
+                    "memoizedProps": null,
+                    "memoizedState": null,
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": null,
+                    "ref": null,
+                    "return": null,
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": Object {
+                      "containerInfo": <div>
+                        <div
+                          class="dashboard-card engagement"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Engagement Trends
+                          </div>
+                        </div>
+                        <div
+                          class="dashboard-card upselling"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Upselling Partners
+                          </div>
+                          <div>
+                            upselling component
+                          </div>
+                        </div>
+                      </div>,
+                      "context": Object {},
+                      "current": [Circular],
+                      "didError": false,
+                      "earliestPendingTime": 0,
+                      "earliestSuspendedTime": 0,
+                      "expirationTime": 0,
+                      "finishedWork": null,
+                      "firstBatch": null,
+                      "hydrate": false,
+                      "interactionThreadID": 15,
+                      "latestPendingTime": 0,
+                      "latestPingedTime": 0,
+                      "latestSuspendedTime": 0,
+                      "memoizedInteractions": Set {},
+                      "nextExpirationTimeToWorkOn": 0,
+                      "nextScheduledRoot": null,
+                      "pendingChildren": null,
+                      "pendingCommitExpirationTime": 0,
+                      "pendingContext": null,
+                      "pendingInteractionMap": Map {},
+                      "pingCache": null,
+                      "timeoutHandle": -1,
+                    },
+                    "tag": 3,
+                    "treeBaseDuration": 0,
+                    "type": null,
+                    "updateQueue": Object {
+                      "baseState": null,
+                      "firstCapturedEffect": null,
+                      "firstCapturedUpdate": null,
+                      "firstEffect": null,
+                      "firstUpdate": Object {
+                        "callback": null,
+                        "expirationTime": 1073741823,
+                        "next": null,
+                        "nextEffect": null,
+                        "payload": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={Object {}}
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "tag": 0,
+                      },
+                      "lastCapturedEffect": null,
+                      "lastCapturedUpdate": null,
+                      "lastEffect": null,
+                      "lastUpdate": Object {
+                        "callback": null,
+                        "expirationTime": 1073741823,
+                        "next": null,
+                        "nextEffect": null,
+                        "payload": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={Object {}}
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "tag": 0,
+                      },
+                    },
+                  },
+                  "child": [Circular],
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 32,
+                  "elementType": null,
+                  "expirationTime": 0,
+                  "firstEffect": [Circular],
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": [Circular],
+                  "memoizedProps": null,
+                  "memoizedState": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={Object {}}
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "mode": 0,
+                  "nextEffect": null,
+                  "pendingProps": null,
+                  "ref": null,
+                  "return": null,
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": Object {
+                    "containerInfo": <div>
+                      <div
+                        class="dashboard-card engagement"
+                      >
+                        <div
+                          class="title"
+                        >
+                          Engagement Trends
+                        </div>
+                      </div>
+                      <div
+                        class="dashboard-card upselling"
+                      >
+                        <div
+                          class="title"
+                        >
+                          Upselling Partners
+                        </div>
+                        <div>
+                          upselling component
+                        </div>
+                      </div>
+                    </div>,
+                    "context": Object {},
+                    "current": [Circular],
+                    "didError": false,
+                    "earliestPendingTime": 0,
+                    "earliestSuspendedTime": 0,
+                    "expirationTime": 0,
+                    "finishedWork": null,
+                    "firstBatch": null,
+                    "hydrate": false,
+                    "interactionThreadID": 15,
+                    "latestPendingTime": 0,
+                    "latestPingedTime": 0,
+                    "latestSuspendedTime": 0,
+                    "memoizedInteractions": Set {},
+                    "nextExpirationTimeToWorkOn": 0,
+                    "nextScheduledRoot": null,
+                    "pendingChildren": null,
+                    "pendingCommitExpirationTime": 0,
+                    "pendingContext": null,
+                    "pendingInteractionMap": Map {},
+                    "pingCache": null,
+                    "timeoutHandle": -1,
+                  },
+                  "tag": 3,
+                  "treeBaseDuration": 0,
+                  "type": null,
+                  "updateQueue": Object {
+                    "baseState": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={Object {}}
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "firstCapturedEffect": null,
+                    "firstCapturedUpdate": null,
+                    "firstEffect": null,
+                    "firstUpdate": null,
+                    "lastCapturedEffect": null,
+                    "lastCapturedUpdate": null,
+                    "lastEffect": null,
+                    "lastUpdate": null,
+                  },
+                },
+                "pendingProps": Object {
+                  "Component": [Function],
+                  "context": null,
+                  "props": Object {},
+                  "wrappingComponentProps": null,
+                },
+                "ref": null,
+                "return": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 60,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": null,
+                  "_debugSource": null,
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 60,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": null,
+                    "_debugSource": null,
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": [Circular],
+                    "child": null,
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 0,
+                    "elementType": null,
+                    "expirationTime": 1073741823,
+                    "firstEffect": null,
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": null,
+                    "memoizedProps": null,
+                    "memoizedState": null,
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": null,
+                    "ref": null,
+                    "return": null,
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": Object {
+                      "containerInfo": <div>
+                        <div
+                          class="dashboard-card engagement"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Engagement Trends
+                          </div>
+                        </div>
+                        <div
+                          class="dashboard-card upselling"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Upselling Partners
+                          </div>
+                          <div>
+                            upselling component
+                          </div>
+                        </div>
+                      </div>,
+                      "context": Object {},
+                      "current": [Circular],
+                      "didError": false,
+                      "earliestPendingTime": 0,
+                      "earliestSuspendedTime": 0,
+                      "expirationTime": 0,
+                      "finishedWork": null,
+                      "firstBatch": null,
+                      "hydrate": false,
+                      "interactionThreadID": 15,
+                      "latestPendingTime": 0,
+                      "latestPingedTime": 0,
+                      "latestSuspendedTime": 0,
+                      "memoizedInteractions": Set {},
+                      "nextExpirationTimeToWorkOn": 0,
+                      "nextScheduledRoot": null,
+                      "pendingChildren": null,
+                      "pendingCommitExpirationTime": 0,
+                      "pendingContext": null,
+                      "pendingInteractionMap": Map {},
+                      "pingCache": null,
+                      "timeoutHandle": -1,
+                    },
+                    "tag": 3,
+                    "treeBaseDuration": 0,
+                    "type": null,
+                    "updateQueue": Object {
+                      "baseState": null,
+                      "firstCapturedEffect": null,
+                      "firstCapturedUpdate": null,
+                      "firstEffect": null,
+                      "firstUpdate": Object {
+                        "callback": null,
+                        "expirationTime": 1073741823,
+                        "next": null,
+                        "nextEffect": null,
+                        "payload": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={Object {}}
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "tag": 0,
+                      },
+                      "lastCapturedEffect": null,
+                      "lastCapturedUpdate": null,
+                      "lastEffect": null,
+                      "lastUpdate": Object {
+                        "callback": null,
+                        "expirationTime": 1073741823,
+                        "next": null,
+                        "nextEffect": null,
+                        "payload": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={Object {}}
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "tag": 0,
+                      },
+                    },
+                  },
+                  "child": [Circular],
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 32,
+                  "elementType": null,
+                  "expirationTime": 0,
+                  "firstEffect": [Circular],
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": [Circular],
+                  "memoizedProps": null,
+                  "memoizedState": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={Object {}}
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "mode": 0,
+                  "nextEffect": null,
+                  "pendingProps": null,
+                  "ref": null,
+                  "return": null,
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": Object {
+                    "containerInfo": <div>
+                      <div
+                        class="dashboard-card engagement"
+                      >
+                        <div
+                          class="title"
+                        >
+                          Engagement Trends
+                        </div>
+                      </div>
+                      <div
+                        class="dashboard-card upselling"
+                      >
+                        <div
+                          class="title"
+                        >
+                          Upselling Partners
+                        </div>
+                        <div>
+                          upselling component
+                        </div>
+                      </div>
+                    </div>,
+                    "context": Object {},
+                    "current": [Circular],
+                    "didError": false,
+                    "earliestPendingTime": 0,
+                    "earliestSuspendedTime": 0,
+                    "expirationTime": 0,
+                    "finishedWork": null,
+                    "firstBatch": null,
+                    "hydrate": false,
+                    "interactionThreadID": 15,
+                    "latestPendingTime": 0,
+                    "latestPingedTime": 0,
+                    "latestSuspendedTime": 0,
+                    "memoizedInteractions": Set {},
+                    "nextExpirationTimeToWorkOn": 0,
+                    "nextScheduledRoot": null,
+                    "pendingChildren": null,
+                    "pendingCommitExpirationTime": 0,
+                    "pendingContext": null,
+                    "pendingInteractionMap": Map {},
+                    "pingCache": null,
+                    "timeoutHandle": -1,
+                  },
+                  "tag": 3,
+                  "treeBaseDuration": 0,
+                  "type": null,
+                  "updateQueue": Object {
+                    "baseState": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={Object {}}
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "firstCapturedEffect": null,
+                    "firstCapturedUpdate": null,
+                    "firstEffect": null,
+                    "firstUpdate": null,
+                    "lastCapturedEffect": null,
+                    "lastCapturedUpdate": null,
+                    "lastEffect": null,
+                    "lastUpdate": null,
+                  },
+                },
+                "selfBaseDuration": 0,
+                "sibling": null,
+                "stateNode": WrapperComponent {
+                  "_reactInternalFiber": [Circular],
+                  "_reactInternalInstance": Object {},
+                  "context": Object {},
+                  "props": Object {
+                    "Component": [Function],
+                    "context": null,
+                    "props": Object {},
+                    "wrappingComponentProps": null,
+                  },
+                  "refs": Object {},
+                  "rootFinderInstance": null,
+                  "state": Object {
+                    "context": null,
+                    "mount": true,
+                    "props": Object {},
+                    "wrappingComponentProps": null,
+                  },
+                  "updater": Object {
+                    "enqueueForceUpdate": [Function],
+                    "enqueueReplaceState": [Function],
+                    "enqueueSetState": [Function],
+                    "isMounted": [Function],
+                  },
+                },
+                "tag": 1,
+                "treeBaseDuration": 0,
+                "type": [Function],
+                "updateQueue": null,
+              },
+              "selfBaseDuration": 0,
+              "sibling": null,
+              "stateNode": Dashboard {
+                "_reactInternalFiber": [Circular],
+                "_reactInternalInstance": Object {},
+                "context": Object {},
+                "props": Object {},
+                "refs": Object {},
+                "renderUpselling": [Function],
+                "state": null,
+                "updater": Object {
+                  "enqueueForceUpdate": [Function],
+                  "enqueueReplaceState": [Function],
+                  "enqueueSetState": [Function],
+                  "isMounted": [Function],
+                },
+              },
+              "tag": 1,
+              "treeBaseDuration": 0,
+              "type": [Function],
+              "updateQueue": null,
+            },
+            "_debugSource": Object {
+              "fileName": "/Users/kevinkoech/Documents/bp-esa-frontend/src/components/Dashboard/index.jsx",
+              "lineNumber": 28,
+            },
+            "actualDuration": 0,
+            "actualStartTime": -1,
+            "alternate": null,
+            "child": FiberNode {
+              "_debugHookTypes": null,
+              "_debugID": 68,
+              "_debugIsCurrentlyTiming": false,
+              "_debugOwner": [Circular],
+              "_debugSource": Object {
+                "fileName": "/Users/kevinkoech/Documents/bp-esa-frontend/src/components/Dashboard/Card.jsx",
+                "lineNumber": 20,
+              },
+              "actualDuration": 0,
+              "actualStartTime": -1,
+              "alternate": null,
+              "child": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 69,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": [Circular],
+                "_debugSource": Object {
+                  "fileName": "/Users/kevinkoech/Documents/bp-esa-frontend/src/components/Dashboard/Card.jsx",
+                  "lineNumber": 21,
+                },
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": null,
+                "child": null,
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 0,
+                "elementType": "div",
+                "expirationTime": 0,
+                "firstEffect": null,
+                "index": 0,
+                "key": null,
+                "lastEffect": null,
+                "memoizedProps": Object {
+                  "children": "Upselling Partners",
+                  "className": "title",
+                },
+                "memoizedState": null,
+                "mode": 0,
+                "nextEffect": null,
+                "pendingProps": Object {
+                  "children": "Upselling Partners",
+                  "className": "title",
+                },
+                "ref": null,
+                "return": [Circular],
+                "selfBaseDuration": 0,
+                "sibling": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 70,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": [Circular],
+                  "_debugSource": Object {
+                    "fileName": "/Users/kevinkoech/Documents/bp-esa-frontend/src/components/Dashboard/index.jsx",
+                    "lineNumber": 15,
+                  },
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": null,
+                  "child": null,
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 0,
+                  "elementType": "div",
+                  "expirationTime": 0,
+                  "firstEffect": null,
+                  "index": 1,
+                  "key": null,
+                  "lastEffect": null,
+                  "memoizedProps": Object {
+                    "children": "upselling component",
+                  },
+                  "memoizedState": null,
+                  "mode": 0,
+                  "nextEffect": null,
+                  "pendingProps": Object {
+                    "children": "upselling component",
+                  },
+                  "ref": null,
+                  "return": [Circular],
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": <div>
+                    upselling component
+                  </div>,
+                  "tag": 5,
+                  "treeBaseDuration": 0,
+                  "type": "div",
+                  "updateQueue": null,
+                },
+                "stateNode": <div
+                  class="title"
+                >
+                  Upselling Partners
+                </div>,
+                "tag": 5,
+                "treeBaseDuration": 0,
+                "type": "div",
+                "updateQueue": null,
+              },
+              "childExpirationTime": 0,
+              "contextDependencies": null,
+              "effectTag": 0,
+              "elementType": "div",
+              "expirationTime": 0,
+              "firstEffect": null,
+              "index": 0,
+              "key": null,
+              "lastEffect": null,
+              "memoizedProps": Object {
+                "children": Array [
+                  <div
+                    className="title"
+                  >
+                    Upselling Partners
+                  </div>,
+                  <div>
+                    upselling component
+                  </div>,
+                ],
+                "className": "dashboard-card upselling",
+              },
+              "memoizedState": null,
+              "mode": 0,
+              "nextEffect": null,
+              "pendingProps": Object {
+                "children": Array [
+                  <div
+                    className="title"
+                  >
+                    Upselling Partners
+                  </div>,
+                  <div>
+                    upselling component
+                  </div>,
+                ],
+                "className": "dashboard-card upselling",
+              },
+              "ref": null,
+              "return": [Circular],
+              "selfBaseDuration": 0,
+              "sibling": null,
+              "stateNode": <div
+                class="dashboard-card upselling"
+              >
+                <div
+                  class="title"
+                >
+                  Upselling Partners
+                </div>
+                <div>
+                  upselling component
+                </div>
+              </div>,
+              "tag": 5,
+              "treeBaseDuration": 0,
+              "type": "div",
+              "updateQueue": null,
+            },
+            "childExpirationTime": 0,
+            "contextDependencies": null,
+            "effectTag": 1,
+            "elementType": [Function],
+            "expirationTime": 0,
+            "firstEffect": null,
+            "index": 1,
+            "key": null,
+            "lastEffect": null,
+            "memoizedProps": Object {
+              "classes": "upselling",
+              "component": [Function],
+              "title": "Upselling Partners",
+            },
+            "memoizedState": null,
+            "mode": 0,
+            "nextEffect": null,
+            "pendingProps": Object {
+              "classes": "upselling",
+              "component": [Function],
+              "title": "Upselling Partners",
+            },
+            "ref": null,
+            "return": FiberNode {
+              "_debugHookTypes": null,
+              "_debugID": 63,
+              "_debugIsCurrentlyTiming": false,
+              "_debugOwner": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 62,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": null,
+                "_debugSource": null,
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": null,
+                "child": [Circular],
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 1,
+                "elementType": [Function],
+                "expirationTime": 0,
+                "firstEffect": null,
+                "index": 0,
+                "key": null,
+                "lastEffect": null,
+                "memoizedProps": Object {
+                  "Component": [Function],
+                  "context": null,
+                  "props": Object {},
+                  "wrappingComponentProps": null,
+                },
+                "memoizedState": Object {
+                  "context": null,
+                  "mount": true,
+                  "props": Object {},
+                  "wrappingComponentProps": null,
+                },
+                "mode": 0,
+                "nextEffect": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 60,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": null,
+                  "_debugSource": null,
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 60,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": null,
+                    "_debugSource": null,
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": [Circular],
+                    "child": null,
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 0,
+                    "elementType": null,
+                    "expirationTime": 1073741823,
+                    "firstEffect": null,
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": null,
+                    "memoizedProps": null,
+                    "memoizedState": null,
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": null,
+                    "ref": null,
+                    "return": null,
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": Object {
+                      "containerInfo": <div>
+                        <div
+                          class="dashboard-card engagement"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Engagement Trends
+                          </div>
+                        </div>
+                        <div
+                          class="dashboard-card upselling"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Upselling Partners
+                          </div>
+                          <div>
+                            upselling component
+                          </div>
+                        </div>
+                      </div>,
+                      "context": Object {},
+                      "current": [Circular],
+                      "didError": false,
+                      "earliestPendingTime": 0,
+                      "earliestSuspendedTime": 0,
+                      "expirationTime": 0,
+                      "finishedWork": null,
+                      "firstBatch": null,
+                      "hydrate": false,
+                      "interactionThreadID": 15,
+                      "latestPendingTime": 0,
+                      "latestPingedTime": 0,
+                      "latestSuspendedTime": 0,
+                      "memoizedInteractions": Set {},
+                      "nextExpirationTimeToWorkOn": 0,
+                      "nextScheduledRoot": null,
+                      "pendingChildren": null,
+                      "pendingCommitExpirationTime": 0,
+                      "pendingContext": null,
+                      "pendingInteractionMap": Map {},
+                      "pingCache": null,
+                      "timeoutHandle": -1,
+                    },
+                    "tag": 3,
+                    "treeBaseDuration": 0,
+                    "type": null,
+                    "updateQueue": Object {
+                      "baseState": null,
+                      "firstCapturedEffect": null,
+                      "firstCapturedUpdate": null,
+                      "firstEffect": null,
+                      "firstUpdate": Object {
+                        "callback": null,
+                        "expirationTime": 1073741823,
+                        "next": null,
+                        "nextEffect": null,
+                        "payload": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={Object {}}
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "tag": 0,
+                      },
+                      "lastCapturedEffect": null,
+                      "lastCapturedUpdate": null,
+                      "lastEffect": null,
+                      "lastUpdate": Object {
+                        "callback": null,
+                        "expirationTime": 1073741823,
+                        "next": null,
+                        "nextEffect": null,
+                        "payload": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={Object {}}
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "tag": 0,
+                      },
+                    },
+                  },
+                  "child": [Circular],
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 32,
+                  "elementType": null,
+                  "expirationTime": 0,
+                  "firstEffect": [Circular],
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": [Circular],
+                  "memoizedProps": null,
+                  "memoizedState": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={Object {}}
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "mode": 0,
+                  "nextEffect": null,
+                  "pendingProps": null,
+                  "ref": null,
+                  "return": null,
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": Object {
+                    "containerInfo": <div>
+                      <div
+                        class="dashboard-card engagement"
+                      >
+                        <div
+                          class="title"
+                        >
+                          Engagement Trends
+                        </div>
+                      </div>
+                      <div
+                        class="dashboard-card upselling"
+                      >
+                        <div
+                          class="title"
+                        >
+                          Upselling Partners
+                        </div>
+                        <div>
+                          upselling component
+                        </div>
+                      </div>
+                    </div>,
+                    "context": Object {},
+                    "current": [Circular],
+                    "didError": false,
+                    "earliestPendingTime": 0,
+                    "earliestSuspendedTime": 0,
+                    "expirationTime": 0,
+                    "finishedWork": null,
+                    "firstBatch": null,
+                    "hydrate": false,
+                    "interactionThreadID": 15,
+                    "latestPendingTime": 0,
+                    "latestPingedTime": 0,
+                    "latestSuspendedTime": 0,
+                    "memoizedInteractions": Set {},
+                    "nextExpirationTimeToWorkOn": 0,
+                    "nextScheduledRoot": null,
+                    "pendingChildren": null,
+                    "pendingCommitExpirationTime": 0,
+                    "pendingContext": null,
+                    "pendingInteractionMap": Map {},
+                    "pingCache": null,
+                    "timeoutHandle": -1,
+                  },
+                  "tag": 3,
+                  "treeBaseDuration": 0,
+                  "type": null,
+                  "updateQueue": Object {
+                    "baseState": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={Object {}}
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "firstCapturedEffect": null,
+                    "firstCapturedUpdate": null,
+                    "firstEffect": null,
+                    "firstUpdate": null,
+                    "lastCapturedEffect": null,
+                    "lastCapturedUpdate": null,
+                    "lastEffect": null,
+                    "lastUpdate": null,
+                  },
+                },
+                "pendingProps": Object {
+                  "Component": [Function],
+                  "context": null,
+                  "props": Object {},
+                  "wrappingComponentProps": null,
+                },
+                "ref": null,
+                "return": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 60,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": null,
+                  "_debugSource": null,
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 60,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": null,
+                    "_debugSource": null,
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": [Circular],
+                    "child": null,
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 0,
+                    "elementType": null,
+                    "expirationTime": 1073741823,
+                    "firstEffect": null,
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": null,
+                    "memoizedProps": null,
+                    "memoizedState": null,
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": null,
+                    "ref": null,
+                    "return": null,
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": Object {
+                      "containerInfo": <div>
+                        <div
+                          class="dashboard-card engagement"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Engagement Trends
+                          </div>
+                        </div>
+                        <div
+                          class="dashboard-card upselling"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Upselling Partners
+                          </div>
+                          <div>
+                            upselling component
+                          </div>
+                        </div>
+                      </div>,
+                      "context": Object {},
+                      "current": [Circular],
+                      "didError": false,
+                      "earliestPendingTime": 0,
+                      "earliestSuspendedTime": 0,
+                      "expirationTime": 0,
+                      "finishedWork": null,
+                      "firstBatch": null,
+                      "hydrate": false,
+                      "interactionThreadID": 15,
+                      "latestPendingTime": 0,
+                      "latestPingedTime": 0,
+                      "latestSuspendedTime": 0,
+                      "memoizedInteractions": Set {},
+                      "nextExpirationTimeToWorkOn": 0,
+                      "nextScheduledRoot": null,
+                      "pendingChildren": null,
+                      "pendingCommitExpirationTime": 0,
+                      "pendingContext": null,
+                      "pendingInteractionMap": Map {},
+                      "pingCache": null,
+                      "timeoutHandle": -1,
+                    },
+                    "tag": 3,
+                    "treeBaseDuration": 0,
+                    "type": null,
+                    "updateQueue": Object {
+                      "baseState": null,
+                      "firstCapturedEffect": null,
+                      "firstCapturedUpdate": null,
+                      "firstEffect": null,
+                      "firstUpdate": Object {
+                        "callback": null,
+                        "expirationTime": 1073741823,
+                        "next": null,
+                        "nextEffect": null,
+                        "payload": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={Object {}}
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "tag": 0,
+                      },
+                      "lastCapturedEffect": null,
+                      "lastCapturedUpdate": null,
+                      "lastEffect": null,
+                      "lastUpdate": Object {
+                        "callback": null,
+                        "expirationTime": 1073741823,
+                        "next": null,
+                        "nextEffect": null,
+                        "payload": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={Object {}}
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "tag": 0,
+                      },
+                    },
+                  },
+                  "child": [Circular],
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 32,
+                  "elementType": null,
+                  "expirationTime": 0,
+                  "firstEffect": [Circular],
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": [Circular],
+                  "memoizedProps": null,
+                  "memoizedState": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={Object {}}
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "mode": 0,
+                  "nextEffect": null,
+                  "pendingProps": null,
+                  "ref": null,
+                  "return": null,
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": Object {
+                    "containerInfo": <div>
+                      <div
+                        class="dashboard-card engagement"
+                      >
+                        <div
+                          class="title"
+                        >
+                          Engagement Trends
+                        </div>
+                      </div>
+                      <div
+                        class="dashboard-card upselling"
+                      >
+                        <div
+                          class="title"
+                        >
+                          Upselling Partners
+                        </div>
+                        <div>
+                          upselling component
+                        </div>
+                      </div>
+                    </div>,
+                    "context": Object {},
+                    "current": [Circular],
+                    "didError": false,
+                    "earliestPendingTime": 0,
+                    "earliestSuspendedTime": 0,
+                    "expirationTime": 0,
+                    "finishedWork": null,
+                    "firstBatch": null,
+                    "hydrate": false,
+                    "interactionThreadID": 15,
+                    "latestPendingTime": 0,
+                    "latestPingedTime": 0,
+                    "latestSuspendedTime": 0,
+                    "memoizedInteractions": Set {},
+                    "nextExpirationTimeToWorkOn": 0,
+                    "nextScheduledRoot": null,
+                    "pendingChildren": null,
+                    "pendingCommitExpirationTime": 0,
+                    "pendingContext": null,
+                    "pendingInteractionMap": Map {},
+                    "pingCache": null,
+                    "timeoutHandle": -1,
+                  },
+                  "tag": 3,
+                  "treeBaseDuration": 0,
+                  "type": null,
+                  "updateQueue": Object {
+                    "baseState": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={Object {}}
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "firstCapturedEffect": null,
+                    "firstCapturedUpdate": null,
+                    "firstEffect": null,
+                    "firstUpdate": null,
+                    "lastCapturedEffect": null,
+                    "lastCapturedUpdate": null,
+                    "lastEffect": null,
+                    "lastUpdate": null,
+                  },
+                },
+                "selfBaseDuration": 0,
+                "sibling": null,
+                "stateNode": WrapperComponent {
+                  "_reactInternalFiber": [Circular],
+                  "_reactInternalInstance": Object {},
+                  "context": Object {},
+                  "props": Object {
+                    "Component": [Function],
+                    "context": null,
+                    "props": Object {},
+                    "wrappingComponentProps": null,
+                  },
+                  "refs": Object {},
+                  "rootFinderInstance": null,
+                  "state": Object {
+                    "context": null,
+                    "mount": true,
+                    "props": Object {},
+                    "wrappingComponentProps": null,
+                  },
+                  "updater": Object {
+                    "enqueueForceUpdate": [Function],
+                    "enqueueReplaceState": [Function],
+                    "enqueueSetState": [Function],
+                    "isMounted": [Function],
+                  },
+                },
+                "tag": 1,
+                "treeBaseDuration": 0,
+                "type": [Function],
+                "updateQueue": null,
+              },
+              "_debugSource": null,
+              "actualDuration": 0,
+              "actualStartTime": -1,
+              "alternate": null,
+              "child": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 64,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": [Circular],
+                "_debugSource": Object {
+                  "fileName": "/Users/kevinkoech/Documents/bp-esa-frontend/src/components/Dashboard/index.jsx",
+                  "lineNumber": 23,
+                },
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": null,
+                "child": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 66,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": [Circular],
+                  "_debugSource": Object {
+                    "fileName": "/Users/kevinkoech/Documents/bp-esa-frontend/src/components/Dashboard/Card.jsx",
+                    "lineNumber": 20,
+                  },
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": null,
+                  "child": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 67,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": [Circular],
+                    "_debugSource": Object {
+                      "fileName": "/Users/kevinkoech/Documents/bp-esa-frontend/src/components/Dashboard/Card.jsx",
+                      "lineNumber": 21,
+                    },
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": null,
+                    "child": null,
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 0,
+                    "elementType": "div",
+                    "expirationTime": 0,
+                    "firstEffect": null,
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": null,
+                    "memoizedProps": Object {
+                      "children": "Engagement Trends",
+                      "className": "title",
+                    },
+                    "memoizedState": null,
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": Object {
+                      "children": "Engagement Trends",
+                      "className": "title",
+                    },
+                    "ref": null,
+                    "return": [Circular],
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": <div
+                      class="title"
+                    >
+                      Engagement Trends
+                    </div>,
+                    "tag": 5,
+                    "treeBaseDuration": 0,
+                    "type": "div",
+                    "updateQueue": null,
+                  },
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 0,
+                  "elementType": "div",
+                  "expirationTime": 0,
+                  "firstEffect": null,
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": null,
+                  "memoizedProps": Object {
+                    "children": Array [
+                      <div
+                        className="title"
+                      >
+                        Engagement Trends
+                      </div>,
+                      undefined,
+                    ],
+                    "className": "dashboard-card engagement",
+                  },
+                  "memoizedState": null,
+                  "mode": 0,
+                  "nextEffect": null,
+                  "pendingProps": Object {
+                    "children": Array [
+                      <div
+                        className="title"
+                      >
+                        Engagement Trends
+                      </div>,
+                      undefined,
+                    ],
+                    "className": "dashboard-card engagement",
+                  },
+                  "ref": null,
+                  "return": [Circular],
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": <div
+                    class="dashboard-card engagement"
+                  >
+                    <div
+                      class="title"
+                    >
+                      Engagement Trends
+                    </div>
+                  </div>,
+                  "tag": 5,
+                  "treeBaseDuration": 0,
+                  "type": "div",
+                  "updateQueue": null,
+                },
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 1,
+                "elementType": [Function],
+                "expirationTime": 0,
+                "firstEffect": null,
+                "index": 0,
+                "key": null,
+                "lastEffect": null,
+                "memoizedProps": Object {
+                  "classes": "engagement",
+                  "component": [Function],
+                  "title": "Engagement Trends",
+                },
+                "memoizedState": null,
+                "mode": 0,
+                "nextEffect": null,
+                "pendingProps": Object {
+                  "classes": "engagement",
+                  "component": [Function],
+                  "title": "Engagement Trends",
+                },
+                "ref": null,
+                "return": [Circular],
+                "selfBaseDuration": 0,
+                "sibling": [Circular],
+                "stateNode": Card {
+                  "_reactInternalFiber": [Circular],
+                  "_reactInternalInstance": Object {},
+                  "context": Object {},
+                  "props": Object {
+                    "classes": "engagement",
+                    "component": [Function],
+                    "title": "Engagement Trends",
+                  },
+                  "refs": Object {},
+                  "state": null,
+                  "updater": Object {
+                    "enqueueForceUpdate": [Function],
+                    "enqueueReplaceState": [Function],
+                    "enqueueSetState": [Function],
+                    "isMounted": [Function],
+                  },
+                },
+                "tag": 1,
+                "treeBaseDuration": 0,
+                "type": [Function],
+                "updateQueue": null,
+              },
+              "childExpirationTime": 0,
+              "contextDependencies": null,
+              "effectTag": 1,
+              "elementType": [Function],
+              "expirationTime": 0,
+              "firstEffect": null,
+              "index": 0,
+              "key": null,
+              "lastEffect": null,
+              "memoizedProps": Object {},
+              "memoizedState": null,
+              "mode": 0,
+              "nextEffect": null,
+              "pendingProps": Object {},
+              "ref": null,
+              "return": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 62,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": null,
+                "_debugSource": null,
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": null,
+                "child": [Circular],
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 1,
+                "elementType": [Function],
+                "expirationTime": 0,
+                "firstEffect": null,
+                "index": 0,
+                "key": null,
+                "lastEffect": null,
+                "memoizedProps": Object {
+                  "Component": [Function],
+                  "context": null,
+                  "props": Object {},
+                  "wrappingComponentProps": null,
+                },
+                "memoizedState": Object {
+                  "context": null,
+                  "mount": true,
+                  "props": Object {},
+                  "wrappingComponentProps": null,
+                },
+                "mode": 0,
+                "nextEffect": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 60,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": null,
+                  "_debugSource": null,
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 60,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": null,
+                    "_debugSource": null,
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": [Circular],
+                    "child": null,
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 0,
+                    "elementType": null,
+                    "expirationTime": 1073741823,
+                    "firstEffect": null,
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": null,
+                    "memoizedProps": null,
+                    "memoizedState": null,
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": null,
+                    "ref": null,
+                    "return": null,
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": Object {
+                      "containerInfo": <div>
+                        <div
+                          class="dashboard-card engagement"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Engagement Trends
+                          </div>
+                        </div>
+                        <div
+                          class="dashboard-card upselling"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Upselling Partners
+                          </div>
+                          <div>
+                            upselling component
+                          </div>
+                        </div>
+                      </div>,
+                      "context": Object {},
+                      "current": [Circular],
+                      "didError": false,
+                      "earliestPendingTime": 0,
+                      "earliestSuspendedTime": 0,
+                      "expirationTime": 0,
+                      "finishedWork": null,
+                      "firstBatch": null,
+                      "hydrate": false,
+                      "interactionThreadID": 15,
+                      "latestPendingTime": 0,
+                      "latestPingedTime": 0,
+                      "latestSuspendedTime": 0,
+                      "memoizedInteractions": Set {},
+                      "nextExpirationTimeToWorkOn": 0,
+                      "nextScheduledRoot": null,
+                      "pendingChildren": null,
+                      "pendingCommitExpirationTime": 0,
+                      "pendingContext": null,
+                      "pendingInteractionMap": Map {},
+                      "pingCache": null,
+                      "timeoutHandle": -1,
+                    },
+                    "tag": 3,
+                    "treeBaseDuration": 0,
+                    "type": null,
+                    "updateQueue": Object {
+                      "baseState": null,
+                      "firstCapturedEffect": null,
+                      "firstCapturedUpdate": null,
+                      "firstEffect": null,
+                      "firstUpdate": Object {
+                        "callback": null,
+                        "expirationTime": 1073741823,
+                        "next": null,
+                        "nextEffect": null,
+                        "payload": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={Object {}}
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "tag": 0,
+                      },
+                      "lastCapturedEffect": null,
+                      "lastCapturedUpdate": null,
+                      "lastEffect": null,
+                      "lastUpdate": Object {
+                        "callback": null,
+                        "expirationTime": 1073741823,
+                        "next": null,
+                        "nextEffect": null,
+                        "payload": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={Object {}}
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "tag": 0,
+                      },
+                    },
+                  },
+                  "child": [Circular],
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 32,
+                  "elementType": null,
+                  "expirationTime": 0,
+                  "firstEffect": [Circular],
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": [Circular],
+                  "memoizedProps": null,
+                  "memoizedState": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={Object {}}
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "mode": 0,
+                  "nextEffect": null,
+                  "pendingProps": null,
+                  "ref": null,
+                  "return": null,
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": Object {
+                    "containerInfo": <div>
+                      <div
+                        class="dashboard-card engagement"
+                      >
+                        <div
+                          class="title"
+                        >
+                          Engagement Trends
+                        </div>
+                      </div>
+                      <div
+                        class="dashboard-card upselling"
+                      >
+                        <div
+                          class="title"
+                        >
+                          Upselling Partners
+                        </div>
+                        <div>
+                          upselling component
+                        </div>
+                      </div>
+                    </div>,
+                    "context": Object {},
+                    "current": [Circular],
+                    "didError": false,
+                    "earliestPendingTime": 0,
+                    "earliestSuspendedTime": 0,
+                    "expirationTime": 0,
+                    "finishedWork": null,
+                    "firstBatch": null,
+                    "hydrate": false,
+                    "interactionThreadID": 15,
+                    "latestPendingTime": 0,
+                    "latestPingedTime": 0,
+                    "latestSuspendedTime": 0,
+                    "memoizedInteractions": Set {},
+                    "nextExpirationTimeToWorkOn": 0,
+                    "nextScheduledRoot": null,
+                    "pendingChildren": null,
+                    "pendingCommitExpirationTime": 0,
+                    "pendingContext": null,
+                    "pendingInteractionMap": Map {},
+                    "pingCache": null,
+                    "timeoutHandle": -1,
+                  },
+                  "tag": 3,
+                  "treeBaseDuration": 0,
+                  "type": null,
+                  "updateQueue": Object {
+                    "baseState": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={Object {}}
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "firstCapturedEffect": null,
+                    "firstCapturedUpdate": null,
+                    "firstEffect": null,
+                    "firstUpdate": null,
+                    "lastCapturedEffect": null,
+                    "lastCapturedUpdate": null,
+                    "lastEffect": null,
+                    "lastUpdate": null,
+                  },
+                },
+                "pendingProps": Object {
+                  "Component": [Function],
+                  "context": null,
+                  "props": Object {},
+                  "wrappingComponentProps": null,
+                },
+                "ref": null,
+                "return": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 60,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": null,
+                  "_debugSource": null,
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 60,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": null,
+                    "_debugSource": null,
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": [Circular],
+                    "child": null,
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 0,
+                    "elementType": null,
+                    "expirationTime": 1073741823,
+                    "firstEffect": null,
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": null,
+                    "memoizedProps": null,
+                    "memoizedState": null,
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": null,
+                    "ref": null,
+                    "return": null,
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": Object {
+                      "containerInfo": <div>
+                        <div
+                          class="dashboard-card engagement"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Engagement Trends
+                          </div>
+                        </div>
+                        <div
+                          class="dashboard-card upselling"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Upselling Partners
+                          </div>
+                          <div>
+                            upselling component
+                          </div>
+                        </div>
+                      </div>,
+                      "context": Object {},
+                      "current": [Circular],
+                      "didError": false,
+                      "earliestPendingTime": 0,
+                      "earliestSuspendedTime": 0,
+                      "expirationTime": 0,
+                      "finishedWork": null,
+                      "firstBatch": null,
+                      "hydrate": false,
+                      "interactionThreadID": 15,
+                      "latestPendingTime": 0,
+                      "latestPingedTime": 0,
+                      "latestSuspendedTime": 0,
+                      "memoizedInteractions": Set {},
+                      "nextExpirationTimeToWorkOn": 0,
+                      "nextScheduledRoot": null,
+                      "pendingChildren": null,
+                      "pendingCommitExpirationTime": 0,
+                      "pendingContext": null,
+                      "pendingInteractionMap": Map {},
+                      "pingCache": null,
+                      "timeoutHandle": -1,
+                    },
+                    "tag": 3,
+                    "treeBaseDuration": 0,
+                    "type": null,
+                    "updateQueue": Object {
+                      "baseState": null,
+                      "firstCapturedEffect": null,
+                      "firstCapturedUpdate": null,
+                      "firstEffect": null,
+                      "firstUpdate": Object {
+                        "callback": null,
+                        "expirationTime": 1073741823,
+                        "next": null,
+                        "nextEffect": null,
+                        "payload": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={Object {}}
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "tag": 0,
+                      },
+                      "lastCapturedEffect": null,
+                      "lastCapturedUpdate": null,
+                      "lastEffect": null,
+                      "lastUpdate": Object {
+                        "callback": null,
+                        "expirationTime": 1073741823,
+                        "next": null,
+                        "nextEffect": null,
+                        "payload": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={Object {}}
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "tag": 0,
+                      },
+                    },
+                  },
+                  "child": [Circular],
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 32,
+                  "elementType": null,
+                  "expirationTime": 0,
+                  "firstEffect": [Circular],
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": [Circular],
+                  "memoizedProps": null,
+                  "memoizedState": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={Object {}}
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "mode": 0,
+                  "nextEffect": null,
+                  "pendingProps": null,
+                  "ref": null,
+                  "return": null,
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": Object {
+                    "containerInfo": <div>
+                      <div
+                        class="dashboard-card engagement"
+                      >
+                        <div
+                          class="title"
+                        >
+                          Engagement Trends
+                        </div>
+                      </div>
+                      <div
+                        class="dashboard-card upselling"
+                      >
+                        <div
+                          class="title"
+                        >
+                          Upselling Partners
+                        </div>
+                        <div>
+                          upselling component
+                        </div>
+                      </div>
+                    </div>,
+                    "context": Object {},
+                    "current": [Circular],
+                    "didError": false,
+                    "earliestPendingTime": 0,
+                    "earliestSuspendedTime": 0,
+                    "expirationTime": 0,
+                    "finishedWork": null,
+                    "firstBatch": null,
+                    "hydrate": false,
+                    "interactionThreadID": 15,
+                    "latestPendingTime": 0,
+                    "latestPingedTime": 0,
+                    "latestSuspendedTime": 0,
+                    "memoizedInteractions": Set {},
+                    "nextExpirationTimeToWorkOn": 0,
+                    "nextScheduledRoot": null,
+                    "pendingChildren": null,
+                    "pendingCommitExpirationTime": 0,
+                    "pendingContext": null,
+                    "pendingInteractionMap": Map {},
+                    "pingCache": null,
+                    "timeoutHandle": -1,
+                  },
+                  "tag": 3,
+                  "treeBaseDuration": 0,
+                  "type": null,
+                  "updateQueue": Object {
+                    "baseState": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={Object {}}
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "firstCapturedEffect": null,
+                    "firstCapturedUpdate": null,
+                    "firstEffect": null,
+                    "firstUpdate": null,
+                    "lastCapturedEffect": null,
+                    "lastCapturedUpdate": null,
+                    "lastEffect": null,
+                    "lastUpdate": null,
+                  },
+                },
+                "selfBaseDuration": 0,
+                "sibling": null,
+                "stateNode": WrapperComponent {
+                  "_reactInternalFiber": [Circular],
+                  "_reactInternalInstance": Object {},
+                  "context": Object {},
+                  "props": Object {
+                    "Component": [Function],
+                    "context": null,
+                    "props": Object {},
+                    "wrappingComponentProps": null,
+                  },
+                  "refs": Object {},
+                  "rootFinderInstance": null,
+                  "state": Object {
+                    "context": null,
+                    "mount": true,
+                    "props": Object {},
+                    "wrappingComponentProps": null,
+                  },
+                  "updater": Object {
+                    "enqueueForceUpdate": [Function],
+                    "enqueueReplaceState": [Function],
+                    "enqueueSetState": [Function],
+                    "isMounted": [Function],
+                  },
+                },
+                "tag": 1,
+                "treeBaseDuration": 0,
+                "type": [Function],
+                "updateQueue": null,
+              },
+              "selfBaseDuration": 0,
+              "sibling": null,
+              "stateNode": Dashboard {
+                "_reactInternalFiber": [Circular],
+                "_reactInternalInstance": Object {},
+                "context": Object {},
+                "props": Object {},
+                "refs": Object {},
+                "renderUpselling": [Function],
+                "state": null,
+                "updater": Object {
+                  "enqueueForceUpdate": [Function],
+                  "enqueueReplaceState": [Function],
+                  "enqueueSetState": [Function],
+                  "isMounted": [Function],
+                },
+              },
+              "tag": 1,
+              "treeBaseDuration": 0,
+              "type": [Function],
+              "updateQueue": null,
+            },
+            "selfBaseDuration": 0,
+            "sibling": null,
+            "stateNode": [Circular],
+            "tag": 1,
+            "treeBaseDuration": 0,
+            "type": [Function],
+            "updateQueue": null,
+          },
+          "_reactInternalInstance": Object {},
+          "context": Object {},
+          "props": Object {
+            "classes": "upselling",
+            "component": [Function],
+            "title": "Upselling Partners",
+          },
+          "refs": Object {},
+          "state": null,
+          "updater": Object {
+            "enqueueForceUpdate": [Function],
+            "enqueueReplaceState": [Function],
+            "enqueueSetState": [Function],
+            "isMounted": [Function],
+          },
+        },
+        "key": undefined,
+        "nodeType": "class",
+        "props": Object {
+          "classes": "upselling",
+          "component": [Function],
+          "title": "Upselling Partners",
+        },
+        "ref": null,
+        "rendered": Object {
+          "instance": <div
+            class="dashboard-card upselling"
+          >
+            <div
+              class="title"
+            >
+              Upselling Partners
+            </div>
+            <div>
+              upselling component
+            </div>
+          </div>,
+          "key": undefined,
+          "nodeType": "host",
+          "props": Object {
+            "children": Array [
+              <div
+                className="title"
+              >
+                Upselling Partners
+              </div>,
+              <div>
+                upselling component
+              </div>,
+            ],
+            "className": "dashboard-card upselling",
+          },
+          "ref": null,
+          "rendered": Array [
+            Object {
+              "instance": <div
+                class="title"
+              >
+                Upselling Partners
+              </div>,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "children": "Upselling Partners",
+                "className": "title",
+              },
+              "ref": null,
+              "rendered": Array [
+                "Upselling Partners",
+              ],
+              "type": "div",
+            },
+            Object {
+              "instance": <div>
+                upselling component
+              </div>,
+              "key": undefined,
+              "nodeType": "host",
+              "props": Object {
+                "children": "upselling component",
+              },
+              "ref": null,
+              "rendered": Array [
+                "upselling component",
+              ],
+              "type": "div",
+            },
+          ],
+          "type": "div",
+        },
+        "type": [Function],
+      },
+    ],
+    "type": [Function],
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": Dashboard {
+        "_reactInternalFiber": FiberNode {
+          "_debugHookTypes": null,
+          "_debugID": 63,
+          "_debugIsCurrentlyTiming": false,
+          "_debugOwner": FiberNode {
+            "_debugHookTypes": null,
+            "_debugID": 62,
+            "_debugIsCurrentlyTiming": false,
+            "_debugOwner": null,
+            "_debugSource": null,
+            "actualDuration": 0,
+            "actualStartTime": -1,
+            "alternate": null,
+            "child": [Circular],
+            "childExpirationTime": 0,
+            "contextDependencies": null,
+            "effectTag": 1,
+            "elementType": [Function],
+            "expirationTime": 0,
+            "firstEffect": null,
+            "index": 0,
+            "key": null,
+            "lastEffect": null,
+            "memoizedProps": Object {
+              "Component": [Function],
+              "context": null,
+              "props": Object {},
+              "wrappingComponentProps": null,
+            },
+            "memoizedState": Object {
+              "context": null,
+              "mount": true,
+              "props": Object {},
+              "wrappingComponentProps": null,
+            },
+            "mode": 0,
+            "nextEffect": FiberNode {
+              "_debugHookTypes": null,
+              "_debugID": 60,
+              "_debugIsCurrentlyTiming": false,
+              "_debugOwner": null,
+              "_debugSource": null,
+              "actualDuration": 0,
+              "actualStartTime": -1,
+              "alternate": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 60,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": null,
+                "_debugSource": null,
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": [Circular],
+                "child": null,
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 0,
+                "elementType": null,
+                "expirationTime": 1073741823,
+                "firstEffect": null,
+                "index": 0,
+                "key": null,
+                "lastEffect": null,
+                "memoizedProps": null,
+                "memoizedState": null,
+                "mode": 0,
+                "nextEffect": null,
+                "pendingProps": null,
+                "ref": null,
+                "return": null,
+                "selfBaseDuration": 0,
+                "sibling": null,
+                "stateNode": Object {
+                  "containerInfo": <div>
+                    <div
+                      class="dashboard-card engagement"
+                    >
+                      <div
+                        class="title"
+                      >
+                        Engagement Trends
+                      </div>
+                    </div>
+                    <div
+                      class="dashboard-card upselling"
+                    >
+                      <div
+                        class="title"
+                      >
+                        Upselling Partners
+                      </div>
+                      <div>
+                        upselling component
+                      </div>
+                    </div>
+                  </div>,
+                  "context": Object {},
+                  "current": [Circular],
+                  "didError": false,
+                  "earliestPendingTime": 0,
+                  "earliestSuspendedTime": 0,
+                  "expirationTime": 0,
+                  "finishedWork": null,
+                  "firstBatch": null,
+                  "hydrate": false,
+                  "interactionThreadID": 15,
+                  "latestPendingTime": 0,
+                  "latestPingedTime": 0,
+                  "latestSuspendedTime": 0,
+                  "memoizedInteractions": Set {},
+                  "nextExpirationTimeToWorkOn": 0,
+                  "nextScheduledRoot": null,
+                  "pendingChildren": null,
+                  "pendingCommitExpirationTime": 0,
+                  "pendingContext": null,
+                  "pendingInteractionMap": Map {},
+                  "pingCache": null,
+                  "timeoutHandle": -1,
+                },
+                "tag": 3,
+                "treeBaseDuration": 0,
+                "type": null,
+                "updateQueue": Object {
+                  "baseState": null,
+                  "firstCapturedEffect": null,
+                  "firstCapturedUpdate": null,
+                  "firstEffect": null,
+                  "firstUpdate": Object {
+                    "callback": null,
+                    "expirationTime": 1073741823,
+                    "next": null,
+                    "nextEffect": null,
+                    "payload": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={Object {}}
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "tag": 0,
+                  },
+                  "lastCapturedEffect": null,
+                  "lastCapturedUpdate": null,
+                  "lastEffect": null,
+                  "lastUpdate": Object {
+                    "callback": null,
+                    "expirationTime": 1073741823,
+                    "next": null,
+                    "nextEffect": null,
+                    "payload": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={Object {}}
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "tag": 0,
+                  },
+                },
+              },
+              "child": [Circular],
+              "childExpirationTime": 0,
+              "contextDependencies": null,
+              "effectTag": 32,
+              "elementType": null,
+              "expirationTime": 0,
+              "firstEffect": [Circular],
+              "index": 0,
+              "key": null,
+              "lastEffect": [Circular],
+              "memoizedProps": null,
+              "memoizedState": Object {
+                "element": <WrapperComponent
+                  Component={[Function]}
+                  context={null}
+                  props={Object {}}
+                  wrappingComponentProps={null}
+                />,
+              },
+              "mode": 0,
+              "nextEffect": null,
+              "pendingProps": null,
+              "ref": null,
+              "return": null,
+              "selfBaseDuration": 0,
+              "sibling": null,
+              "stateNode": Object {
+                "containerInfo": <div>
+                  <div
+                    class="dashboard-card engagement"
+                  >
+                    <div
+                      class="title"
+                    >
+                      Engagement Trends
+                    </div>
+                  </div>
+                  <div
+                    class="dashboard-card upselling"
+                  >
+                    <div
+                      class="title"
+                    >
+                      Upselling Partners
+                    </div>
+                    <div>
+                      upselling component
+                    </div>
+                  </div>
+                </div>,
+                "context": Object {},
+                "current": [Circular],
+                "didError": false,
+                "earliestPendingTime": 0,
+                "earliestSuspendedTime": 0,
+                "expirationTime": 0,
+                "finishedWork": null,
+                "firstBatch": null,
+                "hydrate": false,
+                "interactionThreadID": 15,
+                "latestPendingTime": 0,
+                "latestPingedTime": 0,
+                "latestSuspendedTime": 0,
+                "memoizedInteractions": Set {},
+                "nextExpirationTimeToWorkOn": 0,
+                "nextScheduledRoot": null,
+                "pendingChildren": null,
+                "pendingCommitExpirationTime": 0,
+                "pendingContext": null,
+                "pendingInteractionMap": Map {},
+                "pingCache": null,
+                "timeoutHandle": -1,
+              },
+              "tag": 3,
+              "treeBaseDuration": 0,
+              "type": null,
+              "updateQueue": Object {
+                "baseState": Object {
+                  "element": <WrapperComponent
+                    Component={[Function]}
+                    context={null}
+                    props={Object {}}
+                    wrappingComponentProps={null}
+                  />,
+                },
+                "firstCapturedEffect": null,
+                "firstCapturedUpdate": null,
+                "firstEffect": null,
+                "firstUpdate": null,
+                "lastCapturedEffect": null,
+                "lastCapturedUpdate": null,
+                "lastEffect": null,
+                "lastUpdate": null,
+              },
+            },
+            "pendingProps": Object {
+              "Component": [Function],
+              "context": null,
+              "props": Object {},
+              "wrappingComponentProps": null,
+            },
+            "ref": null,
+            "return": FiberNode {
+              "_debugHookTypes": null,
+              "_debugID": 60,
+              "_debugIsCurrentlyTiming": false,
+              "_debugOwner": null,
+              "_debugSource": null,
+              "actualDuration": 0,
+              "actualStartTime": -1,
+              "alternate": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 60,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": null,
+                "_debugSource": null,
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": [Circular],
+                "child": null,
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 0,
+                "elementType": null,
+                "expirationTime": 1073741823,
+                "firstEffect": null,
+                "index": 0,
+                "key": null,
+                "lastEffect": null,
+                "memoizedProps": null,
+                "memoizedState": null,
+                "mode": 0,
+                "nextEffect": null,
+                "pendingProps": null,
+                "ref": null,
+                "return": null,
+                "selfBaseDuration": 0,
+                "sibling": null,
+                "stateNode": Object {
+                  "containerInfo": <div>
+                    <div
+                      class="dashboard-card engagement"
+                    >
+                      <div
+                        class="title"
+                      >
+                        Engagement Trends
+                      </div>
+                    </div>
+                    <div
+                      class="dashboard-card upselling"
+                    >
+                      <div
+                        class="title"
+                      >
+                        Upselling Partners
+                      </div>
+                      <div>
+                        upselling component
+                      </div>
+                    </div>
+                  </div>,
+                  "context": Object {},
+                  "current": [Circular],
+                  "didError": false,
+                  "earliestPendingTime": 0,
+                  "earliestSuspendedTime": 0,
+                  "expirationTime": 0,
+                  "finishedWork": null,
+                  "firstBatch": null,
+                  "hydrate": false,
+                  "interactionThreadID": 15,
+                  "latestPendingTime": 0,
+                  "latestPingedTime": 0,
+                  "latestSuspendedTime": 0,
+                  "memoizedInteractions": Set {},
+                  "nextExpirationTimeToWorkOn": 0,
+                  "nextScheduledRoot": null,
+                  "pendingChildren": null,
+                  "pendingCommitExpirationTime": 0,
+                  "pendingContext": null,
+                  "pendingInteractionMap": Map {},
+                  "pingCache": null,
+                  "timeoutHandle": -1,
+                },
+                "tag": 3,
+                "treeBaseDuration": 0,
+                "type": null,
+                "updateQueue": Object {
+                  "baseState": null,
+                  "firstCapturedEffect": null,
+                  "firstCapturedUpdate": null,
+                  "firstEffect": null,
+                  "firstUpdate": Object {
+                    "callback": null,
+                    "expirationTime": 1073741823,
+                    "next": null,
+                    "nextEffect": null,
+                    "payload": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={Object {}}
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "tag": 0,
+                  },
+                  "lastCapturedEffect": null,
+                  "lastCapturedUpdate": null,
+                  "lastEffect": null,
+                  "lastUpdate": Object {
+                    "callback": null,
+                    "expirationTime": 1073741823,
+                    "next": null,
+                    "nextEffect": null,
+                    "payload": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={Object {}}
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "tag": 0,
+                  },
+                },
+              },
+              "child": [Circular],
+              "childExpirationTime": 0,
+              "contextDependencies": null,
+              "effectTag": 32,
+              "elementType": null,
+              "expirationTime": 0,
+              "firstEffect": [Circular],
+              "index": 0,
+              "key": null,
+              "lastEffect": [Circular],
+              "memoizedProps": null,
+              "memoizedState": Object {
+                "element": <WrapperComponent
+                  Component={[Function]}
+                  context={null}
+                  props={Object {}}
+                  wrappingComponentProps={null}
+                />,
+              },
+              "mode": 0,
+              "nextEffect": null,
+              "pendingProps": null,
+              "ref": null,
+              "return": null,
+              "selfBaseDuration": 0,
+              "sibling": null,
+              "stateNode": Object {
+                "containerInfo": <div>
+                  <div
+                    class="dashboard-card engagement"
+                  >
+                    <div
+                      class="title"
+                    >
+                      Engagement Trends
+                    </div>
+                  </div>
+                  <div
+                    class="dashboard-card upselling"
+                  >
+                    <div
+                      class="title"
+                    >
+                      Upselling Partners
+                    </div>
+                    <div>
+                      upselling component
+                    </div>
+                  </div>
+                </div>,
+                "context": Object {},
+                "current": [Circular],
+                "didError": false,
+                "earliestPendingTime": 0,
+                "earliestSuspendedTime": 0,
+                "expirationTime": 0,
+                "finishedWork": null,
+                "firstBatch": null,
+                "hydrate": false,
+                "interactionThreadID": 15,
+                "latestPendingTime": 0,
+                "latestPingedTime": 0,
+                "latestSuspendedTime": 0,
+                "memoizedInteractions": Set {},
+                "nextExpirationTimeToWorkOn": 0,
+                "nextScheduledRoot": null,
+                "pendingChildren": null,
+                "pendingCommitExpirationTime": 0,
+                "pendingContext": null,
+                "pendingInteractionMap": Map {},
+                "pingCache": null,
+                "timeoutHandle": -1,
+              },
+              "tag": 3,
+              "treeBaseDuration": 0,
+              "type": null,
+              "updateQueue": Object {
+                "baseState": Object {
+                  "element": <WrapperComponent
+                    Component={[Function]}
+                    context={null}
+                    props={Object {}}
+                    wrappingComponentProps={null}
+                  />,
+                },
+                "firstCapturedEffect": null,
+                "firstCapturedUpdate": null,
+                "firstEffect": null,
+                "firstUpdate": null,
+                "lastCapturedEffect": null,
+                "lastCapturedUpdate": null,
+                "lastEffect": null,
+                "lastUpdate": null,
+              },
+            },
+            "selfBaseDuration": 0,
+            "sibling": null,
+            "stateNode": WrapperComponent {
+              "_reactInternalFiber": [Circular],
+              "_reactInternalInstance": Object {},
+              "context": Object {},
+              "props": Object {
+                "Component": [Function],
+                "context": null,
+                "props": Object {},
+                "wrappingComponentProps": null,
+              },
+              "refs": Object {},
+              "rootFinderInstance": null,
+              "state": Object {
+                "context": null,
+                "mount": true,
+                "props": Object {},
+                "wrappingComponentProps": null,
+              },
+              "updater": Object {
+                "enqueueForceUpdate": [Function],
+                "enqueueReplaceState": [Function],
+                "enqueueSetState": [Function],
+                "isMounted": [Function],
+              },
+            },
+            "tag": 1,
+            "treeBaseDuration": 0,
+            "type": [Function],
+            "updateQueue": null,
+          },
+          "_debugSource": null,
+          "actualDuration": 0,
+          "actualStartTime": -1,
+          "alternate": null,
+          "child": FiberNode {
+            "_debugHookTypes": null,
+            "_debugID": 64,
+            "_debugIsCurrentlyTiming": false,
+            "_debugOwner": [Circular],
+            "_debugSource": Object {
+              "fileName": "/Users/kevinkoech/Documents/bp-esa-frontend/src/components/Dashboard/index.jsx",
+              "lineNumber": 23,
+            },
+            "actualDuration": 0,
+            "actualStartTime": -1,
+            "alternate": null,
+            "child": FiberNode {
+              "_debugHookTypes": null,
+              "_debugID": 66,
+              "_debugIsCurrentlyTiming": false,
+              "_debugOwner": [Circular],
+              "_debugSource": Object {
+                "fileName": "/Users/kevinkoech/Documents/bp-esa-frontend/src/components/Dashboard/Card.jsx",
+                "lineNumber": 20,
+              },
+              "actualDuration": 0,
+              "actualStartTime": -1,
+              "alternate": null,
+              "child": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 67,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": [Circular],
+                "_debugSource": Object {
+                  "fileName": "/Users/kevinkoech/Documents/bp-esa-frontend/src/components/Dashboard/Card.jsx",
+                  "lineNumber": 21,
+                },
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": null,
+                "child": null,
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 0,
+                "elementType": "div",
+                "expirationTime": 0,
+                "firstEffect": null,
+                "index": 0,
+                "key": null,
+                "lastEffect": null,
+                "memoizedProps": Object {
+                  "children": "Engagement Trends",
+                  "className": "title",
+                },
+                "memoizedState": null,
+                "mode": 0,
+                "nextEffect": null,
+                "pendingProps": Object {
+                  "children": "Engagement Trends",
+                  "className": "title",
+                },
+                "ref": null,
+                "return": [Circular],
+                "selfBaseDuration": 0,
+                "sibling": null,
+                "stateNode": <div
+                  class="title"
+                >
+                  Engagement Trends
+                </div>,
+                "tag": 5,
+                "treeBaseDuration": 0,
+                "type": "div",
+                "updateQueue": null,
+              },
+              "childExpirationTime": 0,
+              "contextDependencies": null,
+              "effectTag": 0,
+              "elementType": "div",
+              "expirationTime": 0,
+              "firstEffect": null,
+              "index": 0,
+              "key": null,
+              "lastEffect": null,
+              "memoizedProps": Object {
+                "children": Array [
+                  <div
+                    className="title"
+                  >
+                    Engagement Trends
+                  </div>,
+                  undefined,
+                ],
+                "className": "dashboard-card engagement",
+              },
+              "memoizedState": null,
+              "mode": 0,
+              "nextEffect": null,
+              "pendingProps": Object {
+                "children": Array [
+                  <div
+                    className="title"
+                  >
+                    Engagement Trends
+                  </div>,
+                  undefined,
+                ],
+                "className": "dashboard-card engagement",
+              },
+              "ref": null,
+              "return": [Circular],
+              "selfBaseDuration": 0,
+              "sibling": null,
+              "stateNode": <div
+                class="dashboard-card engagement"
+              >
+                <div
+                  class="title"
+                >
+                  Engagement Trends
+                </div>
+              </div>,
+              "tag": 5,
+              "treeBaseDuration": 0,
+              "type": "div",
+              "updateQueue": null,
+            },
+            "childExpirationTime": 0,
+            "contextDependencies": null,
+            "effectTag": 1,
+            "elementType": [Function],
+            "expirationTime": 0,
+            "firstEffect": null,
+            "index": 0,
+            "key": null,
+            "lastEffect": null,
+            "memoizedProps": Object {
+              "classes": "engagement",
+              "component": [Function],
+              "title": "Engagement Trends",
+            },
+            "memoizedState": null,
+            "mode": 0,
+            "nextEffect": null,
+            "pendingProps": Object {
+              "classes": "engagement",
+              "component": [Function],
+              "title": "Engagement Trends",
+            },
+            "ref": null,
+            "return": [Circular],
+            "selfBaseDuration": 0,
+            "sibling": FiberNode {
+              "_debugHookTypes": null,
+              "_debugID": 65,
+              "_debugIsCurrentlyTiming": false,
+              "_debugOwner": [Circular],
+              "_debugSource": Object {
+                "fileName": "/Users/kevinkoech/Documents/bp-esa-frontend/src/components/Dashboard/index.jsx",
+                "lineNumber": 28,
+              },
+              "actualDuration": 0,
+              "actualStartTime": -1,
+              "alternate": null,
+              "child": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 68,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": [Circular],
+                "_debugSource": Object {
+                  "fileName": "/Users/kevinkoech/Documents/bp-esa-frontend/src/components/Dashboard/Card.jsx",
+                  "lineNumber": 20,
+                },
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": null,
+                "child": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 69,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": [Circular],
+                  "_debugSource": Object {
+                    "fileName": "/Users/kevinkoech/Documents/bp-esa-frontend/src/components/Dashboard/Card.jsx",
+                    "lineNumber": 21,
+                  },
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": null,
+                  "child": null,
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 0,
+                  "elementType": "div",
+                  "expirationTime": 0,
+                  "firstEffect": null,
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": null,
+                  "memoizedProps": Object {
+                    "children": "Upselling Partners",
+                    "className": "title",
+                  },
+                  "memoizedState": null,
+                  "mode": 0,
+                  "nextEffect": null,
+                  "pendingProps": Object {
+                    "children": "Upselling Partners",
+                    "className": "title",
+                  },
+                  "ref": null,
+                  "return": [Circular],
+                  "selfBaseDuration": 0,
+                  "sibling": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 70,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": [Circular],
+                    "_debugSource": Object {
+                      "fileName": "/Users/kevinkoech/Documents/bp-esa-frontend/src/components/Dashboard/index.jsx",
+                      "lineNumber": 15,
+                    },
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": null,
+                    "child": null,
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 0,
+                    "elementType": "div",
+                    "expirationTime": 0,
+                    "firstEffect": null,
+                    "index": 1,
+                    "key": null,
+                    "lastEffect": null,
+                    "memoizedProps": Object {
+                      "children": "upselling component",
+                    },
+                    "memoizedState": null,
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": Object {
+                      "children": "upselling component",
+                    },
+                    "ref": null,
+                    "return": [Circular],
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": <div>
+                      upselling component
+                    </div>,
+                    "tag": 5,
+                    "treeBaseDuration": 0,
+                    "type": "div",
+                    "updateQueue": null,
+                  },
+                  "stateNode": <div
+                    class="title"
+                  >
+                    Upselling Partners
+                  </div>,
+                  "tag": 5,
+                  "treeBaseDuration": 0,
+                  "type": "div",
+                  "updateQueue": null,
+                },
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 0,
+                "elementType": "div",
+                "expirationTime": 0,
+                "firstEffect": null,
+                "index": 0,
+                "key": null,
+                "lastEffect": null,
+                "memoizedProps": Object {
+                  "children": Array [
+                    <div
+                      className="title"
+                    >
+                      Upselling Partners
+                    </div>,
+                    <div>
+                      upselling component
+                    </div>,
+                  ],
+                  "className": "dashboard-card upselling",
+                },
+                "memoizedState": null,
+                "mode": 0,
+                "nextEffect": null,
+                "pendingProps": Object {
+                  "children": Array [
+                    <div
+                      className="title"
+                    >
+                      Upselling Partners
+                    </div>,
+                    <div>
+                      upselling component
+                    </div>,
+                  ],
+                  "className": "dashboard-card upselling",
+                },
+                "ref": null,
+                "return": [Circular],
+                "selfBaseDuration": 0,
+                "sibling": null,
+                "stateNode": <div
+                  class="dashboard-card upselling"
+                >
+                  <div
+                    class="title"
+                  >
+                    Upselling Partners
+                  </div>
+                  <div>
+                    upselling component
+                  </div>
+                </div>,
+                "tag": 5,
+                "treeBaseDuration": 0,
+                "type": "div",
+                "updateQueue": null,
+              },
+              "childExpirationTime": 0,
+              "contextDependencies": null,
+              "effectTag": 1,
+              "elementType": [Function],
+              "expirationTime": 0,
+              "firstEffect": null,
+              "index": 1,
+              "key": null,
+              "lastEffect": null,
+              "memoizedProps": Object {
+                "classes": "upselling",
+                "component": [Function],
+                "title": "Upselling Partners",
+              },
+              "memoizedState": null,
+              "mode": 0,
+              "nextEffect": null,
+              "pendingProps": Object {
+                "classes": "upselling",
+                "component": [Function],
+                "title": "Upselling Partners",
+              },
+              "ref": null,
+              "return": [Circular],
+              "selfBaseDuration": 0,
+              "sibling": null,
+              "stateNode": Card {
+                "_reactInternalFiber": [Circular],
+                "_reactInternalInstance": Object {},
+                "context": Object {},
+                "props": Object {
+                  "classes": "upselling",
+                  "component": [Function],
+                  "title": "Upselling Partners",
+                },
+                "refs": Object {},
+                "state": null,
+                "updater": Object {
+                  "enqueueForceUpdate": [Function],
+                  "enqueueReplaceState": [Function],
+                  "enqueueSetState": [Function],
+                  "isMounted": [Function],
+                },
+              },
+              "tag": 1,
+              "treeBaseDuration": 0,
+              "type": [Function],
+              "updateQueue": null,
+            },
+            "stateNode": Card {
+              "_reactInternalFiber": [Circular],
+              "_reactInternalInstance": Object {},
+              "context": Object {},
+              "props": Object {
+                "classes": "engagement",
+                "component": [Function],
+                "title": "Engagement Trends",
+              },
+              "refs": Object {},
+              "state": null,
+              "updater": Object {
+                "enqueueForceUpdate": [Function],
+                "enqueueReplaceState": [Function],
+                "enqueueSetState": [Function],
+                "isMounted": [Function],
+              },
+            },
+            "tag": 1,
+            "treeBaseDuration": 0,
+            "type": [Function],
+            "updateQueue": null,
+          },
+          "childExpirationTime": 0,
+          "contextDependencies": null,
+          "effectTag": 1,
+          "elementType": [Function],
+          "expirationTime": 0,
+          "firstEffect": null,
+          "index": 0,
+          "key": null,
+          "lastEffect": null,
+          "memoizedProps": Object {},
+          "memoizedState": null,
+          "mode": 0,
+          "nextEffect": null,
+          "pendingProps": Object {},
+          "ref": null,
+          "return": FiberNode {
+            "_debugHookTypes": null,
+            "_debugID": 62,
+            "_debugIsCurrentlyTiming": false,
+            "_debugOwner": null,
+            "_debugSource": null,
+            "actualDuration": 0,
+            "actualStartTime": -1,
+            "alternate": null,
+            "child": [Circular],
+            "childExpirationTime": 0,
+            "contextDependencies": null,
+            "effectTag": 1,
+            "elementType": [Function],
+            "expirationTime": 0,
+            "firstEffect": null,
+            "index": 0,
+            "key": null,
+            "lastEffect": null,
+            "memoizedProps": Object {
+              "Component": [Function],
+              "context": null,
+              "props": Object {},
+              "wrappingComponentProps": null,
+            },
+            "memoizedState": Object {
+              "context": null,
+              "mount": true,
+              "props": Object {},
+              "wrappingComponentProps": null,
+            },
+            "mode": 0,
+            "nextEffect": FiberNode {
+              "_debugHookTypes": null,
+              "_debugID": 60,
+              "_debugIsCurrentlyTiming": false,
+              "_debugOwner": null,
+              "_debugSource": null,
+              "actualDuration": 0,
+              "actualStartTime": -1,
+              "alternate": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 60,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": null,
+                "_debugSource": null,
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": [Circular],
+                "child": null,
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 0,
+                "elementType": null,
+                "expirationTime": 1073741823,
+                "firstEffect": null,
+                "index": 0,
+                "key": null,
+                "lastEffect": null,
+                "memoizedProps": null,
+                "memoizedState": null,
+                "mode": 0,
+                "nextEffect": null,
+                "pendingProps": null,
+                "ref": null,
+                "return": null,
+                "selfBaseDuration": 0,
+                "sibling": null,
+                "stateNode": Object {
+                  "containerInfo": <div>
+                    <div
+                      class="dashboard-card engagement"
+                    >
+                      <div
+                        class="title"
+                      >
+                        Engagement Trends
+                      </div>
+                    </div>
+                    <div
+                      class="dashboard-card upselling"
+                    >
+                      <div
+                        class="title"
+                      >
+                        Upselling Partners
+                      </div>
+                      <div>
+                        upselling component
+                      </div>
+                    </div>
+                  </div>,
+                  "context": Object {},
+                  "current": [Circular],
+                  "didError": false,
+                  "earliestPendingTime": 0,
+                  "earliestSuspendedTime": 0,
+                  "expirationTime": 0,
+                  "finishedWork": null,
+                  "firstBatch": null,
+                  "hydrate": false,
+                  "interactionThreadID": 15,
+                  "latestPendingTime": 0,
+                  "latestPingedTime": 0,
+                  "latestSuspendedTime": 0,
+                  "memoizedInteractions": Set {},
+                  "nextExpirationTimeToWorkOn": 0,
+                  "nextScheduledRoot": null,
+                  "pendingChildren": null,
+                  "pendingCommitExpirationTime": 0,
+                  "pendingContext": null,
+                  "pendingInteractionMap": Map {},
+                  "pingCache": null,
+                  "timeoutHandle": -1,
+                },
+                "tag": 3,
+                "treeBaseDuration": 0,
+                "type": null,
+                "updateQueue": Object {
+                  "baseState": null,
+                  "firstCapturedEffect": null,
+                  "firstCapturedUpdate": null,
+                  "firstEffect": null,
+                  "firstUpdate": Object {
+                    "callback": null,
+                    "expirationTime": 1073741823,
+                    "next": null,
+                    "nextEffect": null,
+                    "payload": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={Object {}}
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "tag": 0,
+                  },
+                  "lastCapturedEffect": null,
+                  "lastCapturedUpdate": null,
+                  "lastEffect": null,
+                  "lastUpdate": Object {
+                    "callback": null,
+                    "expirationTime": 1073741823,
+                    "next": null,
+                    "nextEffect": null,
+                    "payload": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={Object {}}
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "tag": 0,
+                  },
+                },
+              },
+              "child": [Circular],
+              "childExpirationTime": 0,
+              "contextDependencies": null,
+              "effectTag": 32,
+              "elementType": null,
+              "expirationTime": 0,
+              "firstEffect": [Circular],
+              "index": 0,
+              "key": null,
+              "lastEffect": [Circular],
+              "memoizedProps": null,
+              "memoizedState": Object {
+                "element": <WrapperComponent
+                  Component={[Function]}
+                  context={null}
+                  props={Object {}}
+                  wrappingComponentProps={null}
+                />,
+              },
+              "mode": 0,
+              "nextEffect": null,
+              "pendingProps": null,
+              "ref": null,
+              "return": null,
+              "selfBaseDuration": 0,
+              "sibling": null,
+              "stateNode": Object {
+                "containerInfo": <div>
+                  <div
+                    class="dashboard-card engagement"
+                  >
+                    <div
+                      class="title"
+                    >
+                      Engagement Trends
+                    </div>
+                  </div>
+                  <div
+                    class="dashboard-card upselling"
+                  >
+                    <div
+                      class="title"
+                    >
+                      Upselling Partners
+                    </div>
+                    <div>
+                      upselling component
+                    </div>
+                  </div>
+                </div>,
+                "context": Object {},
+                "current": [Circular],
+                "didError": false,
+                "earliestPendingTime": 0,
+                "earliestSuspendedTime": 0,
+                "expirationTime": 0,
+                "finishedWork": null,
+                "firstBatch": null,
+                "hydrate": false,
+                "interactionThreadID": 15,
+                "latestPendingTime": 0,
+                "latestPingedTime": 0,
+                "latestSuspendedTime": 0,
+                "memoizedInteractions": Set {},
+                "nextExpirationTimeToWorkOn": 0,
+                "nextScheduledRoot": null,
+                "pendingChildren": null,
+                "pendingCommitExpirationTime": 0,
+                "pendingContext": null,
+                "pendingInteractionMap": Map {},
+                "pingCache": null,
+                "timeoutHandle": -1,
+              },
+              "tag": 3,
+              "treeBaseDuration": 0,
+              "type": null,
+              "updateQueue": Object {
+                "baseState": Object {
+                  "element": <WrapperComponent
+                    Component={[Function]}
+                    context={null}
+                    props={Object {}}
+                    wrappingComponentProps={null}
+                  />,
+                },
+                "firstCapturedEffect": null,
+                "firstCapturedUpdate": null,
+                "firstEffect": null,
+                "firstUpdate": null,
+                "lastCapturedEffect": null,
+                "lastCapturedUpdate": null,
+                "lastEffect": null,
+                "lastUpdate": null,
+              },
+            },
+            "pendingProps": Object {
+              "Component": [Function],
+              "context": null,
+              "props": Object {},
+              "wrappingComponentProps": null,
+            },
+            "ref": null,
+            "return": FiberNode {
+              "_debugHookTypes": null,
+              "_debugID": 60,
+              "_debugIsCurrentlyTiming": false,
+              "_debugOwner": null,
+              "_debugSource": null,
+              "actualDuration": 0,
+              "actualStartTime": -1,
+              "alternate": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 60,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": null,
+                "_debugSource": null,
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": [Circular],
+                "child": null,
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 0,
+                "elementType": null,
+                "expirationTime": 1073741823,
+                "firstEffect": null,
+                "index": 0,
+                "key": null,
+                "lastEffect": null,
+                "memoizedProps": null,
+                "memoizedState": null,
+                "mode": 0,
+                "nextEffect": null,
+                "pendingProps": null,
+                "ref": null,
+                "return": null,
+                "selfBaseDuration": 0,
+                "sibling": null,
+                "stateNode": Object {
+                  "containerInfo": <div>
+                    <div
+                      class="dashboard-card engagement"
+                    >
+                      <div
+                        class="title"
+                      >
+                        Engagement Trends
+                      </div>
+                    </div>
+                    <div
+                      class="dashboard-card upselling"
+                    >
+                      <div
+                        class="title"
+                      >
+                        Upselling Partners
+                      </div>
+                      <div>
+                        upselling component
+                      </div>
+                    </div>
+                  </div>,
+                  "context": Object {},
+                  "current": [Circular],
+                  "didError": false,
+                  "earliestPendingTime": 0,
+                  "earliestSuspendedTime": 0,
+                  "expirationTime": 0,
+                  "finishedWork": null,
+                  "firstBatch": null,
+                  "hydrate": false,
+                  "interactionThreadID": 15,
+                  "latestPendingTime": 0,
+                  "latestPingedTime": 0,
+                  "latestSuspendedTime": 0,
+                  "memoizedInteractions": Set {},
+                  "nextExpirationTimeToWorkOn": 0,
+                  "nextScheduledRoot": null,
+                  "pendingChildren": null,
+                  "pendingCommitExpirationTime": 0,
+                  "pendingContext": null,
+                  "pendingInteractionMap": Map {},
+                  "pingCache": null,
+                  "timeoutHandle": -1,
+                },
+                "tag": 3,
+                "treeBaseDuration": 0,
+                "type": null,
+                "updateQueue": Object {
+                  "baseState": null,
+                  "firstCapturedEffect": null,
+                  "firstCapturedUpdate": null,
+                  "firstEffect": null,
+                  "firstUpdate": Object {
+                    "callback": null,
+                    "expirationTime": 1073741823,
+                    "next": null,
+                    "nextEffect": null,
+                    "payload": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={Object {}}
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "tag": 0,
+                  },
+                  "lastCapturedEffect": null,
+                  "lastCapturedUpdate": null,
+                  "lastEffect": null,
+                  "lastUpdate": Object {
+                    "callback": null,
+                    "expirationTime": 1073741823,
+                    "next": null,
+                    "nextEffect": null,
+                    "payload": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={Object {}}
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "tag": 0,
+                  },
+                },
+              },
+              "child": [Circular],
+              "childExpirationTime": 0,
+              "contextDependencies": null,
+              "effectTag": 32,
+              "elementType": null,
+              "expirationTime": 0,
+              "firstEffect": [Circular],
+              "index": 0,
+              "key": null,
+              "lastEffect": [Circular],
+              "memoizedProps": null,
+              "memoizedState": Object {
+                "element": <WrapperComponent
+                  Component={[Function]}
+                  context={null}
+                  props={Object {}}
+                  wrappingComponentProps={null}
+                />,
+              },
+              "mode": 0,
+              "nextEffect": null,
+              "pendingProps": null,
+              "ref": null,
+              "return": null,
+              "selfBaseDuration": 0,
+              "sibling": null,
+              "stateNode": Object {
+                "containerInfo": <div>
+                  <div
+                    class="dashboard-card engagement"
+                  >
+                    <div
+                      class="title"
+                    >
+                      Engagement Trends
+                    </div>
+                  </div>
+                  <div
+                    class="dashboard-card upselling"
+                  >
+                    <div
+                      class="title"
+                    >
+                      Upselling Partners
+                    </div>
+                    <div>
+                      upselling component
+                    </div>
+                  </div>
+                </div>,
+                "context": Object {},
+                "current": [Circular],
+                "didError": false,
+                "earliestPendingTime": 0,
+                "earliestSuspendedTime": 0,
+                "expirationTime": 0,
+                "finishedWork": null,
+                "firstBatch": null,
+                "hydrate": false,
+                "interactionThreadID": 15,
+                "latestPendingTime": 0,
+                "latestPingedTime": 0,
+                "latestSuspendedTime": 0,
+                "memoizedInteractions": Set {},
+                "nextExpirationTimeToWorkOn": 0,
+                "nextScheduledRoot": null,
+                "pendingChildren": null,
+                "pendingCommitExpirationTime": 0,
+                "pendingContext": null,
+                "pendingInteractionMap": Map {},
+                "pingCache": null,
+                "timeoutHandle": -1,
+              },
+              "tag": 3,
+              "treeBaseDuration": 0,
+              "type": null,
+              "updateQueue": Object {
+                "baseState": Object {
+                  "element": <WrapperComponent
+                    Component={[Function]}
+                    context={null}
+                    props={Object {}}
+                    wrappingComponentProps={null}
+                  />,
+                },
+                "firstCapturedEffect": null,
+                "firstCapturedUpdate": null,
+                "firstEffect": null,
+                "firstUpdate": null,
+                "lastCapturedEffect": null,
+                "lastCapturedUpdate": null,
+                "lastEffect": null,
+                "lastUpdate": null,
+              },
+            },
+            "selfBaseDuration": 0,
+            "sibling": null,
+            "stateNode": WrapperComponent {
+              "_reactInternalFiber": [Circular],
+              "_reactInternalInstance": Object {},
+              "context": Object {},
+              "props": Object {
+                "Component": [Function],
+                "context": null,
+                "props": Object {},
+                "wrappingComponentProps": null,
+              },
+              "refs": Object {},
+              "rootFinderInstance": null,
+              "state": Object {
+                "context": null,
+                "mount": true,
+                "props": Object {},
+                "wrappingComponentProps": null,
+              },
+              "updater": Object {
+                "enqueueForceUpdate": [Function],
+                "enqueueReplaceState": [Function],
+                "enqueueSetState": [Function],
+                "isMounted": [Function],
+              },
+            },
+            "tag": 1,
+            "treeBaseDuration": 0,
+            "type": [Function],
+            "updateQueue": null,
+          },
+          "selfBaseDuration": 0,
+          "sibling": null,
+          "stateNode": [Circular],
+          "tag": 1,
+          "treeBaseDuration": 0,
+          "type": [Function],
+          "updateQueue": null,
+        },
+        "_reactInternalInstance": Object {},
+        "context": Object {},
+        "props": Object {},
+        "refs": Object {},
+        "renderUpselling": [Function],
+        "state": null,
+        "updater": Object {
+          "enqueueForceUpdate": [Function],
+          "enqueueReplaceState": [Function],
+          "enqueueSetState": [Function],
+          "isMounted": [Function],
+        },
+      },
+      "key": undefined,
+      "nodeType": "class",
+      "props": Object {},
+      "ref": null,
+      "rendered": Array [
+        Object {
+          "instance": Card {
+            "_reactInternalFiber": FiberNode {
+              "_debugHookTypes": null,
+              "_debugID": 64,
+              "_debugIsCurrentlyTiming": false,
+              "_debugOwner": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 63,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 62,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": null,
+                  "_debugSource": null,
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": null,
+                  "child": [Circular],
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 1,
+                  "elementType": [Function],
+                  "expirationTime": 0,
+                  "firstEffect": null,
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": null,
+                  "memoizedProps": Object {
+                    "Component": [Function],
+                    "context": null,
+                    "props": Object {},
+                    "wrappingComponentProps": null,
+                  },
+                  "memoizedState": Object {
+                    "context": null,
+                    "mount": true,
+                    "props": Object {},
+                    "wrappingComponentProps": null,
+                  },
+                  "mode": 0,
+                  "nextEffect": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 60,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": null,
+                    "_debugSource": null,
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": FiberNode {
+                      "_debugHookTypes": null,
+                      "_debugID": 60,
+                      "_debugIsCurrentlyTiming": false,
+                      "_debugOwner": null,
+                      "_debugSource": null,
+                      "actualDuration": 0,
+                      "actualStartTime": -1,
+                      "alternate": [Circular],
+                      "child": null,
+                      "childExpirationTime": 0,
+                      "contextDependencies": null,
+                      "effectTag": 0,
+                      "elementType": null,
+                      "expirationTime": 1073741823,
+                      "firstEffect": null,
+                      "index": 0,
+                      "key": null,
+                      "lastEffect": null,
+                      "memoizedProps": null,
+                      "memoizedState": null,
+                      "mode": 0,
+                      "nextEffect": null,
+                      "pendingProps": null,
+                      "ref": null,
+                      "return": null,
+                      "selfBaseDuration": 0,
+                      "sibling": null,
+                      "stateNode": Object {
+                        "containerInfo": <div>
+                          <div
+                            class="dashboard-card engagement"
+                          >
+                            <div
+                              class="title"
+                            >
+                              Engagement Trends
+                            </div>
+                          </div>
+                          <div
+                            class="dashboard-card upselling"
+                          >
+                            <div
+                              class="title"
+                            >
+                              Upselling Partners
+                            </div>
+                            <div>
+                              upselling component
+                            </div>
+                          </div>
+                        </div>,
+                        "context": Object {},
+                        "current": [Circular],
+                        "didError": false,
+                        "earliestPendingTime": 0,
+                        "earliestSuspendedTime": 0,
+                        "expirationTime": 0,
+                        "finishedWork": null,
+                        "firstBatch": null,
+                        "hydrate": false,
+                        "interactionThreadID": 15,
+                        "latestPendingTime": 0,
+                        "latestPingedTime": 0,
+                        "latestSuspendedTime": 0,
+                        "memoizedInteractions": Set {},
+                        "nextExpirationTimeToWorkOn": 0,
+                        "nextScheduledRoot": null,
+                        "pendingChildren": null,
+                        "pendingCommitExpirationTime": 0,
+                        "pendingContext": null,
+                        "pendingInteractionMap": Map {},
+                        "pingCache": null,
+                        "timeoutHandle": -1,
+                      },
+                      "tag": 3,
+                      "treeBaseDuration": 0,
+                      "type": null,
+                      "updateQueue": Object {
+                        "baseState": null,
+                        "firstCapturedEffect": null,
+                        "firstCapturedUpdate": null,
+                        "firstEffect": null,
+                        "firstUpdate": Object {
+                          "callback": null,
+                          "expirationTime": 1073741823,
+                          "next": null,
+                          "nextEffect": null,
+                          "payload": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={Object {}}
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "tag": 0,
+                        },
+                        "lastCapturedEffect": null,
+                        "lastCapturedUpdate": null,
+                        "lastEffect": null,
+                        "lastUpdate": Object {
+                          "callback": null,
+                          "expirationTime": 1073741823,
+                          "next": null,
+                          "nextEffect": null,
+                          "payload": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={Object {}}
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "tag": 0,
+                        },
+                      },
+                    },
+                    "child": [Circular],
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 32,
+                    "elementType": null,
+                    "expirationTime": 0,
+                    "firstEffect": [Circular],
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": [Circular],
+                    "memoizedProps": null,
+                    "memoizedState": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={Object {}}
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": null,
+                    "ref": null,
+                    "return": null,
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": Object {
+                      "containerInfo": <div>
+                        <div
+                          class="dashboard-card engagement"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Engagement Trends
+                          </div>
+                        </div>
+                        <div
+                          class="dashboard-card upselling"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Upselling Partners
+                          </div>
+                          <div>
+                            upselling component
+                          </div>
+                        </div>
+                      </div>,
+                      "context": Object {},
+                      "current": [Circular],
+                      "didError": false,
+                      "earliestPendingTime": 0,
+                      "earliestSuspendedTime": 0,
+                      "expirationTime": 0,
+                      "finishedWork": null,
+                      "firstBatch": null,
+                      "hydrate": false,
+                      "interactionThreadID": 15,
+                      "latestPendingTime": 0,
+                      "latestPingedTime": 0,
+                      "latestSuspendedTime": 0,
+                      "memoizedInteractions": Set {},
+                      "nextExpirationTimeToWorkOn": 0,
+                      "nextScheduledRoot": null,
+                      "pendingChildren": null,
+                      "pendingCommitExpirationTime": 0,
+                      "pendingContext": null,
+                      "pendingInteractionMap": Map {},
+                      "pingCache": null,
+                      "timeoutHandle": -1,
+                    },
+                    "tag": 3,
+                    "treeBaseDuration": 0,
+                    "type": null,
+                    "updateQueue": Object {
+                      "baseState": Object {
+                        "element": <WrapperComponent
+                          Component={[Function]}
+                          context={null}
+                          props={Object {}}
+                          wrappingComponentProps={null}
+                        />,
+                      },
+                      "firstCapturedEffect": null,
+                      "firstCapturedUpdate": null,
+                      "firstEffect": null,
+                      "firstUpdate": null,
+                      "lastCapturedEffect": null,
+                      "lastCapturedUpdate": null,
+                      "lastEffect": null,
+                      "lastUpdate": null,
+                    },
+                  },
+                  "pendingProps": Object {
+                    "Component": [Function],
+                    "context": null,
+                    "props": Object {},
+                    "wrappingComponentProps": null,
+                  },
+                  "ref": null,
+                  "return": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 60,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": null,
+                    "_debugSource": null,
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": FiberNode {
+                      "_debugHookTypes": null,
+                      "_debugID": 60,
+                      "_debugIsCurrentlyTiming": false,
+                      "_debugOwner": null,
+                      "_debugSource": null,
+                      "actualDuration": 0,
+                      "actualStartTime": -1,
+                      "alternate": [Circular],
+                      "child": null,
+                      "childExpirationTime": 0,
+                      "contextDependencies": null,
+                      "effectTag": 0,
+                      "elementType": null,
+                      "expirationTime": 1073741823,
+                      "firstEffect": null,
+                      "index": 0,
+                      "key": null,
+                      "lastEffect": null,
+                      "memoizedProps": null,
+                      "memoizedState": null,
+                      "mode": 0,
+                      "nextEffect": null,
+                      "pendingProps": null,
+                      "ref": null,
+                      "return": null,
+                      "selfBaseDuration": 0,
+                      "sibling": null,
+                      "stateNode": Object {
+                        "containerInfo": <div>
+                          <div
+                            class="dashboard-card engagement"
+                          >
+                            <div
+                              class="title"
+                            >
+                              Engagement Trends
+                            </div>
+                          </div>
+                          <div
+                            class="dashboard-card upselling"
+                          >
+                            <div
+                              class="title"
+                            >
+                              Upselling Partners
+                            </div>
+                            <div>
+                              upselling component
+                            </div>
+                          </div>
+                        </div>,
+                        "context": Object {},
+                        "current": [Circular],
+                        "didError": false,
+                        "earliestPendingTime": 0,
+                        "earliestSuspendedTime": 0,
+                        "expirationTime": 0,
+                        "finishedWork": null,
+                        "firstBatch": null,
+                        "hydrate": false,
+                        "interactionThreadID": 15,
+                        "latestPendingTime": 0,
+                        "latestPingedTime": 0,
+                        "latestSuspendedTime": 0,
+                        "memoizedInteractions": Set {},
+                        "nextExpirationTimeToWorkOn": 0,
+                        "nextScheduledRoot": null,
+                        "pendingChildren": null,
+                        "pendingCommitExpirationTime": 0,
+                        "pendingContext": null,
+                        "pendingInteractionMap": Map {},
+                        "pingCache": null,
+                        "timeoutHandle": -1,
+                      },
+                      "tag": 3,
+                      "treeBaseDuration": 0,
+                      "type": null,
+                      "updateQueue": Object {
+                        "baseState": null,
+                        "firstCapturedEffect": null,
+                        "firstCapturedUpdate": null,
+                        "firstEffect": null,
+                        "firstUpdate": Object {
+                          "callback": null,
+                          "expirationTime": 1073741823,
+                          "next": null,
+                          "nextEffect": null,
+                          "payload": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={Object {}}
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "tag": 0,
+                        },
+                        "lastCapturedEffect": null,
+                        "lastCapturedUpdate": null,
+                        "lastEffect": null,
+                        "lastUpdate": Object {
+                          "callback": null,
+                          "expirationTime": 1073741823,
+                          "next": null,
+                          "nextEffect": null,
+                          "payload": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={Object {}}
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "tag": 0,
+                        },
+                      },
+                    },
+                    "child": [Circular],
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 32,
+                    "elementType": null,
+                    "expirationTime": 0,
+                    "firstEffect": [Circular],
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": [Circular],
+                    "memoizedProps": null,
+                    "memoizedState": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={Object {}}
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": null,
+                    "ref": null,
+                    "return": null,
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": Object {
+                      "containerInfo": <div>
+                        <div
+                          class="dashboard-card engagement"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Engagement Trends
+                          </div>
+                        </div>
+                        <div
+                          class="dashboard-card upselling"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Upselling Partners
+                          </div>
+                          <div>
+                            upselling component
+                          </div>
+                        </div>
+                      </div>,
+                      "context": Object {},
+                      "current": [Circular],
+                      "didError": false,
+                      "earliestPendingTime": 0,
+                      "earliestSuspendedTime": 0,
+                      "expirationTime": 0,
+                      "finishedWork": null,
+                      "firstBatch": null,
+                      "hydrate": false,
+                      "interactionThreadID": 15,
+                      "latestPendingTime": 0,
+                      "latestPingedTime": 0,
+                      "latestSuspendedTime": 0,
+                      "memoizedInteractions": Set {},
+                      "nextExpirationTimeToWorkOn": 0,
+                      "nextScheduledRoot": null,
+                      "pendingChildren": null,
+                      "pendingCommitExpirationTime": 0,
+                      "pendingContext": null,
+                      "pendingInteractionMap": Map {},
+                      "pingCache": null,
+                      "timeoutHandle": -1,
+                    },
+                    "tag": 3,
+                    "treeBaseDuration": 0,
+                    "type": null,
+                    "updateQueue": Object {
+                      "baseState": Object {
+                        "element": <WrapperComponent
+                          Component={[Function]}
+                          context={null}
+                          props={Object {}}
+                          wrappingComponentProps={null}
+                        />,
+                      },
+                      "firstCapturedEffect": null,
+                      "firstCapturedUpdate": null,
+                      "firstEffect": null,
+                      "firstUpdate": null,
+                      "lastCapturedEffect": null,
+                      "lastCapturedUpdate": null,
+                      "lastEffect": null,
+                      "lastUpdate": null,
+                    },
+                  },
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": WrapperComponent {
+                    "_reactInternalFiber": [Circular],
+                    "_reactInternalInstance": Object {},
+                    "context": Object {},
+                    "props": Object {
+                      "Component": [Function],
+                      "context": null,
+                      "props": Object {},
+                      "wrappingComponentProps": null,
+                    },
+                    "refs": Object {},
+                    "rootFinderInstance": null,
+                    "state": Object {
+                      "context": null,
+                      "mount": true,
+                      "props": Object {},
+                      "wrappingComponentProps": null,
+                    },
+                    "updater": Object {
+                      "enqueueForceUpdate": [Function],
+                      "enqueueReplaceState": [Function],
+                      "enqueueSetState": [Function],
+                      "isMounted": [Function],
+                    },
+                  },
+                  "tag": 1,
+                  "treeBaseDuration": 0,
+                  "type": [Function],
+                  "updateQueue": null,
+                },
+                "_debugSource": null,
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": null,
+                "child": [Circular],
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 1,
+                "elementType": [Function],
+                "expirationTime": 0,
+                "firstEffect": null,
+                "index": 0,
+                "key": null,
+                "lastEffect": null,
+                "memoizedProps": Object {},
+                "memoizedState": null,
+                "mode": 0,
+                "nextEffect": null,
+                "pendingProps": Object {},
+                "ref": null,
+                "return": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 62,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": null,
+                  "_debugSource": null,
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": null,
+                  "child": [Circular],
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 1,
+                  "elementType": [Function],
+                  "expirationTime": 0,
+                  "firstEffect": null,
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": null,
+                  "memoizedProps": Object {
+                    "Component": [Function],
+                    "context": null,
+                    "props": Object {},
+                    "wrappingComponentProps": null,
+                  },
+                  "memoizedState": Object {
+                    "context": null,
+                    "mount": true,
+                    "props": Object {},
+                    "wrappingComponentProps": null,
+                  },
+                  "mode": 0,
+                  "nextEffect": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 60,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": null,
+                    "_debugSource": null,
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": FiberNode {
+                      "_debugHookTypes": null,
+                      "_debugID": 60,
+                      "_debugIsCurrentlyTiming": false,
+                      "_debugOwner": null,
+                      "_debugSource": null,
+                      "actualDuration": 0,
+                      "actualStartTime": -1,
+                      "alternate": [Circular],
+                      "child": null,
+                      "childExpirationTime": 0,
+                      "contextDependencies": null,
+                      "effectTag": 0,
+                      "elementType": null,
+                      "expirationTime": 1073741823,
+                      "firstEffect": null,
+                      "index": 0,
+                      "key": null,
+                      "lastEffect": null,
+                      "memoizedProps": null,
+                      "memoizedState": null,
+                      "mode": 0,
+                      "nextEffect": null,
+                      "pendingProps": null,
+                      "ref": null,
+                      "return": null,
+                      "selfBaseDuration": 0,
+                      "sibling": null,
+                      "stateNode": Object {
+                        "containerInfo": <div>
+                          <div
+                            class="dashboard-card engagement"
+                          >
+                            <div
+                              class="title"
+                            >
+                              Engagement Trends
+                            </div>
+                          </div>
+                          <div
+                            class="dashboard-card upselling"
+                          >
+                            <div
+                              class="title"
+                            >
+                              Upselling Partners
+                            </div>
+                            <div>
+                              upselling component
+                            </div>
+                          </div>
+                        </div>,
+                        "context": Object {},
+                        "current": [Circular],
+                        "didError": false,
+                        "earliestPendingTime": 0,
+                        "earliestSuspendedTime": 0,
+                        "expirationTime": 0,
+                        "finishedWork": null,
+                        "firstBatch": null,
+                        "hydrate": false,
+                        "interactionThreadID": 15,
+                        "latestPendingTime": 0,
+                        "latestPingedTime": 0,
+                        "latestSuspendedTime": 0,
+                        "memoizedInteractions": Set {},
+                        "nextExpirationTimeToWorkOn": 0,
+                        "nextScheduledRoot": null,
+                        "pendingChildren": null,
+                        "pendingCommitExpirationTime": 0,
+                        "pendingContext": null,
+                        "pendingInteractionMap": Map {},
+                        "pingCache": null,
+                        "timeoutHandle": -1,
+                      },
+                      "tag": 3,
+                      "treeBaseDuration": 0,
+                      "type": null,
+                      "updateQueue": Object {
+                        "baseState": null,
+                        "firstCapturedEffect": null,
+                        "firstCapturedUpdate": null,
+                        "firstEffect": null,
+                        "firstUpdate": Object {
+                          "callback": null,
+                          "expirationTime": 1073741823,
+                          "next": null,
+                          "nextEffect": null,
+                          "payload": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={Object {}}
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "tag": 0,
+                        },
+                        "lastCapturedEffect": null,
+                        "lastCapturedUpdate": null,
+                        "lastEffect": null,
+                        "lastUpdate": Object {
+                          "callback": null,
+                          "expirationTime": 1073741823,
+                          "next": null,
+                          "nextEffect": null,
+                          "payload": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={Object {}}
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "tag": 0,
+                        },
+                      },
+                    },
+                    "child": [Circular],
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 32,
+                    "elementType": null,
+                    "expirationTime": 0,
+                    "firstEffect": [Circular],
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": [Circular],
+                    "memoizedProps": null,
+                    "memoizedState": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={Object {}}
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": null,
+                    "ref": null,
+                    "return": null,
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": Object {
+                      "containerInfo": <div>
+                        <div
+                          class="dashboard-card engagement"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Engagement Trends
+                          </div>
+                        </div>
+                        <div
+                          class="dashboard-card upselling"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Upselling Partners
+                          </div>
+                          <div>
+                            upselling component
+                          </div>
+                        </div>
+                      </div>,
+                      "context": Object {},
+                      "current": [Circular],
+                      "didError": false,
+                      "earliestPendingTime": 0,
+                      "earliestSuspendedTime": 0,
+                      "expirationTime": 0,
+                      "finishedWork": null,
+                      "firstBatch": null,
+                      "hydrate": false,
+                      "interactionThreadID": 15,
+                      "latestPendingTime": 0,
+                      "latestPingedTime": 0,
+                      "latestSuspendedTime": 0,
+                      "memoizedInteractions": Set {},
+                      "nextExpirationTimeToWorkOn": 0,
+                      "nextScheduledRoot": null,
+                      "pendingChildren": null,
+                      "pendingCommitExpirationTime": 0,
+                      "pendingContext": null,
+                      "pendingInteractionMap": Map {},
+                      "pingCache": null,
+                      "timeoutHandle": -1,
+                    },
+                    "tag": 3,
+                    "treeBaseDuration": 0,
+                    "type": null,
+                    "updateQueue": Object {
+                      "baseState": Object {
+                        "element": <WrapperComponent
+                          Component={[Function]}
+                          context={null}
+                          props={Object {}}
+                          wrappingComponentProps={null}
+                        />,
+                      },
+                      "firstCapturedEffect": null,
+                      "firstCapturedUpdate": null,
+                      "firstEffect": null,
+                      "firstUpdate": null,
+                      "lastCapturedEffect": null,
+                      "lastCapturedUpdate": null,
+                      "lastEffect": null,
+                      "lastUpdate": null,
+                    },
+                  },
+                  "pendingProps": Object {
+                    "Component": [Function],
+                    "context": null,
+                    "props": Object {},
+                    "wrappingComponentProps": null,
+                  },
+                  "ref": null,
+                  "return": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 60,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": null,
+                    "_debugSource": null,
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": FiberNode {
+                      "_debugHookTypes": null,
+                      "_debugID": 60,
+                      "_debugIsCurrentlyTiming": false,
+                      "_debugOwner": null,
+                      "_debugSource": null,
+                      "actualDuration": 0,
+                      "actualStartTime": -1,
+                      "alternate": [Circular],
+                      "child": null,
+                      "childExpirationTime": 0,
+                      "contextDependencies": null,
+                      "effectTag": 0,
+                      "elementType": null,
+                      "expirationTime": 1073741823,
+                      "firstEffect": null,
+                      "index": 0,
+                      "key": null,
+                      "lastEffect": null,
+                      "memoizedProps": null,
+                      "memoizedState": null,
+                      "mode": 0,
+                      "nextEffect": null,
+                      "pendingProps": null,
+                      "ref": null,
+                      "return": null,
+                      "selfBaseDuration": 0,
+                      "sibling": null,
+                      "stateNode": Object {
+                        "containerInfo": <div>
+                          <div
+                            class="dashboard-card engagement"
+                          >
+                            <div
+                              class="title"
+                            >
+                              Engagement Trends
+                            </div>
+                          </div>
+                          <div
+                            class="dashboard-card upselling"
+                          >
+                            <div
+                              class="title"
+                            >
+                              Upselling Partners
+                            </div>
+                            <div>
+                              upselling component
+                            </div>
+                          </div>
+                        </div>,
+                        "context": Object {},
+                        "current": [Circular],
+                        "didError": false,
+                        "earliestPendingTime": 0,
+                        "earliestSuspendedTime": 0,
+                        "expirationTime": 0,
+                        "finishedWork": null,
+                        "firstBatch": null,
+                        "hydrate": false,
+                        "interactionThreadID": 15,
+                        "latestPendingTime": 0,
+                        "latestPingedTime": 0,
+                        "latestSuspendedTime": 0,
+                        "memoizedInteractions": Set {},
+                        "nextExpirationTimeToWorkOn": 0,
+                        "nextScheduledRoot": null,
+                        "pendingChildren": null,
+                        "pendingCommitExpirationTime": 0,
+                        "pendingContext": null,
+                        "pendingInteractionMap": Map {},
+                        "pingCache": null,
+                        "timeoutHandle": -1,
+                      },
+                      "tag": 3,
+                      "treeBaseDuration": 0,
+                      "type": null,
+                      "updateQueue": Object {
+                        "baseState": null,
+                        "firstCapturedEffect": null,
+                        "firstCapturedUpdate": null,
+                        "firstEffect": null,
+                        "firstUpdate": Object {
+                          "callback": null,
+                          "expirationTime": 1073741823,
+                          "next": null,
+                          "nextEffect": null,
+                          "payload": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={Object {}}
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "tag": 0,
+                        },
+                        "lastCapturedEffect": null,
+                        "lastCapturedUpdate": null,
+                        "lastEffect": null,
+                        "lastUpdate": Object {
+                          "callback": null,
+                          "expirationTime": 1073741823,
+                          "next": null,
+                          "nextEffect": null,
+                          "payload": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={Object {}}
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "tag": 0,
+                        },
+                      },
+                    },
+                    "child": [Circular],
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 32,
+                    "elementType": null,
+                    "expirationTime": 0,
+                    "firstEffect": [Circular],
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": [Circular],
+                    "memoizedProps": null,
+                    "memoizedState": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={Object {}}
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": null,
+                    "ref": null,
+                    "return": null,
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": Object {
+                      "containerInfo": <div>
+                        <div
+                          class="dashboard-card engagement"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Engagement Trends
+                          </div>
+                        </div>
+                        <div
+                          class="dashboard-card upselling"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Upselling Partners
+                          </div>
+                          <div>
+                            upselling component
+                          </div>
+                        </div>
+                      </div>,
+                      "context": Object {},
+                      "current": [Circular],
+                      "didError": false,
+                      "earliestPendingTime": 0,
+                      "earliestSuspendedTime": 0,
+                      "expirationTime": 0,
+                      "finishedWork": null,
+                      "firstBatch": null,
+                      "hydrate": false,
+                      "interactionThreadID": 15,
+                      "latestPendingTime": 0,
+                      "latestPingedTime": 0,
+                      "latestSuspendedTime": 0,
+                      "memoizedInteractions": Set {},
+                      "nextExpirationTimeToWorkOn": 0,
+                      "nextScheduledRoot": null,
+                      "pendingChildren": null,
+                      "pendingCommitExpirationTime": 0,
+                      "pendingContext": null,
+                      "pendingInteractionMap": Map {},
+                      "pingCache": null,
+                      "timeoutHandle": -1,
+                    },
+                    "tag": 3,
+                    "treeBaseDuration": 0,
+                    "type": null,
+                    "updateQueue": Object {
+                      "baseState": Object {
+                        "element": <WrapperComponent
+                          Component={[Function]}
+                          context={null}
+                          props={Object {}}
+                          wrappingComponentProps={null}
+                        />,
+                      },
+                      "firstCapturedEffect": null,
+                      "firstCapturedUpdate": null,
+                      "firstEffect": null,
+                      "firstUpdate": null,
+                      "lastCapturedEffect": null,
+                      "lastCapturedUpdate": null,
+                      "lastEffect": null,
+                      "lastUpdate": null,
+                    },
+                  },
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": WrapperComponent {
+                    "_reactInternalFiber": [Circular],
+                    "_reactInternalInstance": Object {},
+                    "context": Object {},
+                    "props": Object {
+                      "Component": [Function],
+                      "context": null,
+                      "props": Object {},
+                      "wrappingComponentProps": null,
+                    },
+                    "refs": Object {},
+                    "rootFinderInstance": null,
+                    "state": Object {
+                      "context": null,
+                      "mount": true,
+                      "props": Object {},
+                      "wrappingComponentProps": null,
+                    },
+                    "updater": Object {
+                      "enqueueForceUpdate": [Function],
+                      "enqueueReplaceState": [Function],
+                      "enqueueSetState": [Function],
+                      "isMounted": [Function],
+                    },
+                  },
+                  "tag": 1,
+                  "treeBaseDuration": 0,
+                  "type": [Function],
+                  "updateQueue": null,
+                },
+                "selfBaseDuration": 0,
+                "sibling": null,
+                "stateNode": Dashboard {
+                  "_reactInternalFiber": [Circular],
+                  "_reactInternalInstance": Object {},
+                  "context": Object {},
+                  "props": Object {},
+                  "refs": Object {},
+                  "renderUpselling": [Function],
+                  "state": null,
+                  "updater": Object {
+                    "enqueueForceUpdate": [Function],
+                    "enqueueReplaceState": [Function],
+                    "enqueueSetState": [Function],
+                    "isMounted": [Function],
+                  },
+                },
+                "tag": 1,
+                "treeBaseDuration": 0,
+                "type": [Function],
+                "updateQueue": null,
+              },
+              "_debugSource": Object {
+                "fileName": "/Users/kevinkoech/Documents/bp-esa-frontend/src/components/Dashboard/index.jsx",
+                "lineNumber": 23,
+              },
+              "actualDuration": 0,
+              "actualStartTime": -1,
+              "alternate": null,
+              "child": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 66,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": [Circular],
+                "_debugSource": Object {
+                  "fileName": "/Users/kevinkoech/Documents/bp-esa-frontend/src/components/Dashboard/Card.jsx",
+                  "lineNumber": 20,
+                },
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": null,
+                "child": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 67,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": [Circular],
+                  "_debugSource": Object {
+                    "fileName": "/Users/kevinkoech/Documents/bp-esa-frontend/src/components/Dashboard/Card.jsx",
+                    "lineNumber": 21,
+                  },
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": null,
+                  "child": null,
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 0,
+                  "elementType": "div",
+                  "expirationTime": 0,
+                  "firstEffect": null,
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": null,
+                  "memoizedProps": Object {
+                    "children": "Engagement Trends",
+                    "className": "title",
+                  },
+                  "memoizedState": null,
+                  "mode": 0,
+                  "nextEffect": null,
+                  "pendingProps": Object {
+                    "children": "Engagement Trends",
+                    "className": "title",
+                  },
+                  "ref": null,
+                  "return": [Circular],
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": <div
+                    class="title"
+                  >
+                    Engagement Trends
+                  </div>,
+                  "tag": 5,
+                  "treeBaseDuration": 0,
+                  "type": "div",
+                  "updateQueue": null,
+                },
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 0,
+                "elementType": "div",
+                "expirationTime": 0,
+                "firstEffect": null,
+                "index": 0,
+                "key": null,
+                "lastEffect": null,
+                "memoizedProps": Object {
+                  "children": Array [
+                    <div
+                      className="title"
+                    >
+                      Engagement Trends
+                    </div>,
+                    undefined,
+                  ],
+                  "className": "dashboard-card engagement",
+                },
+                "memoizedState": null,
+                "mode": 0,
+                "nextEffect": null,
+                "pendingProps": Object {
+                  "children": Array [
+                    <div
+                      className="title"
+                    >
+                      Engagement Trends
+                    </div>,
+                    undefined,
+                  ],
+                  "className": "dashboard-card engagement",
+                },
+                "ref": null,
+                "return": [Circular],
+                "selfBaseDuration": 0,
+                "sibling": null,
+                "stateNode": <div
+                  class="dashboard-card engagement"
+                >
+                  <div
+                    class="title"
+                  >
+                    Engagement Trends
+                  </div>
+                </div>,
+                "tag": 5,
+                "treeBaseDuration": 0,
+                "type": "div",
+                "updateQueue": null,
+              },
+              "childExpirationTime": 0,
+              "contextDependencies": null,
+              "effectTag": 1,
+              "elementType": [Function],
+              "expirationTime": 0,
+              "firstEffect": null,
+              "index": 0,
+              "key": null,
+              "lastEffect": null,
+              "memoizedProps": Object {
+                "classes": "engagement",
+                "component": [Function],
+                "title": "Engagement Trends",
+              },
+              "memoizedState": null,
+              "mode": 0,
+              "nextEffect": null,
+              "pendingProps": Object {
+                "classes": "engagement",
+                "component": [Function],
+                "title": "Engagement Trends",
+              },
+              "ref": null,
+              "return": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 63,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 62,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": null,
+                  "_debugSource": null,
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": null,
+                  "child": [Circular],
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 1,
+                  "elementType": [Function],
+                  "expirationTime": 0,
+                  "firstEffect": null,
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": null,
+                  "memoizedProps": Object {
+                    "Component": [Function],
+                    "context": null,
+                    "props": Object {},
+                    "wrappingComponentProps": null,
+                  },
+                  "memoizedState": Object {
+                    "context": null,
+                    "mount": true,
+                    "props": Object {},
+                    "wrappingComponentProps": null,
+                  },
+                  "mode": 0,
+                  "nextEffect": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 60,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": null,
+                    "_debugSource": null,
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": FiberNode {
+                      "_debugHookTypes": null,
+                      "_debugID": 60,
+                      "_debugIsCurrentlyTiming": false,
+                      "_debugOwner": null,
+                      "_debugSource": null,
+                      "actualDuration": 0,
+                      "actualStartTime": -1,
+                      "alternate": [Circular],
+                      "child": null,
+                      "childExpirationTime": 0,
+                      "contextDependencies": null,
+                      "effectTag": 0,
+                      "elementType": null,
+                      "expirationTime": 1073741823,
+                      "firstEffect": null,
+                      "index": 0,
+                      "key": null,
+                      "lastEffect": null,
+                      "memoizedProps": null,
+                      "memoizedState": null,
+                      "mode": 0,
+                      "nextEffect": null,
+                      "pendingProps": null,
+                      "ref": null,
+                      "return": null,
+                      "selfBaseDuration": 0,
+                      "sibling": null,
+                      "stateNode": Object {
+                        "containerInfo": <div>
+                          <div
+                            class="dashboard-card engagement"
+                          >
+                            <div
+                              class="title"
+                            >
+                              Engagement Trends
+                            </div>
+                          </div>
+                          <div
+                            class="dashboard-card upselling"
+                          >
+                            <div
+                              class="title"
+                            >
+                              Upselling Partners
+                            </div>
+                            <div>
+                              upselling component
+                            </div>
+                          </div>
+                        </div>,
+                        "context": Object {},
+                        "current": [Circular],
+                        "didError": false,
+                        "earliestPendingTime": 0,
+                        "earliestSuspendedTime": 0,
+                        "expirationTime": 0,
+                        "finishedWork": null,
+                        "firstBatch": null,
+                        "hydrate": false,
+                        "interactionThreadID": 15,
+                        "latestPendingTime": 0,
+                        "latestPingedTime": 0,
+                        "latestSuspendedTime": 0,
+                        "memoizedInteractions": Set {},
+                        "nextExpirationTimeToWorkOn": 0,
+                        "nextScheduledRoot": null,
+                        "pendingChildren": null,
+                        "pendingCommitExpirationTime": 0,
+                        "pendingContext": null,
+                        "pendingInteractionMap": Map {},
+                        "pingCache": null,
+                        "timeoutHandle": -1,
+                      },
+                      "tag": 3,
+                      "treeBaseDuration": 0,
+                      "type": null,
+                      "updateQueue": Object {
+                        "baseState": null,
+                        "firstCapturedEffect": null,
+                        "firstCapturedUpdate": null,
+                        "firstEffect": null,
+                        "firstUpdate": Object {
+                          "callback": null,
+                          "expirationTime": 1073741823,
+                          "next": null,
+                          "nextEffect": null,
+                          "payload": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={Object {}}
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "tag": 0,
+                        },
+                        "lastCapturedEffect": null,
+                        "lastCapturedUpdate": null,
+                        "lastEffect": null,
+                        "lastUpdate": Object {
+                          "callback": null,
+                          "expirationTime": 1073741823,
+                          "next": null,
+                          "nextEffect": null,
+                          "payload": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={Object {}}
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "tag": 0,
+                        },
+                      },
+                    },
+                    "child": [Circular],
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 32,
+                    "elementType": null,
+                    "expirationTime": 0,
+                    "firstEffect": [Circular],
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": [Circular],
+                    "memoizedProps": null,
+                    "memoizedState": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={Object {}}
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": null,
+                    "ref": null,
+                    "return": null,
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": Object {
+                      "containerInfo": <div>
+                        <div
+                          class="dashboard-card engagement"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Engagement Trends
+                          </div>
+                        </div>
+                        <div
+                          class="dashboard-card upselling"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Upselling Partners
+                          </div>
+                          <div>
+                            upselling component
+                          </div>
+                        </div>
+                      </div>,
+                      "context": Object {},
+                      "current": [Circular],
+                      "didError": false,
+                      "earliestPendingTime": 0,
+                      "earliestSuspendedTime": 0,
+                      "expirationTime": 0,
+                      "finishedWork": null,
+                      "firstBatch": null,
+                      "hydrate": false,
+                      "interactionThreadID": 15,
+                      "latestPendingTime": 0,
+                      "latestPingedTime": 0,
+                      "latestSuspendedTime": 0,
+                      "memoizedInteractions": Set {},
+                      "nextExpirationTimeToWorkOn": 0,
+                      "nextScheduledRoot": null,
+                      "pendingChildren": null,
+                      "pendingCommitExpirationTime": 0,
+                      "pendingContext": null,
+                      "pendingInteractionMap": Map {},
+                      "pingCache": null,
+                      "timeoutHandle": -1,
+                    },
+                    "tag": 3,
+                    "treeBaseDuration": 0,
+                    "type": null,
+                    "updateQueue": Object {
+                      "baseState": Object {
+                        "element": <WrapperComponent
+                          Component={[Function]}
+                          context={null}
+                          props={Object {}}
+                          wrappingComponentProps={null}
+                        />,
+                      },
+                      "firstCapturedEffect": null,
+                      "firstCapturedUpdate": null,
+                      "firstEffect": null,
+                      "firstUpdate": null,
+                      "lastCapturedEffect": null,
+                      "lastCapturedUpdate": null,
+                      "lastEffect": null,
+                      "lastUpdate": null,
+                    },
+                  },
+                  "pendingProps": Object {
+                    "Component": [Function],
+                    "context": null,
+                    "props": Object {},
+                    "wrappingComponentProps": null,
+                  },
+                  "ref": null,
+                  "return": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 60,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": null,
+                    "_debugSource": null,
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": FiberNode {
+                      "_debugHookTypes": null,
+                      "_debugID": 60,
+                      "_debugIsCurrentlyTiming": false,
+                      "_debugOwner": null,
+                      "_debugSource": null,
+                      "actualDuration": 0,
+                      "actualStartTime": -1,
+                      "alternate": [Circular],
+                      "child": null,
+                      "childExpirationTime": 0,
+                      "contextDependencies": null,
+                      "effectTag": 0,
+                      "elementType": null,
+                      "expirationTime": 1073741823,
+                      "firstEffect": null,
+                      "index": 0,
+                      "key": null,
+                      "lastEffect": null,
+                      "memoizedProps": null,
+                      "memoizedState": null,
+                      "mode": 0,
+                      "nextEffect": null,
+                      "pendingProps": null,
+                      "ref": null,
+                      "return": null,
+                      "selfBaseDuration": 0,
+                      "sibling": null,
+                      "stateNode": Object {
+                        "containerInfo": <div>
+                          <div
+                            class="dashboard-card engagement"
+                          >
+                            <div
+                              class="title"
+                            >
+                              Engagement Trends
+                            </div>
+                          </div>
+                          <div
+                            class="dashboard-card upselling"
+                          >
+                            <div
+                              class="title"
+                            >
+                              Upselling Partners
+                            </div>
+                            <div>
+                              upselling component
+                            </div>
+                          </div>
+                        </div>,
+                        "context": Object {},
+                        "current": [Circular],
+                        "didError": false,
+                        "earliestPendingTime": 0,
+                        "earliestSuspendedTime": 0,
+                        "expirationTime": 0,
+                        "finishedWork": null,
+                        "firstBatch": null,
+                        "hydrate": false,
+                        "interactionThreadID": 15,
+                        "latestPendingTime": 0,
+                        "latestPingedTime": 0,
+                        "latestSuspendedTime": 0,
+                        "memoizedInteractions": Set {},
+                        "nextExpirationTimeToWorkOn": 0,
+                        "nextScheduledRoot": null,
+                        "pendingChildren": null,
+                        "pendingCommitExpirationTime": 0,
+                        "pendingContext": null,
+                        "pendingInteractionMap": Map {},
+                        "pingCache": null,
+                        "timeoutHandle": -1,
+                      },
+                      "tag": 3,
+                      "treeBaseDuration": 0,
+                      "type": null,
+                      "updateQueue": Object {
+                        "baseState": null,
+                        "firstCapturedEffect": null,
+                        "firstCapturedUpdate": null,
+                        "firstEffect": null,
+                        "firstUpdate": Object {
+                          "callback": null,
+                          "expirationTime": 1073741823,
+                          "next": null,
+                          "nextEffect": null,
+                          "payload": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={Object {}}
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "tag": 0,
+                        },
+                        "lastCapturedEffect": null,
+                        "lastCapturedUpdate": null,
+                        "lastEffect": null,
+                        "lastUpdate": Object {
+                          "callback": null,
+                          "expirationTime": 1073741823,
+                          "next": null,
+                          "nextEffect": null,
+                          "payload": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={Object {}}
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "tag": 0,
+                        },
+                      },
+                    },
+                    "child": [Circular],
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 32,
+                    "elementType": null,
+                    "expirationTime": 0,
+                    "firstEffect": [Circular],
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": [Circular],
+                    "memoizedProps": null,
+                    "memoizedState": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={Object {}}
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": null,
+                    "ref": null,
+                    "return": null,
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": Object {
+                      "containerInfo": <div>
+                        <div
+                          class="dashboard-card engagement"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Engagement Trends
+                          </div>
+                        </div>
+                        <div
+                          class="dashboard-card upselling"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Upselling Partners
+                          </div>
+                          <div>
+                            upselling component
+                          </div>
+                        </div>
+                      </div>,
+                      "context": Object {},
+                      "current": [Circular],
+                      "didError": false,
+                      "earliestPendingTime": 0,
+                      "earliestSuspendedTime": 0,
+                      "expirationTime": 0,
+                      "finishedWork": null,
+                      "firstBatch": null,
+                      "hydrate": false,
+                      "interactionThreadID": 15,
+                      "latestPendingTime": 0,
+                      "latestPingedTime": 0,
+                      "latestSuspendedTime": 0,
+                      "memoizedInteractions": Set {},
+                      "nextExpirationTimeToWorkOn": 0,
+                      "nextScheduledRoot": null,
+                      "pendingChildren": null,
+                      "pendingCommitExpirationTime": 0,
+                      "pendingContext": null,
+                      "pendingInteractionMap": Map {},
+                      "pingCache": null,
+                      "timeoutHandle": -1,
+                    },
+                    "tag": 3,
+                    "treeBaseDuration": 0,
+                    "type": null,
+                    "updateQueue": Object {
+                      "baseState": Object {
+                        "element": <WrapperComponent
+                          Component={[Function]}
+                          context={null}
+                          props={Object {}}
+                          wrappingComponentProps={null}
+                        />,
+                      },
+                      "firstCapturedEffect": null,
+                      "firstCapturedUpdate": null,
+                      "firstEffect": null,
+                      "firstUpdate": null,
+                      "lastCapturedEffect": null,
+                      "lastCapturedUpdate": null,
+                      "lastEffect": null,
+                      "lastUpdate": null,
+                    },
+                  },
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": WrapperComponent {
+                    "_reactInternalFiber": [Circular],
+                    "_reactInternalInstance": Object {},
+                    "context": Object {},
+                    "props": Object {
+                      "Component": [Function],
+                      "context": null,
+                      "props": Object {},
+                      "wrappingComponentProps": null,
+                    },
+                    "refs": Object {},
+                    "rootFinderInstance": null,
+                    "state": Object {
+                      "context": null,
+                      "mount": true,
+                      "props": Object {},
+                      "wrappingComponentProps": null,
+                    },
+                    "updater": Object {
+                      "enqueueForceUpdate": [Function],
+                      "enqueueReplaceState": [Function],
+                      "enqueueSetState": [Function],
+                      "isMounted": [Function],
+                    },
+                  },
+                  "tag": 1,
+                  "treeBaseDuration": 0,
+                  "type": [Function],
+                  "updateQueue": null,
+                },
+                "_debugSource": null,
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": null,
+                "child": [Circular],
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 1,
+                "elementType": [Function],
+                "expirationTime": 0,
+                "firstEffect": null,
+                "index": 0,
+                "key": null,
+                "lastEffect": null,
+                "memoizedProps": Object {},
+                "memoizedState": null,
+                "mode": 0,
+                "nextEffect": null,
+                "pendingProps": Object {},
+                "ref": null,
+                "return": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 62,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": null,
+                  "_debugSource": null,
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": null,
+                  "child": [Circular],
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 1,
+                  "elementType": [Function],
+                  "expirationTime": 0,
+                  "firstEffect": null,
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": null,
+                  "memoizedProps": Object {
+                    "Component": [Function],
+                    "context": null,
+                    "props": Object {},
+                    "wrappingComponentProps": null,
+                  },
+                  "memoizedState": Object {
+                    "context": null,
+                    "mount": true,
+                    "props": Object {},
+                    "wrappingComponentProps": null,
+                  },
+                  "mode": 0,
+                  "nextEffect": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 60,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": null,
+                    "_debugSource": null,
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": FiberNode {
+                      "_debugHookTypes": null,
+                      "_debugID": 60,
+                      "_debugIsCurrentlyTiming": false,
+                      "_debugOwner": null,
+                      "_debugSource": null,
+                      "actualDuration": 0,
+                      "actualStartTime": -1,
+                      "alternate": [Circular],
+                      "child": null,
+                      "childExpirationTime": 0,
+                      "contextDependencies": null,
+                      "effectTag": 0,
+                      "elementType": null,
+                      "expirationTime": 1073741823,
+                      "firstEffect": null,
+                      "index": 0,
+                      "key": null,
+                      "lastEffect": null,
+                      "memoizedProps": null,
+                      "memoizedState": null,
+                      "mode": 0,
+                      "nextEffect": null,
+                      "pendingProps": null,
+                      "ref": null,
+                      "return": null,
+                      "selfBaseDuration": 0,
+                      "sibling": null,
+                      "stateNode": Object {
+                        "containerInfo": <div>
+                          <div
+                            class="dashboard-card engagement"
+                          >
+                            <div
+                              class="title"
+                            >
+                              Engagement Trends
+                            </div>
+                          </div>
+                          <div
+                            class="dashboard-card upselling"
+                          >
+                            <div
+                              class="title"
+                            >
+                              Upselling Partners
+                            </div>
+                            <div>
+                              upselling component
+                            </div>
+                          </div>
+                        </div>,
+                        "context": Object {},
+                        "current": [Circular],
+                        "didError": false,
+                        "earliestPendingTime": 0,
+                        "earliestSuspendedTime": 0,
+                        "expirationTime": 0,
+                        "finishedWork": null,
+                        "firstBatch": null,
+                        "hydrate": false,
+                        "interactionThreadID": 15,
+                        "latestPendingTime": 0,
+                        "latestPingedTime": 0,
+                        "latestSuspendedTime": 0,
+                        "memoizedInteractions": Set {},
+                        "nextExpirationTimeToWorkOn": 0,
+                        "nextScheduledRoot": null,
+                        "pendingChildren": null,
+                        "pendingCommitExpirationTime": 0,
+                        "pendingContext": null,
+                        "pendingInteractionMap": Map {},
+                        "pingCache": null,
+                        "timeoutHandle": -1,
+                      },
+                      "tag": 3,
+                      "treeBaseDuration": 0,
+                      "type": null,
+                      "updateQueue": Object {
+                        "baseState": null,
+                        "firstCapturedEffect": null,
+                        "firstCapturedUpdate": null,
+                        "firstEffect": null,
+                        "firstUpdate": Object {
+                          "callback": null,
+                          "expirationTime": 1073741823,
+                          "next": null,
+                          "nextEffect": null,
+                          "payload": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={Object {}}
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "tag": 0,
+                        },
+                        "lastCapturedEffect": null,
+                        "lastCapturedUpdate": null,
+                        "lastEffect": null,
+                        "lastUpdate": Object {
+                          "callback": null,
+                          "expirationTime": 1073741823,
+                          "next": null,
+                          "nextEffect": null,
+                          "payload": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={Object {}}
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "tag": 0,
+                        },
+                      },
+                    },
+                    "child": [Circular],
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 32,
+                    "elementType": null,
+                    "expirationTime": 0,
+                    "firstEffect": [Circular],
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": [Circular],
+                    "memoizedProps": null,
+                    "memoizedState": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={Object {}}
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": null,
+                    "ref": null,
+                    "return": null,
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": Object {
+                      "containerInfo": <div>
+                        <div
+                          class="dashboard-card engagement"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Engagement Trends
+                          </div>
+                        </div>
+                        <div
+                          class="dashboard-card upselling"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Upselling Partners
+                          </div>
+                          <div>
+                            upselling component
+                          </div>
+                        </div>
+                      </div>,
+                      "context": Object {},
+                      "current": [Circular],
+                      "didError": false,
+                      "earliestPendingTime": 0,
+                      "earliestSuspendedTime": 0,
+                      "expirationTime": 0,
+                      "finishedWork": null,
+                      "firstBatch": null,
+                      "hydrate": false,
+                      "interactionThreadID": 15,
+                      "latestPendingTime": 0,
+                      "latestPingedTime": 0,
+                      "latestSuspendedTime": 0,
+                      "memoizedInteractions": Set {},
+                      "nextExpirationTimeToWorkOn": 0,
+                      "nextScheduledRoot": null,
+                      "pendingChildren": null,
+                      "pendingCommitExpirationTime": 0,
+                      "pendingContext": null,
+                      "pendingInteractionMap": Map {},
+                      "pingCache": null,
+                      "timeoutHandle": -1,
+                    },
+                    "tag": 3,
+                    "treeBaseDuration": 0,
+                    "type": null,
+                    "updateQueue": Object {
+                      "baseState": Object {
+                        "element": <WrapperComponent
+                          Component={[Function]}
+                          context={null}
+                          props={Object {}}
+                          wrappingComponentProps={null}
+                        />,
+                      },
+                      "firstCapturedEffect": null,
+                      "firstCapturedUpdate": null,
+                      "firstEffect": null,
+                      "firstUpdate": null,
+                      "lastCapturedEffect": null,
+                      "lastCapturedUpdate": null,
+                      "lastEffect": null,
+                      "lastUpdate": null,
+                    },
+                  },
+                  "pendingProps": Object {
+                    "Component": [Function],
+                    "context": null,
+                    "props": Object {},
+                    "wrappingComponentProps": null,
+                  },
+                  "ref": null,
+                  "return": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 60,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": null,
+                    "_debugSource": null,
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": FiberNode {
+                      "_debugHookTypes": null,
+                      "_debugID": 60,
+                      "_debugIsCurrentlyTiming": false,
+                      "_debugOwner": null,
+                      "_debugSource": null,
+                      "actualDuration": 0,
+                      "actualStartTime": -1,
+                      "alternate": [Circular],
+                      "child": null,
+                      "childExpirationTime": 0,
+                      "contextDependencies": null,
+                      "effectTag": 0,
+                      "elementType": null,
+                      "expirationTime": 1073741823,
+                      "firstEffect": null,
+                      "index": 0,
+                      "key": null,
+                      "lastEffect": null,
+                      "memoizedProps": null,
+                      "memoizedState": null,
+                      "mode": 0,
+                      "nextEffect": null,
+                      "pendingProps": null,
+                      "ref": null,
+                      "return": null,
+                      "selfBaseDuration": 0,
+                      "sibling": null,
+                      "stateNode": Object {
+                        "containerInfo": <div>
+                          <div
+                            class="dashboard-card engagement"
+                          >
+                            <div
+                              class="title"
+                            >
+                              Engagement Trends
+                            </div>
+                          </div>
+                          <div
+                            class="dashboard-card upselling"
+                          >
+                            <div
+                              class="title"
+                            >
+                              Upselling Partners
+                            </div>
+                            <div>
+                              upselling component
+                            </div>
+                          </div>
+                        </div>,
+                        "context": Object {},
+                        "current": [Circular],
+                        "didError": false,
+                        "earliestPendingTime": 0,
+                        "earliestSuspendedTime": 0,
+                        "expirationTime": 0,
+                        "finishedWork": null,
+                        "firstBatch": null,
+                        "hydrate": false,
+                        "interactionThreadID": 15,
+                        "latestPendingTime": 0,
+                        "latestPingedTime": 0,
+                        "latestSuspendedTime": 0,
+                        "memoizedInteractions": Set {},
+                        "nextExpirationTimeToWorkOn": 0,
+                        "nextScheduledRoot": null,
+                        "pendingChildren": null,
+                        "pendingCommitExpirationTime": 0,
+                        "pendingContext": null,
+                        "pendingInteractionMap": Map {},
+                        "pingCache": null,
+                        "timeoutHandle": -1,
+                      },
+                      "tag": 3,
+                      "treeBaseDuration": 0,
+                      "type": null,
+                      "updateQueue": Object {
+                        "baseState": null,
+                        "firstCapturedEffect": null,
+                        "firstCapturedUpdate": null,
+                        "firstEffect": null,
+                        "firstUpdate": Object {
+                          "callback": null,
+                          "expirationTime": 1073741823,
+                          "next": null,
+                          "nextEffect": null,
+                          "payload": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={Object {}}
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "tag": 0,
+                        },
+                        "lastCapturedEffect": null,
+                        "lastCapturedUpdate": null,
+                        "lastEffect": null,
+                        "lastUpdate": Object {
+                          "callback": null,
+                          "expirationTime": 1073741823,
+                          "next": null,
+                          "nextEffect": null,
+                          "payload": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={Object {}}
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "tag": 0,
+                        },
+                      },
+                    },
+                    "child": [Circular],
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 32,
+                    "elementType": null,
+                    "expirationTime": 0,
+                    "firstEffect": [Circular],
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": [Circular],
+                    "memoizedProps": null,
+                    "memoizedState": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={Object {}}
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": null,
+                    "ref": null,
+                    "return": null,
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": Object {
+                      "containerInfo": <div>
+                        <div
+                          class="dashboard-card engagement"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Engagement Trends
+                          </div>
+                        </div>
+                        <div
+                          class="dashboard-card upselling"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Upselling Partners
+                          </div>
+                          <div>
+                            upselling component
+                          </div>
+                        </div>
+                      </div>,
+                      "context": Object {},
+                      "current": [Circular],
+                      "didError": false,
+                      "earliestPendingTime": 0,
+                      "earliestSuspendedTime": 0,
+                      "expirationTime": 0,
+                      "finishedWork": null,
+                      "firstBatch": null,
+                      "hydrate": false,
+                      "interactionThreadID": 15,
+                      "latestPendingTime": 0,
+                      "latestPingedTime": 0,
+                      "latestSuspendedTime": 0,
+                      "memoizedInteractions": Set {},
+                      "nextExpirationTimeToWorkOn": 0,
+                      "nextScheduledRoot": null,
+                      "pendingChildren": null,
+                      "pendingCommitExpirationTime": 0,
+                      "pendingContext": null,
+                      "pendingInteractionMap": Map {},
+                      "pingCache": null,
+                      "timeoutHandle": -1,
+                    },
+                    "tag": 3,
+                    "treeBaseDuration": 0,
+                    "type": null,
+                    "updateQueue": Object {
+                      "baseState": Object {
+                        "element": <WrapperComponent
+                          Component={[Function]}
+                          context={null}
+                          props={Object {}}
+                          wrappingComponentProps={null}
+                        />,
+                      },
+                      "firstCapturedEffect": null,
+                      "firstCapturedUpdate": null,
+                      "firstEffect": null,
+                      "firstUpdate": null,
+                      "lastCapturedEffect": null,
+                      "lastCapturedUpdate": null,
+                      "lastEffect": null,
+                      "lastUpdate": null,
+                    },
+                  },
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": WrapperComponent {
+                    "_reactInternalFiber": [Circular],
+                    "_reactInternalInstance": Object {},
+                    "context": Object {},
+                    "props": Object {
+                      "Component": [Function],
+                      "context": null,
+                      "props": Object {},
+                      "wrappingComponentProps": null,
+                    },
+                    "refs": Object {},
+                    "rootFinderInstance": null,
+                    "state": Object {
+                      "context": null,
+                      "mount": true,
+                      "props": Object {},
+                      "wrappingComponentProps": null,
+                    },
+                    "updater": Object {
+                      "enqueueForceUpdate": [Function],
+                      "enqueueReplaceState": [Function],
+                      "enqueueSetState": [Function],
+                      "isMounted": [Function],
+                    },
+                  },
+                  "tag": 1,
+                  "treeBaseDuration": 0,
+                  "type": [Function],
+                  "updateQueue": null,
+                },
+                "selfBaseDuration": 0,
+                "sibling": null,
+                "stateNode": Dashboard {
+                  "_reactInternalFiber": [Circular],
+                  "_reactInternalInstance": Object {},
+                  "context": Object {},
+                  "props": Object {},
+                  "refs": Object {},
+                  "renderUpselling": [Function],
+                  "state": null,
+                  "updater": Object {
+                    "enqueueForceUpdate": [Function],
+                    "enqueueReplaceState": [Function],
+                    "enqueueSetState": [Function],
+                    "isMounted": [Function],
+                  },
+                },
+                "tag": 1,
+                "treeBaseDuration": 0,
+                "type": [Function],
+                "updateQueue": null,
+              },
+              "selfBaseDuration": 0,
+              "sibling": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 65,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 63,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 62,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": null,
+                    "_debugSource": null,
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": null,
+                    "child": [Circular],
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 1,
+                    "elementType": [Function],
+                    "expirationTime": 0,
+                    "firstEffect": null,
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": null,
+                    "memoizedProps": Object {
+                      "Component": [Function],
+                      "context": null,
+                      "props": Object {},
+                      "wrappingComponentProps": null,
+                    },
+                    "memoizedState": Object {
+                      "context": null,
+                      "mount": true,
+                      "props": Object {},
+                      "wrappingComponentProps": null,
+                    },
+                    "mode": 0,
+                    "nextEffect": FiberNode {
+                      "_debugHookTypes": null,
+                      "_debugID": 60,
+                      "_debugIsCurrentlyTiming": false,
+                      "_debugOwner": null,
+                      "_debugSource": null,
+                      "actualDuration": 0,
+                      "actualStartTime": -1,
+                      "alternate": FiberNode {
+                        "_debugHookTypes": null,
+                        "_debugID": 60,
+                        "_debugIsCurrentlyTiming": false,
+                        "_debugOwner": null,
+                        "_debugSource": null,
+                        "actualDuration": 0,
+                        "actualStartTime": -1,
+                        "alternate": [Circular],
+                        "child": null,
+                        "childExpirationTime": 0,
+                        "contextDependencies": null,
+                        "effectTag": 0,
+                        "elementType": null,
+                        "expirationTime": 1073741823,
+                        "firstEffect": null,
+                        "index": 0,
+                        "key": null,
+                        "lastEffect": null,
+                        "memoizedProps": null,
+                        "memoizedState": null,
+                        "mode": 0,
+                        "nextEffect": null,
+                        "pendingProps": null,
+                        "ref": null,
+                        "return": null,
+                        "selfBaseDuration": 0,
+                        "sibling": null,
+                        "stateNode": Object {
+                          "containerInfo": <div>
+                            <div
+                              class="dashboard-card engagement"
+                            >
+                              <div
+                                class="title"
+                              >
+                                Engagement Trends
+                              </div>
+                            </div>
+                            <div
+                              class="dashboard-card upselling"
+                            >
+                              <div
+                                class="title"
+                              >
+                                Upselling Partners
+                              </div>
+                              <div>
+                                upselling component
+                              </div>
+                            </div>
+                          </div>,
+                          "context": Object {},
+                          "current": [Circular],
+                          "didError": false,
+                          "earliestPendingTime": 0,
+                          "earliestSuspendedTime": 0,
+                          "expirationTime": 0,
+                          "finishedWork": null,
+                          "firstBatch": null,
+                          "hydrate": false,
+                          "interactionThreadID": 15,
+                          "latestPendingTime": 0,
+                          "latestPingedTime": 0,
+                          "latestSuspendedTime": 0,
+                          "memoizedInteractions": Set {},
+                          "nextExpirationTimeToWorkOn": 0,
+                          "nextScheduledRoot": null,
+                          "pendingChildren": null,
+                          "pendingCommitExpirationTime": 0,
+                          "pendingContext": null,
+                          "pendingInteractionMap": Map {},
+                          "pingCache": null,
+                          "timeoutHandle": -1,
+                        },
+                        "tag": 3,
+                        "treeBaseDuration": 0,
+                        "type": null,
+                        "updateQueue": Object {
+                          "baseState": null,
+                          "firstCapturedEffect": null,
+                          "firstCapturedUpdate": null,
+                          "firstEffect": null,
+                          "firstUpdate": Object {
+                            "callback": null,
+                            "expirationTime": 1073741823,
+                            "next": null,
+                            "nextEffect": null,
+                            "payload": Object {
+                              "element": <WrapperComponent
+                                Component={[Function]}
+                                context={null}
+                                props={Object {}}
+                                wrappingComponentProps={null}
+                              />,
+                            },
+                            "tag": 0,
+                          },
+                          "lastCapturedEffect": null,
+                          "lastCapturedUpdate": null,
+                          "lastEffect": null,
+                          "lastUpdate": Object {
+                            "callback": null,
+                            "expirationTime": 1073741823,
+                            "next": null,
+                            "nextEffect": null,
+                            "payload": Object {
+                              "element": <WrapperComponent
+                                Component={[Function]}
+                                context={null}
+                                props={Object {}}
+                                wrappingComponentProps={null}
+                              />,
+                            },
+                            "tag": 0,
+                          },
+                        },
+                      },
+                      "child": [Circular],
+                      "childExpirationTime": 0,
+                      "contextDependencies": null,
+                      "effectTag": 32,
+                      "elementType": null,
+                      "expirationTime": 0,
+                      "firstEffect": [Circular],
+                      "index": 0,
+                      "key": null,
+                      "lastEffect": [Circular],
+                      "memoizedProps": null,
+                      "memoizedState": Object {
+                        "element": <WrapperComponent
+                          Component={[Function]}
+                          context={null}
+                          props={Object {}}
+                          wrappingComponentProps={null}
+                        />,
+                      },
+                      "mode": 0,
+                      "nextEffect": null,
+                      "pendingProps": null,
+                      "ref": null,
+                      "return": null,
+                      "selfBaseDuration": 0,
+                      "sibling": null,
+                      "stateNode": Object {
+                        "containerInfo": <div>
+                          <div
+                            class="dashboard-card engagement"
+                          >
+                            <div
+                              class="title"
+                            >
+                              Engagement Trends
+                            </div>
+                          </div>
+                          <div
+                            class="dashboard-card upselling"
+                          >
+                            <div
+                              class="title"
+                            >
+                              Upselling Partners
+                            </div>
+                            <div>
+                              upselling component
+                            </div>
+                          </div>
+                        </div>,
+                        "context": Object {},
+                        "current": [Circular],
+                        "didError": false,
+                        "earliestPendingTime": 0,
+                        "earliestSuspendedTime": 0,
+                        "expirationTime": 0,
+                        "finishedWork": null,
+                        "firstBatch": null,
+                        "hydrate": false,
+                        "interactionThreadID": 15,
+                        "latestPendingTime": 0,
+                        "latestPingedTime": 0,
+                        "latestSuspendedTime": 0,
+                        "memoizedInteractions": Set {},
+                        "nextExpirationTimeToWorkOn": 0,
+                        "nextScheduledRoot": null,
+                        "pendingChildren": null,
+                        "pendingCommitExpirationTime": 0,
+                        "pendingContext": null,
+                        "pendingInteractionMap": Map {},
+                        "pingCache": null,
+                        "timeoutHandle": -1,
+                      },
+                      "tag": 3,
+                      "treeBaseDuration": 0,
+                      "type": null,
+                      "updateQueue": Object {
+                        "baseState": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={Object {}}
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "firstCapturedEffect": null,
+                        "firstCapturedUpdate": null,
+                        "firstEffect": null,
+                        "firstUpdate": null,
+                        "lastCapturedEffect": null,
+                        "lastCapturedUpdate": null,
+                        "lastEffect": null,
+                        "lastUpdate": null,
+                      },
+                    },
+                    "pendingProps": Object {
+                      "Component": [Function],
+                      "context": null,
+                      "props": Object {},
+                      "wrappingComponentProps": null,
+                    },
+                    "ref": null,
+                    "return": FiberNode {
+                      "_debugHookTypes": null,
+                      "_debugID": 60,
+                      "_debugIsCurrentlyTiming": false,
+                      "_debugOwner": null,
+                      "_debugSource": null,
+                      "actualDuration": 0,
+                      "actualStartTime": -1,
+                      "alternate": FiberNode {
+                        "_debugHookTypes": null,
+                        "_debugID": 60,
+                        "_debugIsCurrentlyTiming": false,
+                        "_debugOwner": null,
+                        "_debugSource": null,
+                        "actualDuration": 0,
+                        "actualStartTime": -1,
+                        "alternate": [Circular],
+                        "child": null,
+                        "childExpirationTime": 0,
+                        "contextDependencies": null,
+                        "effectTag": 0,
+                        "elementType": null,
+                        "expirationTime": 1073741823,
+                        "firstEffect": null,
+                        "index": 0,
+                        "key": null,
+                        "lastEffect": null,
+                        "memoizedProps": null,
+                        "memoizedState": null,
+                        "mode": 0,
+                        "nextEffect": null,
+                        "pendingProps": null,
+                        "ref": null,
+                        "return": null,
+                        "selfBaseDuration": 0,
+                        "sibling": null,
+                        "stateNode": Object {
+                          "containerInfo": <div>
+                            <div
+                              class="dashboard-card engagement"
+                            >
+                              <div
+                                class="title"
+                              >
+                                Engagement Trends
+                              </div>
+                            </div>
+                            <div
+                              class="dashboard-card upselling"
+                            >
+                              <div
+                                class="title"
+                              >
+                                Upselling Partners
+                              </div>
+                              <div>
+                                upselling component
+                              </div>
+                            </div>
+                          </div>,
+                          "context": Object {},
+                          "current": [Circular],
+                          "didError": false,
+                          "earliestPendingTime": 0,
+                          "earliestSuspendedTime": 0,
+                          "expirationTime": 0,
+                          "finishedWork": null,
+                          "firstBatch": null,
+                          "hydrate": false,
+                          "interactionThreadID": 15,
+                          "latestPendingTime": 0,
+                          "latestPingedTime": 0,
+                          "latestSuspendedTime": 0,
+                          "memoizedInteractions": Set {},
+                          "nextExpirationTimeToWorkOn": 0,
+                          "nextScheduledRoot": null,
+                          "pendingChildren": null,
+                          "pendingCommitExpirationTime": 0,
+                          "pendingContext": null,
+                          "pendingInteractionMap": Map {},
+                          "pingCache": null,
+                          "timeoutHandle": -1,
+                        },
+                        "tag": 3,
+                        "treeBaseDuration": 0,
+                        "type": null,
+                        "updateQueue": Object {
+                          "baseState": null,
+                          "firstCapturedEffect": null,
+                          "firstCapturedUpdate": null,
+                          "firstEffect": null,
+                          "firstUpdate": Object {
+                            "callback": null,
+                            "expirationTime": 1073741823,
+                            "next": null,
+                            "nextEffect": null,
+                            "payload": Object {
+                              "element": <WrapperComponent
+                                Component={[Function]}
+                                context={null}
+                                props={Object {}}
+                                wrappingComponentProps={null}
+                              />,
+                            },
+                            "tag": 0,
+                          },
+                          "lastCapturedEffect": null,
+                          "lastCapturedUpdate": null,
+                          "lastEffect": null,
+                          "lastUpdate": Object {
+                            "callback": null,
+                            "expirationTime": 1073741823,
+                            "next": null,
+                            "nextEffect": null,
+                            "payload": Object {
+                              "element": <WrapperComponent
+                                Component={[Function]}
+                                context={null}
+                                props={Object {}}
+                                wrappingComponentProps={null}
+                              />,
+                            },
+                            "tag": 0,
+                          },
+                        },
+                      },
+                      "child": [Circular],
+                      "childExpirationTime": 0,
+                      "contextDependencies": null,
+                      "effectTag": 32,
+                      "elementType": null,
+                      "expirationTime": 0,
+                      "firstEffect": [Circular],
+                      "index": 0,
+                      "key": null,
+                      "lastEffect": [Circular],
+                      "memoizedProps": null,
+                      "memoizedState": Object {
+                        "element": <WrapperComponent
+                          Component={[Function]}
+                          context={null}
+                          props={Object {}}
+                          wrappingComponentProps={null}
+                        />,
+                      },
+                      "mode": 0,
+                      "nextEffect": null,
+                      "pendingProps": null,
+                      "ref": null,
+                      "return": null,
+                      "selfBaseDuration": 0,
+                      "sibling": null,
+                      "stateNode": Object {
+                        "containerInfo": <div>
+                          <div
+                            class="dashboard-card engagement"
+                          >
+                            <div
+                              class="title"
+                            >
+                              Engagement Trends
+                            </div>
+                          </div>
+                          <div
+                            class="dashboard-card upselling"
+                          >
+                            <div
+                              class="title"
+                            >
+                              Upselling Partners
+                            </div>
+                            <div>
+                              upselling component
+                            </div>
+                          </div>
+                        </div>,
+                        "context": Object {},
+                        "current": [Circular],
+                        "didError": false,
+                        "earliestPendingTime": 0,
+                        "earliestSuspendedTime": 0,
+                        "expirationTime": 0,
+                        "finishedWork": null,
+                        "firstBatch": null,
+                        "hydrate": false,
+                        "interactionThreadID": 15,
+                        "latestPendingTime": 0,
+                        "latestPingedTime": 0,
+                        "latestSuspendedTime": 0,
+                        "memoizedInteractions": Set {},
+                        "nextExpirationTimeToWorkOn": 0,
+                        "nextScheduledRoot": null,
+                        "pendingChildren": null,
+                        "pendingCommitExpirationTime": 0,
+                        "pendingContext": null,
+                        "pendingInteractionMap": Map {},
+                        "pingCache": null,
+                        "timeoutHandle": -1,
+                      },
+                      "tag": 3,
+                      "treeBaseDuration": 0,
+                      "type": null,
+                      "updateQueue": Object {
+                        "baseState": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={Object {}}
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "firstCapturedEffect": null,
+                        "firstCapturedUpdate": null,
+                        "firstEffect": null,
+                        "firstUpdate": null,
+                        "lastCapturedEffect": null,
+                        "lastCapturedUpdate": null,
+                        "lastEffect": null,
+                        "lastUpdate": null,
+                      },
+                    },
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": WrapperComponent {
+                      "_reactInternalFiber": [Circular],
+                      "_reactInternalInstance": Object {},
+                      "context": Object {},
+                      "props": Object {
+                        "Component": [Function],
+                        "context": null,
+                        "props": Object {},
+                        "wrappingComponentProps": null,
+                      },
+                      "refs": Object {},
+                      "rootFinderInstance": null,
+                      "state": Object {
+                        "context": null,
+                        "mount": true,
+                        "props": Object {},
+                        "wrappingComponentProps": null,
+                      },
+                      "updater": Object {
+                        "enqueueForceUpdate": [Function],
+                        "enqueueReplaceState": [Function],
+                        "enqueueSetState": [Function],
+                        "isMounted": [Function],
+                      },
+                    },
+                    "tag": 1,
+                    "treeBaseDuration": 0,
+                    "type": [Function],
+                    "updateQueue": null,
+                  },
+                  "_debugSource": null,
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": null,
+                  "child": [Circular],
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 1,
+                  "elementType": [Function],
+                  "expirationTime": 0,
+                  "firstEffect": null,
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": null,
+                  "memoizedProps": Object {},
+                  "memoizedState": null,
+                  "mode": 0,
+                  "nextEffect": null,
+                  "pendingProps": Object {},
+                  "ref": null,
+                  "return": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 62,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": null,
+                    "_debugSource": null,
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": null,
+                    "child": [Circular],
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 1,
+                    "elementType": [Function],
+                    "expirationTime": 0,
+                    "firstEffect": null,
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": null,
+                    "memoizedProps": Object {
+                      "Component": [Function],
+                      "context": null,
+                      "props": Object {},
+                      "wrappingComponentProps": null,
+                    },
+                    "memoizedState": Object {
+                      "context": null,
+                      "mount": true,
+                      "props": Object {},
+                      "wrappingComponentProps": null,
+                    },
+                    "mode": 0,
+                    "nextEffect": FiberNode {
+                      "_debugHookTypes": null,
+                      "_debugID": 60,
+                      "_debugIsCurrentlyTiming": false,
+                      "_debugOwner": null,
+                      "_debugSource": null,
+                      "actualDuration": 0,
+                      "actualStartTime": -1,
+                      "alternate": FiberNode {
+                        "_debugHookTypes": null,
+                        "_debugID": 60,
+                        "_debugIsCurrentlyTiming": false,
+                        "_debugOwner": null,
+                        "_debugSource": null,
+                        "actualDuration": 0,
+                        "actualStartTime": -1,
+                        "alternate": [Circular],
+                        "child": null,
+                        "childExpirationTime": 0,
+                        "contextDependencies": null,
+                        "effectTag": 0,
+                        "elementType": null,
+                        "expirationTime": 1073741823,
+                        "firstEffect": null,
+                        "index": 0,
+                        "key": null,
+                        "lastEffect": null,
+                        "memoizedProps": null,
+                        "memoizedState": null,
+                        "mode": 0,
+                        "nextEffect": null,
+                        "pendingProps": null,
+                        "ref": null,
+                        "return": null,
+                        "selfBaseDuration": 0,
+                        "sibling": null,
+                        "stateNode": Object {
+                          "containerInfo": <div>
+                            <div
+                              class="dashboard-card engagement"
+                            >
+                              <div
+                                class="title"
+                              >
+                                Engagement Trends
+                              </div>
+                            </div>
+                            <div
+                              class="dashboard-card upselling"
+                            >
+                              <div
+                                class="title"
+                              >
+                                Upselling Partners
+                              </div>
+                              <div>
+                                upselling component
+                              </div>
+                            </div>
+                          </div>,
+                          "context": Object {},
+                          "current": [Circular],
+                          "didError": false,
+                          "earliestPendingTime": 0,
+                          "earliestSuspendedTime": 0,
+                          "expirationTime": 0,
+                          "finishedWork": null,
+                          "firstBatch": null,
+                          "hydrate": false,
+                          "interactionThreadID": 15,
+                          "latestPendingTime": 0,
+                          "latestPingedTime": 0,
+                          "latestSuspendedTime": 0,
+                          "memoizedInteractions": Set {},
+                          "nextExpirationTimeToWorkOn": 0,
+                          "nextScheduledRoot": null,
+                          "pendingChildren": null,
+                          "pendingCommitExpirationTime": 0,
+                          "pendingContext": null,
+                          "pendingInteractionMap": Map {},
+                          "pingCache": null,
+                          "timeoutHandle": -1,
+                        },
+                        "tag": 3,
+                        "treeBaseDuration": 0,
+                        "type": null,
+                        "updateQueue": Object {
+                          "baseState": null,
+                          "firstCapturedEffect": null,
+                          "firstCapturedUpdate": null,
+                          "firstEffect": null,
+                          "firstUpdate": Object {
+                            "callback": null,
+                            "expirationTime": 1073741823,
+                            "next": null,
+                            "nextEffect": null,
+                            "payload": Object {
+                              "element": <WrapperComponent
+                                Component={[Function]}
+                                context={null}
+                                props={Object {}}
+                                wrappingComponentProps={null}
+                              />,
+                            },
+                            "tag": 0,
+                          },
+                          "lastCapturedEffect": null,
+                          "lastCapturedUpdate": null,
+                          "lastEffect": null,
+                          "lastUpdate": Object {
+                            "callback": null,
+                            "expirationTime": 1073741823,
+                            "next": null,
+                            "nextEffect": null,
+                            "payload": Object {
+                              "element": <WrapperComponent
+                                Component={[Function]}
+                                context={null}
+                                props={Object {}}
+                                wrappingComponentProps={null}
+                              />,
+                            },
+                            "tag": 0,
+                          },
+                        },
+                      },
+                      "child": [Circular],
+                      "childExpirationTime": 0,
+                      "contextDependencies": null,
+                      "effectTag": 32,
+                      "elementType": null,
+                      "expirationTime": 0,
+                      "firstEffect": [Circular],
+                      "index": 0,
+                      "key": null,
+                      "lastEffect": [Circular],
+                      "memoizedProps": null,
+                      "memoizedState": Object {
+                        "element": <WrapperComponent
+                          Component={[Function]}
+                          context={null}
+                          props={Object {}}
+                          wrappingComponentProps={null}
+                        />,
+                      },
+                      "mode": 0,
+                      "nextEffect": null,
+                      "pendingProps": null,
+                      "ref": null,
+                      "return": null,
+                      "selfBaseDuration": 0,
+                      "sibling": null,
+                      "stateNode": Object {
+                        "containerInfo": <div>
+                          <div
+                            class="dashboard-card engagement"
+                          >
+                            <div
+                              class="title"
+                            >
+                              Engagement Trends
+                            </div>
+                          </div>
+                          <div
+                            class="dashboard-card upselling"
+                          >
+                            <div
+                              class="title"
+                            >
+                              Upselling Partners
+                            </div>
+                            <div>
+                              upselling component
+                            </div>
+                          </div>
+                        </div>,
+                        "context": Object {},
+                        "current": [Circular],
+                        "didError": false,
+                        "earliestPendingTime": 0,
+                        "earliestSuspendedTime": 0,
+                        "expirationTime": 0,
+                        "finishedWork": null,
+                        "firstBatch": null,
+                        "hydrate": false,
+                        "interactionThreadID": 15,
+                        "latestPendingTime": 0,
+                        "latestPingedTime": 0,
+                        "latestSuspendedTime": 0,
+                        "memoizedInteractions": Set {},
+                        "nextExpirationTimeToWorkOn": 0,
+                        "nextScheduledRoot": null,
+                        "pendingChildren": null,
+                        "pendingCommitExpirationTime": 0,
+                        "pendingContext": null,
+                        "pendingInteractionMap": Map {},
+                        "pingCache": null,
+                        "timeoutHandle": -1,
+                      },
+                      "tag": 3,
+                      "treeBaseDuration": 0,
+                      "type": null,
+                      "updateQueue": Object {
+                        "baseState": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={Object {}}
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "firstCapturedEffect": null,
+                        "firstCapturedUpdate": null,
+                        "firstEffect": null,
+                        "firstUpdate": null,
+                        "lastCapturedEffect": null,
+                        "lastCapturedUpdate": null,
+                        "lastEffect": null,
+                        "lastUpdate": null,
+                      },
+                    },
+                    "pendingProps": Object {
+                      "Component": [Function],
+                      "context": null,
+                      "props": Object {},
+                      "wrappingComponentProps": null,
+                    },
+                    "ref": null,
+                    "return": FiberNode {
+                      "_debugHookTypes": null,
+                      "_debugID": 60,
+                      "_debugIsCurrentlyTiming": false,
+                      "_debugOwner": null,
+                      "_debugSource": null,
+                      "actualDuration": 0,
+                      "actualStartTime": -1,
+                      "alternate": FiberNode {
+                        "_debugHookTypes": null,
+                        "_debugID": 60,
+                        "_debugIsCurrentlyTiming": false,
+                        "_debugOwner": null,
+                        "_debugSource": null,
+                        "actualDuration": 0,
+                        "actualStartTime": -1,
+                        "alternate": [Circular],
+                        "child": null,
+                        "childExpirationTime": 0,
+                        "contextDependencies": null,
+                        "effectTag": 0,
+                        "elementType": null,
+                        "expirationTime": 1073741823,
+                        "firstEffect": null,
+                        "index": 0,
+                        "key": null,
+                        "lastEffect": null,
+                        "memoizedProps": null,
+                        "memoizedState": null,
+                        "mode": 0,
+                        "nextEffect": null,
+                        "pendingProps": null,
+                        "ref": null,
+                        "return": null,
+                        "selfBaseDuration": 0,
+                        "sibling": null,
+                        "stateNode": Object {
+                          "containerInfo": <div>
+                            <div
+                              class="dashboard-card engagement"
+                            >
+                              <div
+                                class="title"
+                              >
+                                Engagement Trends
+                              </div>
+                            </div>
+                            <div
+                              class="dashboard-card upselling"
+                            >
+                              <div
+                                class="title"
+                              >
+                                Upselling Partners
+                              </div>
+                              <div>
+                                upselling component
+                              </div>
+                            </div>
+                          </div>,
+                          "context": Object {},
+                          "current": [Circular],
+                          "didError": false,
+                          "earliestPendingTime": 0,
+                          "earliestSuspendedTime": 0,
+                          "expirationTime": 0,
+                          "finishedWork": null,
+                          "firstBatch": null,
+                          "hydrate": false,
+                          "interactionThreadID": 15,
+                          "latestPendingTime": 0,
+                          "latestPingedTime": 0,
+                          "latestSuspendedTime": 0,
+                          "memoizedInteractions": Set {},
+                          "nextExpirationTimeToWorkOn": 0,
+                          "nextScheduledRoot": null,
+                          "pendingChildren": null,
+                          "pendingCommitExpirationTime": 0,
+                          "pendingContext": null,
+                          "pendingInteractionMap": Map {},
+                          "pingCache": null,
+                          "timeoutHandle": -1,
+                        },
+                        "tag": 3,
+                        "treeBaseDuration": 0,
+                        "type": null,
+                        "updateQueue": Object {
+                          "baseState": null,
+                          "firstCapturedEffect": null,
+                          "firstCapturedUpdate": null,
+                          "firstEffect": null,
+                          "firstUpdate": Object {
+                            "callback": null,
+                            "expirationTime": 1073741823,
+                            "next": null,
+                            "nextEffect": null,
+                            "payload": Object {
+                              "element": <WrapperComponent
+                                Component={[Function]}
+                                context={null}
+                                props={Object {}}
+                                wrappingComponentProps={null}
+                              />,
+                            },
+                            "tag": 0,
+                          },
+                          "lastCapturedEffect": null,
+                          "lastCapturedUpdate": null,
+                          "lastEffect": null,
+                          "lastUpdate": Object {
+                            "callback": null,
+                            "expirationTime": 1073741823,
+                            "next": null,
+                            "nextEffect": null,
+                            "payload": Object {
+                              "element": <WrapperComponent
+                                Component={[Function]}
+                                context={null}
+                                props={Object {}}
+                                wrappingComponentProps={null}
+                              />,
+                            },
+                            "tag": 0,
+                          },
+                        },
+                      },
+                      "child": [Circular],
+                      "childExpirationTime": 0,
+                      "contextDependencies": null,
+                      "effectTag": 32,
+                      "elementType": null,
+                      "expirationTime": 0,
+                      "firstEffect": [Circular],
+                      "index": 0,
+                      "key": null,
+                      "lastEffect": [Circular],
+                      "memoizedProps": null,
+                      "memoizedState": Object {
+                        "element": <WrapperComponent
+                          Component={[Function]}
+                          context={null}
+                          props={Object {}}
+                          wrappingComponentProps={null}
+                        />,
+                      },
+                      "mode": 0,
+                      "nextEffect": null,
+                      "pendingProps": null,
+                      "ref": null,
+                      "return": null,
+                      "selfBaseDuration": 0,
+                      "sibling": null,
+                      "stateNode": Object {
+                        "containerInfo": <div>
+                          <div
+                            class="dashboard-card engagement"
+                          >
+                            <div
+                              class="title"
+                            >
+                              Engagement Trends
+                            </div>
+                          </div>
+                          <div
+                            class="dashboard-card upselling"
+                          >
+                            <div
+                              class="title"
+                            >
+                              Upselling Partners
+                            </div>
+                            <div>
+                              upselling component
+                            </div>
+                          </div>
+                        </div>,
+                        "context": Object {},
+                        "current": [Circular],
+                        "didError": false,
+                        "earliestPendingTime": 0,
+                        "earliestSuspendedTime": 0,
+                        "expirationTime": 0,
+                        "finishedWork": null,
+                        "firstBatch": null,
+                        "hydrate": false,
+                        "interactionThreadID": 15,
+                        "latestPendingTime": 0,
+                        "latestPingedTime": 0,
+                        "latestSuspendedTime": 0,
+                        "memoizedInteractions": Set {},
+                        "nextExpirationTimeToWorkOn": 0,
+                        "nextScheduledRoot": null,
+                        "pendingChildren": null,
+                        "pendingCommitExpirationTime": 0,
+                        "pendingContext": null,
+                        "pendingInteractionMap": Map {},
+                        "pingCache": null,
+                        "timeoutHandle": -1,
+                      },
+                      "tag": 3,
+                      "treeBaseDuration": 0,
+                      "type": null,
+                      "updateQueue": Object {
+                        "baseState": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={Object {}}
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "firstCapturedEffect": null,
+                        "firstCapturedUpdate": null,
+                        "firstEffect": null,
+                        "firstUpdate": null,
+                        "lastCapturedEffect": null,
+                        "lastCapturedUpdate": null,
+                        "lastEffect": null,
+                        "lastUpdate": null,
+                      },
+                    },
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": WrapperComponent {
+                      "_reactInternalFiber": [Circular],
+                      "_reactInternalInstance": Object {},
+                      "context": Object {},
+                      "props": Object {
+                        "Component": [Function],
+                        "context": null,
+                        "props": Object {},
+                        "wrappingComponentProps": null,
+                      },
+                      "refs": Object {},
+                      "rootFinderInstance": null,
+                      "state": Object {
+                        "context": null,
+                        "mount": true,
+                        "props": Object {},
+                        "wrappingComponentProps": null,
+                      },
+                      "updater": Object {
+                        "enqueueForceUpdate": [Function],
+                        "enqueueReplaceState": [Function],
+                        "enqueueSetState": [Function],
+                        "isMounted": [Function],
+                      },
+                    },
+                    "tag": 1,
+                    "treeBaseDuration": 0,
+                    "type": [Function],
+                    "updateQueue": null,
+                  },
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": Dashboard {
+                    "_reactInternalFiber": [Circular],
+                    "_reactInternalInstance": Object {},
+                    "context": Object {},
+                    "props": Object {},
+                    "refs": Object {},
+                    "renderUpselling": [Function],
+                    "state": null,
+                    "updater": Object {
+                      "enqueueForceUpdate": [Function],
+                      "enqueueReplaceState": [Function],
+                      "enqueueSetState": [Function],
+                      "isMounted": [Function],
+                    },
+                  },
+                  "tag": 1,
+                  "treeBaseDuration": 0,
+                  "type": [Function],
+                  "updateQueue": null,
+                },
+                "_debugSource": Object {
+                  "fileName": "/Users/kevinkoech/Documents/bp-esa-frontend/src/components/Dashboard/index.jsx",
+                  "lineNumber": 28,
+                },
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": null,
+                "child": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 68,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": [Circular],
+                  "_debugSource": Object {
+                    "fileName": "/Users/kevinkoech/Documents/bp-esa-frontend/src/components/Dashboard/Card.jsx",
+                    "lineNumber": 20,
+                  },
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": null,
+                  "child": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 69,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": [Circular],
+                    "_debugSource": Object {
+                      "fileName": "/Users/kevinkoech/Documents/bp-esa-frontend/src/components/Dashboard/Card.jsx",
+                      "lineNumber": 21,
+                    },
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": null,
+                    "child": null,
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 0,
+                    "elementType": "div",
+                    "expirationTime": 0,
+                    "firstEffect": null,
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": null,
+                    "memoizedProps": Object {
+                      "children": "Upselling Partners",
+                      "className": "title",
+                    },
+                    "memoizedState": null,
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": Object {
+                      "children": "Upselling Partners",
+                      "className": "title",
+                    },
+                    "ref": null,
+                    "return": [Circular],
+                    "selfBaseDuration": 0,
+                    "sibling": FiberNode {
+                      "_debugHookTypes": null,
+                      "_debugID": 70,
+                      "_debugIsCurrentlyTiming": false,
+                      "_debugOwner": [Circular],
+                      "_debugSource": Object {
+                        "fileName": "/Users/kevinkoech/Documents/bp-esa-frontend/src/components/Dashboard/index.jsx",
+                        "lineNumber": 15,
+                      },
+                      "actualDuration": 0,
+                      "actualStartTime": -1,
+                      "alternate": null,
+                      "child": null,
+                      "childExpirationTime": 0,
+                      "contextDependencies": null,
+                      "effectTag": 0,
+                      "elementType": "div",
+                      "expirationTime": 0,
+                      "firstEffect": null,
+                      "index": 1,
+                      "key": null,
+                      "lastEffect": null,
+                      "memoizedProps": Object {
+                        "children": "upselling component",
+                      },
+                      "memoizedState": null,
+                      "mode": 0,
+                      "nextEffect": null,
+                      "pendingProps": Object {
+                        "children": "upselling component",
+                      },
+                      "ref": null,
+                      "return": [Circular],
+                      "selfBaseDuration": 0,
+                      "sibling": null,
+                      "stateNode": <div>
+                        upselling component
+                      </div>,
+                      "tag": 5,
+                      "treeBaseDuration": 0,
+                      "type": "div",
+                      "updateQueue": null,
+                    },
+                    "stateNode": <div
+                      class="title"
+                    >
+                      Upselling Partners
+                    </div>,
+                    "tag": 5,
+                    "treeBaseDuration": 0,
+                    "type": "div",
+                    "updateQueue": null,
+                  },
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 0,
+                  "elementType": "div",
+                  "expirationTime": 0,
+                  "firstEffect": null,
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": null,
+                  "memoizedProps": Object {
+                    "children": Array [
+                      <div
+                        className="title"
+                      >
+                        Upselling Partners
+                      </div>,
+                      <div>
+                        upselling component
+                      </div>,
+                    ],
+                    "className": "dashboard-card upselling",
+                  },
+                  "memoizedState": null,
+                  "mode": 0,
+                  "nextEffect": null,
+                  "pendingProps": Object {
+                    "children": Array [
+                      <div
+                        className="title"
+                      >
+                        Upselling Partners
+                      </div>,
+                      <div>
+                        upselling component
+                      </div>,
+                    ],
+                    "className": "dashboard-card upselling",
+                  },
+                  "ref": null,
+                  "return": [Circular],
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": <div
+                    class="dashboard-card upselling"
+                  >
+                    <div
+                      class="title"
+                    >
+                      Upselling Partners
+                    </div>
+                    <div>
+                      upselling component
+                    </div>
+                  </div>,
+                  "tag": 5,
+                  "treeBaseDuration": 0,
+                  "type": "div",
+                  "updateQueue": null,
+                },
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 1,
+                "elementType": [Function],
+                "expirationTime": 0,
+                "firstEffect": null,
+                "index": 1,
+                "key": null,
+                "lastEffect": null,
+                "memoizedProps": Object {
+                  "classes": "upselling",
+                  "component": [Function],
+                  "title": "Upselling Partners",
+                },
+                "memoizedState": null,
+                "mode": 0,
+                "nextEffect": null,
+                "pendingProps": Object {
+                  "classes": "upselling",
+                  "component": [Function],
+                  "title": "Upselling Partners",
+                },
+                "ref": null,
+                "return": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 63,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 62,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": null,
+                    "_debugSource": null,
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": null,
+                    "child": [Circular],
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 1,
+                    "elementType": [Function],
+                    "expirationTime": 0,
+                    "firstEffect": null,
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": null,
+                    "memoizedProps": Object {
+                      "Component": [Function],
+                      "context": null,
+                      "props": Object {},
+                      "wrappingComponentProps": null,
+                    },
+                    "memoizedState": Object {
+                      "context": null,
+                      "mount": true,
+                      "props": Object {},
+                      "wrappingComponentProps": null,
+                    },
+                    "mode": 0,
+                    "nextEffect": FiberNode {
+                      "_debugHookTypes": null,
+                      "_debugID": 60,
+                      "_debugIsCurrentlyTiming": false,
+                      "_debugOwner": null,
+                      "_debugSource": null,
+                      "actualDuration": 0,
+                      "actualStartTime": -1,
+                      "alternate": FiberNode {
+                        "_debugHookTypes": null,
+                        "_debugID": 60,
+                        "_debugIsCurrentlyTiming": false,
+                        "_debugOwner": null,
+                        "_debugSource": null,
+                        "actualDuration": 0,
+                        "actualStartTime": -1,
+                        "alternate": [Circular],
+                        "child": null,
+                        "childExpirationTime": 0,
+                        "contextDependencies": null,
+                        "effectTag": 0,
+                        "elementType": null,
+                        "expirationTime": 1073741823,
+                        "firstEffect": null,
+                        "index": 0,
+                        "key": null,
+                        "lastEffect": null,
+                        "memoizedProps": null,
+                        "memoizedState": null,
+                        "mode": 0,
+                        "nextEffect": null,
+                        "pendingProps": null,
+                        "ref": null,
+                        "return": null,
+                        "selfBaseDuration": 0,
+                        "sibling": null,
+                        "stateNode": Object {
+                          "containerInfo": <div>
+                            <div
+                              class="dashboard-card engagement"
+                            >
+                              <div
+                                class="title"
+                              >
+                                Engagement Trends
+                              </div>
+                            </div>
+                            <div
+                              class="dashboard-card upselling"
+                            >
+                              <div
+                                class="title"
+                              >
+                                Upselling Partners
+                              </div>
+                              <div>
+                                upselling component
+                              </div>
+                            </div>
+                          </div>,
+                          "context": Object {},
+                          "current": [Circular],
+                          "didError": false,
+                          "earliestPendingTime": 0,
+                          "earliestSuspendedTime": 0,
+                          "expirationTime": 0,
+                          "finishedWork": null,
+                          "firstBatch": null,
+                          "hydrate": false,
+                          "interactionThreadID": 15,
+                          "latestPendingTime": 0,
+                          "latestPingedTime": 0,
+                          "latestSuspendedTime": 0,
+                          "memoizedInteractions": Set {},
+                          "nextExpirationTimeToWorkOn": 0,
+                          "nextScheduledRoot": null,
+                          "pendingChildren": null,
+                          "pendingCommitExpirationTime": 0,
+                          "pendingContext": null,
+                          "pendingInteractionMap": Map {},
+                          "pingCache": null,
+                          "timeoutHandle": -1,
+                        },
+                        "tag": 3,
+                        "treeBaseDuration": 0,
+                        "type": null,
+                        "updateQueue": Object {
+                          "baseState": null,
+                          "firstCapturedEffect": null,
+                          "firstCapturedUpdate": null,
+                          "firstEffect": null,
+                          "firstUpdate": Object {
+                            "callback": null,
+                            "expirationTime": 1073741823,
+                            "next": null,
+                            "nextEffect": null,
+                            "payload": Object {
+                              "element": <WrapperComponent
+                                Component={[Function]}
+                                context={null}
+                                props={Object {}}
+                                wrappingComponentProps={null}
+                              />,
+                            },
+                            "tag": 0,
+                          },
+                          "lastCapturedEffect": null,
+                          "lastCapturedUpdate": null,
+                          "lastEffect": null,
+                          "lastUpdate": Object {
+                            "callback": null,
+                            "expirationTime": 1073741823,
+                            "next": null,
+                            "nextEffect": null,
+                            "payload": Object {
+                              "element": <WrapperComponent
+                                Component={[Function]}
+                                context={null}
+                                props={Object {}}
+                                wrappingComponentProps={null}
+                              />,
+                            },
+                            "tag": 0,
+                          },
+                        },
+                      },
+                      "child": [Circular],
+                      "childExpirationTime": 0,
+                      "contextDependencies": null,
+                      "effectTag": 32,
+                      "elementType": null,
+                      "expirationTime": 0,
+                      "firstEffect": [Circular],
+                      "index": 0,
+                      "key": null,
+                      "lastEffect": [Circular],
+                      "memoizedProps": null,
+                      "memoizedState": Object {
+                        "element": <WrapperComponent
+                          Component={[Function]}
+                          context={null}
+                          props={Object {}}
+                          wrappingComponentProps={null}
+                        />,
+                      },
+                      "mode": 0,
+                      "nextEffect": null,
+                      "pendingProps": null,
+                      "ref": null,
+                      "return": null,
+                      "selfBaseDuration": 0,
+                      "sibling": null,
+                      "stateNode": Object {
+                        "containerInfo": <div>
+                          <div
+                            class="dashboard-card engagement"
+                          >
+                            <div
+                              class="title"
+                            >
+                              Engagement Trends
+                            </div>
+                          </div>
+                          <div
+                            class="dashboard-card upselling"
+                          >
+                            <div
+                              class="title"
+                            >
+                              Upselling Partners
+                            </div>
+                            <div>
+                              upselling component
+                            </div>
+                          </div>
+                        </div>,
+                        "context": Object {},
+                        "current": [Circular],
+                        "didError": false,
+                        "earliestPendingTime": 0,
+                        "earliestSuspendedTime": 0,
+                        "expirationTime": 0,
+                        "finishedWork": null,
+                        "firstBatch": null,
+                        "hydrate": false,
+                        "interactionThreadID": 15,
+                        "latestPendingTime": 0,
+                        "latestPingedTime": 0,
+                        "latestSuspendedTime": 0,
+                        "memoizedInteractions": Set {},
+                        "nextExpirationTimeToWorkOn": 0,
+                        "nextScheduledRoot": null,
+                        "pendingChildren": null,
+                        "pendingCommitExpirationTime": 0,
+                        "pendingContext": null,
+                        "pendingInteractionMap": Map {},
+                        "pingCache": null,
+                        "timeoutHandle": -1,
+                      },
+                      "tag": 3,
+                      "treeBaseDuration": 0,
+                      "type": null,
+                      "updateQueue": Object {
+                        "baseState": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={Object {}}
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "firstCapturedEffect": null,
+                        "firstCapturedUpdate": null,
+                        "firstEffect": null,
+                        "firstUpdate": null,
+                        "lastCapturedEffect": null,
+                        "lastCapturedUpdate": null,
+                        "lastEffect": null,
+                        "lastUpdate": null,
+                      },
+                    },
+                    "pendingProps": Object {
+                      "Component": [Function],
+                      "context": null,
+                      "props": Object {},
+                      "wrappingComponentProps": null,
+                    },
+                    "ref": null,
+                    "return": FiberNode {
+                      "_debugHookTypes": null,
+                      "_debugID": 60,
+                      "_debugIsCurrentlyTiming": false,
+                      "_debugOwner": null,
+                      "_debugSource": null,
+                      "actualDuration": 0,
+                      "actualStartTime": -1,
+                      "alternate": FiberNode {
+                        "_debugHookTypes": null,
+                        "_debugID": 60,
+                        "_debugIsCurrentlyTiming": false,
+                        "_debugOwner": null,
+                        "_debugSource": null,
+                        "actualDuration": 0,
+                        "actualStartTime": -1,
+                        "alternate": [Circular],
+                        "child": null,
+                        "childExpirationTime": 0,
+                        "contextDependencies": null,
+                        "effectTag": 0,
+                        "elementType": null,
+                        "expirationTime": 1073741823,
+                        "firstEffect": null,
+                        "index": 0,
+                        "key": null,
+                        "lastEffect": null,
+                        "memoizedProps": null,
+                        "memoizedState": null,
+                        "mode": 0,
+                        "nextEffect": null,
+                        "pendingProps": null,
+                        "ref": null,
+                        "return": null,
+                        "selfBaseDuration": 0,
+                        "sibling": null,
+                        "stateNode": Object {
+                          "containerInfo": <div>
+                            <div
+                              class="dashboard-card engagement"
+                            >
+                              <div
+                                class="title"
+                              >
+                                Engagement Trends
+                              </div>
+                            </div>
+                            <div
+                              class="dashboard-card upselling"
+                            >
+                              <div
+                                class="title"
+                              >
+                                Upselling Partners
+                              </div>
+                              <div>
+                                upselling component
+                              </div>
+                            </div>
+                          </div>,
+                          "context": Object {},
+                          "current": [Circular],
+                          "didError": false,
+                          "earliestPendingTime": 0,
+                          "earliestSuspendedTime": 0,
+                          "expirationTime": 0,
+                          "finishedWork": null,
+                          "firstBatch": null,
+                          "hydrate": false,
+                          "interactionThreadID": 15,
+                          "latestPendingTime": 0,
+                          "latestPingedTime": 0,
+                          "latestSuspendedTime": 0,
+                          "memoizedInteractions": Set {},
+                          "nextExpirationTimeToWorkOn": 0,
+                          "nextScheduledRoot": null,
+                          "pendingChildren": null,
+                          "pendingCommitExpirationTime": 0,
+                          "pendingContext": null,
+                          "pendingInteractionMap": Map {},
+                          "pingCache": null,
+                          "timeoutHandle": -1,
+                        },
+                        "tag": 3,
+                        "treeBaseDuration": 0,
+                        "type": null,
+                        "updateQueue": Object {
+                          "baseState": null,
+                          "firstCapturedEffect": null,
+                          "firstCapturedUpdate": null,
+                          "firstEffect": null,
+                          "firstUpdate": Object {
+                            "callback": null,
+                            "expirationTime": 1073741823,
+                            "next": null,
+                            "nextEffect": null,
+                            "payload": Object {
+                              "element": <WrapperComponent
+                                Component={[Function]}
+                                context={null}
+                                props={Object {}}
+                                wrappingComponentProps={null}
+                              />,
+                            },
+                            "tag": 0,
+                          },
+                          "lastCapturedEffect": null,
+                          "lastCapturedUpdate": null,
+                          "lastEffect": null,
+                          "lastUpdate": Object {
+                            "callback": null,
+                            "expirationTime": 1073741823,
+                            "next": null,
+                            "nextEffect": null,
+                            "payload": Object {
+                              "element": <WrapperComponent
+                                Component={[Function]}
+                                context={null}
+                                props={Object {}}
+                                wrappingComponentProps={null}
+                              />,
+                            },
+                            "tag": 0,
+                          },
+                        },
+                      },
+                      "child": [Circular],
+                      "childExpirationTime": 0,
+                      "contextDependencies": null,
+                      "effectTag": 32,
+                      "elementType": null,
+                      "expirationTime": 0,
+                      "firstEffect": [Circular],
+                      "index": 0,
+                      "key": null,
+                      "lastEffect": [Circular],
+                      "memoizedProps": null,
+                      "memoizedState": Object {
+                        "element": <WrapperComponent
+                          Component={[Function]}
+                          context={null}
+                          props={Object {}}
+                          wrappingComponentProps={null}
+                        />,
+                      },
+                      "mode": 0,
+                      "nextEffect": null,
+                      "pendingProps": null,
+                      "ref": null,
+                      "return": null,
+                      "selfBaseDuration": 0,
+                      "sibling": null,
+                      "stateNode": Object {
+                        "containerInfo": <div>
+                          <div
+                            class="dashboard-card engagement"
+                          >
+                            <div
+                              class="title"
+                            >
+                              Engagement Trends
+                            </div>
+                          </div>
+                          <div
+                            class="dashboard-card upselling"
+                          >
+                            <div
+                              class="title"
+                            >
+                              Upselling Partners
+                            </div>
+                            <div>
+                              upselling component
+                            </div>
+                          </div>
+                        </div>,
+                        "context": Object {},
+                        "current": [Circular],
+                        "didError": false,
+                        "earliestPendingTime": 0,
+                        "earliestSuspendedTime": 0,
+                        "expirationTime": 0,
+                        "finishedWork": null,
+                        "firstBatch": null,
+                        "hydrate": false,
+                        "interactionThreadID": 15,
+                        "latestPendingTime": 0,
+                        "latestPingedTime": 0,
+                        "latestSuspendedTime": 0,
+                        "memoizedInteractions": Set {},
+                        "nextExpirationTimeToWorkOn": 0,
+                        "nextScheduledRoot": null,
+                        "pendingChildren": null,
+                        "pendingCommitExpirationTime": 0,
+                        "pendingContext": null,
+                        "pendingInteractionMap": Map {},
+                        "pingCache": null,
+                        "timeoutHandle": -1,
+                      },
+                      "tag": 3,
+                      "treeBaseDuration": 0,
+                      "type": null,
+                      "updateQueue": Object {
+                        "baseState": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={Object {}}
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "firstCapturedEffect": null,
+                        "firstCapturedUpdate": null,
+                        "firstEffect": null,
+                        "firstUpdate": null,
+                        "lastCapturedEffect": null,
+                        "lastCapturedUpdate": null,
+                        "lastEffect": null,
+                        "lastUpdate": null,
+                      },
+                    },
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": WrapperComponent {
+                      "_reactInternalFiber": [Circular],
+                      "_reactInternalInstance": Object {},
+                      "context": Object {},
+                      "props": Object {
+                        "Component": [Function],
+                        "context": null,
+                        "props": Object {},
+                        "wrappingComponentProps": null,
+                      },
+                      "refs": Object {},
+                      "rootFinderInstance": null,
+                      "state": Object {
+                        "context": null,
+                        "mount": true,
+                        "props": Object {},
+                        "wrappingComponentProps": null,
+                      },
+                      "updater": Object {
+                        "enqueueForceUpdate": [Function],
+                        "enqueueReplaceState": [Function],
+                        "enqueueSetState": [Function],
+                        "isMounted": [Function],
+                      },
+                    },
+                    "tag": 1,
+                    "treeBaseDuration": 0,
+                    "type": [Function],
+                    "updateQueue": null,
+                  },
+                  "_debugSource": null,
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": null,
+                  "child": [Circular],
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 1,
+                  "elementType": [Function],
+                  "expirationTime": 0,
+                  "firstEffect": null,
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": null,
+                  "memoizedProps": Object {},
+                  "memoizedState": null,
+                  "mode": 0,
+                  "nextEffect": null,
+                  "pendingProps": Object {},
+                  "ref": null,
+                  "return": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 62,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": null,
+                    "_debugSource": null,
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": null,
+                    "child": [Circular],
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 1,
+                    "elementType": [Function],
+                    "expirationTime": 0,
+                    "firstEffect": null,
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": null,
+                    "memoizedProps": Object {
+                      "Component": [Function],
+                      "context": null,
+                      "props": Object {},
+                      "wrappingComponentProps": null,
+                    },
+                    "memoizedState": Object {
+                      "context": null,
+                      "mount": true,
+                      "props": Object {},
+                      "wrappingComponentProps": null,
+                    },
+                    "mode": 0,
+                    "nextEffect": FiberNode {
+                      "_debugHookTypes": null,
+                      "_debugID": 60,
+                      "_debugIsCurrentlyTiming": false,
+                      "_debugOwner": null,
+                      "_debugSource": null,
+                      "actualDuration": 0,
+                      "actualStartTime": -1,
+                      "alternate": FiberNode {
+                        "_debugHookTypes": null,
+                        "_debugID": 60,
+                        "_debugIsCurrentlyTiming": false,
+                        "_debugOwner": null,
+                        "_debugSource": null,
+                        "actualDuration": 0,
+                        "actualStartTime": -1,
+                        "alternate": [Circular],
+                        "child": null,
+                        "childExpirationTime": 0,
+                        "contextDependencies": null,
+                        "effectTag": 0,
+                        "elementType": null,
+                        "expirationTime": 1073741823,
+                        "firstEffect": null,
+                        "index": 0,
+                        "key": null,
+                        "lastEffect": null,
+                        "memoizedProps": null,
+                        "memoizedState": null,
+                        "mode": 0,
+                        "nextEffect": null,
+                        "pendingProps": null,
+                        "ref": null,
+                        "return": null,
+                        "selfBaseDuration": 0,
+                        "sibling": null,
+                        "stateNode": Object {
+                          "containerInfo": <div>
+                            <div
+                              class="dashboard-card engagement"
+                            >
+                              <div
+                                class="title"
+                              >
+                                Engagement Trends
+                              </div>
+                            </div>
+                            <div
+                              class="dashboard-card upselling"
+                            >
+                              <div
+                                class="title"
+                              >
+                                Upselling Partners
+                              </div>
+                              <div>
+                                upselling component
+                              </div>
+                            </div>
+                          </div>,
+                          "context": Object {},
+                          "current": [Circular],
+                          "didError": false,
+                          "earliestPendingTime": 0,
+                          "earliestSuspendedTime": 0,
+                          "expirationTime": 0,
+                          "finishedWork": null,
+                          "firstBatch": null,
+                          "hydrate": false,
+                          "interactionThreadID": 15,
+                          "latestPendingTime": 0,
+                          "latestPingedTime": 0,
+                          "latestSuspendedTime": 0,
+                          "memoizedInteractions": Set {},
+                          "nextExpirationTimeToWorkOn": 0,
+                          "nextScheduledRoot": null,
+                          "pendingChildren": null,
+                          "pendingCommitExpirationTime": 0,
+                          "pendingContext": null,
+                          "pendingInteractionMap": Map {},
+                          "pingCache": null,
+                          "timeoutHandle": -1,
+                        },
+                        "tag": 3,
+                        "treeBaseDuration": 0,
+                        "type": null,
+                        "updateQueue": Object {
+                          "baseState": null,
+                          "firstCapturedEffect": null,
+                          "firstCapturedUpdate": null,
+                          "firstEffect": null,
+                          "firstUpdate": Object {
+                            "callback": null,
+                            "expirationTime": 1073741823,
+                            "next": null,
+                            "nextEffect": null,
+                            "payload": Object {
+                              "element": <WrapperComponent
+                                Component={[Function]}
+                                context={null}
+                                props={Object {}}
+                                wrappingComponentProps={null}
+                              />,
+                            },
+                            "tag": 0,
+                          },
+                          "lastCapturedEffect": null,
+                          "lastCapturedUpdate": null,
+                          "lastEffect": null,
+                          "lastUpdate": Object {
+                            "callback": null,
+                            "expirationTime": 1073741823,
+                            "next": null,
+                            "nextEffect": null,
+                            "payload": Object {
+                              "element": <WrapperComponent
+                                Component={[Function]}
+                                context={null}
+                                props={Object {}}
+                                wrappingComponentProps={null}
+                              />,
+                            },
+                            "tag": 0,
+                          },
+                        },
+                      },
+                      "child": [Circular],
+                      "childExpirationTime": 0,
+                      "contextDependencies": null,
+                      "effectTag": 32,
+                      "elementType": null,
+                      "expirationTime": 0,
+                      "firstEffect": [Circular],
+                      "index": 0,
+                      "key": null,
+                      "lastEffect": [Circular],
+                      "memoizedProps": null,
+                      "memoizedState": Object {
+                        "element": <WrapperComponent
+                          Component={[Function]}
+                          context={null}
+                          props={Object {}}
+                          wrappingComponentProps={null}
+                        />,
+                      },
+                      "mode": 0,
+                      "nextEffect": null,
+                      "pendingProps": null,
+                      "ref": null,
+                      "return": null,
+                      "selfBaseDuration": 0,
+                      "sibling": null,
+                      "stateNode": Object {
+                        "containerInfo": <div>
+                          <div
+                            class="dashboard-card engagement"
+                          >
+                            <div
+                              class="title"
+                            >
+                              Engagement Trends
+                            </div>
+                          </div>
+                          <div
+                            class="dashboard-card upselling"
+                          >
+                            <div
+                              class="title"
+                            >
+                              Upselling Partners
+                            </div>
+                            <div>
+                              upselling component
+                            </div>
+                          </div>
+                        </div>,
+                        "context": Object {},
+                        "current": [Circular],
+                        "didError": false,
+                        "earliestPendingTime": 0,
+                        "earliestSuspendedTime": 0,
+                        "expirationTime": 0,
+                        "finishedWork": null,
+                        "firstBatch": null,
+                        "hydrate": false,
+                        "interactionThreadID": 15,
+                        "latestPendingTime": 0,
+                        "latestPingedTime": 0,
+                        "latestSuspendedTime": 0,
+                        "memoizedInteractions": Set {},
+                        "nextExpirationTimeToWorkOn": 0,
+                        "nextScheduledRoot": null,
+                        "pendingChildren": null,
+                        "pendingCommitExpirationTime": 0,
+                        "pendingContext": null,
+                        "pendingInteractionMap": Map {},
+                        "pingCache": null,
+                        "timeoutHandle": -1,
+                      },
+                      "tag": 3,
+                      "treeBaseDuration": 0,
+                      "type": null,
+                      "updateQueue": Object {
+                        "baseState": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={Object {}}
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "firstCapturedEffect": null,
+                        "firstCapturedUpdate": null,
+                        "firstEffect": null,
+                        "firstUpdate": null,
+                        "lastCapturedEffect": null,
+                        "lastCapturedUpdate": null,
+                        "lastEffect": null,
+                        "lastUpdate": null,
+                      },
+                    },
+                    "pendingProps": Object {
+                      "Component": [Function],
+                      "context": null,
+                      "props": Object {},
+                      "wrappingComponentProps": null,
+                    },
+                    "ref": null,
+                    "return": FiberNode {
+                      "_debugHookTypes": null,
+                      "_debugID": 60,
+                      "_debugIsCurrentlyTiming": false,
+                      "_debugOwner": null,
+                      "_debugSource": null,
+                      "actualDuration": 0,
+                      "actualStartTime": -1,
+                      "alternate": FiberNode {
+                        "_debugHookTypes": null,
+                        "_debugID": 60,
+                        "_debugIsCurrentlyTiming": false,
+                        "_debugOwner": null,
+                        "_debugSource": null,
+                        "actualDuration": 0,
+                        "actualStartTime": -1,
+                        "alternate": [Circular],
+                        "child": null,
+                        "childExpirationTime": 0,
+                        "contextDependencies": null,
+                        "effectTag": 0,
+                        "elementType": null,
+                        "expirationTime": 1073741823,
+                        "firstEffect": null,
+                        "index": 0,
+                        "key": null,
+                        "lastEffect": null,
+                        "memoizedProps": null,
+                        "memoizedState": null,
+                        "mode": 0,
+                        "nextEffect": null,
+                        "pendingProps": null,
+                        "ref": null,
+                        "return": null,
+                        "selfBaseDuration": 0,
+                        "sibling": null,
+                        "stateNode": Object {
+                          "containerInfo": <div>
+                            <div
+                              class="dashboard-card engagement"
+                            >
+                              <div
+                                class="title"
+                              >
+                                Engagement Trends
+                              </div>
+                            </div>
+                            <div
+                              class="dashboard-card upselling"
+                            >
+                              <div
+                                class="title"
+                              >
+                                Upselling Partners
+                              </div>
+                              <div>
+                                upselling component
+                              </div>
+                            </div>
+                          </div>,
+                          "context": Object {},
+                          "current": [Circular],
+                          "didError": false,
+                          "earliestPendingTime": 0,
+                          "earliestSuspendedTime": 0,
+                          "expirationTime": 0,
+                          "finishedWork": null,
+                          "firstBatch": null,
+                          "hydrate": false,
+                          "interactionThreadID": 15,
+                          "latestPendingTime": 0,
+                          "latestPingedTime": 0,
+                          "latestSuspendedTime": 0,
+                          "memoizedInteractions": Set {},
+                          "nextExpirationTimeToWorkOn": 0,
+                          "nextScheduledRoot": null,
+                          "pendingChildren": null,
+                          "pendingCommitExpirationTime": 0,
+                          "pendingContext": null,
+                          "pendingInteractionMap": Map {},
+                          "pingCache": null,
+                          "timeoutHandle": -1,
+                        },
+                        "tag": 3,
+                        "treeBaseDuration": 0,
+                        "type": null,
+                        "updateQueue": Object {
+                          "baseState": null,
+                          "firstCapturedEffect": null,
+                          "firstCapturedUpdate": null,
+                          "firstEffect": null,
+                          "firstUpdate": Object {
+                            "callback": null,
+                            "expirationTime": 1073741823,
+                            "next": null,
+                            "nextEffect": null,
+                            "payload": Object {
+                              "element": <WrapperComponent
+                                Component={[Function]}
+                                context={null}
+                                props={Object {}}
+                                wrappingComponentProps={null}
+                              />,
+                            },
+                            "tag": 0,
+                          },
+                          "lastCapturedEffect": null,
+                          "lastCapturedUpdate": null,
+                          "lastEffect": null,
+                          "lastUpdate": Object {
+                            "callback": null,
+                            "expirationTime": 1073741823,
+                            "next": null,
+                            "nextEffect": null,
+                            "payload": Object {
+                              "element": <WrapperComponent
+                                Component={[Function]}
+                                context={null}
+                                props={Object {}}
+                                wrappingComponentProps={null}
+                              />,
+                            },
+                            "tag": 0,
+                          },
+                        },
+                      },
+                      "child": [Circular],
+                      "childExpirationTime": 0,
+                      "contextDependencies": null,
+                      "effectTag": 32,
+                      "elementType": null,
+                      "expirationTime": 0,
+                      "firstEffect": [Circular],
+                      "index": 0,
+                      "key": null,
+                      "lastEffect": [Circular],
+                      "memoizedProps": null,
+                      "memoizedState": Object {
+                        "element": <WrapperComponent
+                          Component={[Function]}
+                          context={null}
+                          props={Object {}}
+                          wrappingComponentProps={null}
+                        />,
+                      },
+                      "mode": 0,
+                      "nextEffect": null,
+                      "pendingProps": null,
+                      "ref": null,
+                      "return": null,
+                      "selfBaseDuration": 0,
+                      "sibling": null,
+                      "stateNode": Object {
+                        "containerInfo": <div>
+                          <div
+                            class="dashboard-card engagement"
+                          >
+                            <div
+                              class="title"
+                            >
+                              Engagement Trends
+                            </div>
+                          </div>
+                          <div
+                            class="dashboard-card upselling"
+                          >
+                            <div
+                              class="title"
+                            >
+                              Upselling Partners
+                            </div>
+                            <div>
+                              upselling component
+                            </div>
+                          </div>
+                        </div>,
+                        "context": Object {},
+                        "current": [Circular],
+                        "didError": false,
+                        "earliestPendingTime": 0,
+                        "earliestSuspendedTime": 0,
+                        "expirationTime": 0,
+                        "finishedWork": null,
+                        "firstBatch": null,
+                        "hydrate": false,
+                        "interactionThreadID": 15,
+                        "latestPendingTime": 0,
+                        "latestPingedTime": 0,
+                        "latestSuspendedTime": 0,
+                        "memoizedInteractions": Set {},
+                        "nextExpirationTimeToWorkOn": 0,
+                        "nextScheduledRoot": null,
+                        "pendingChildren": null,
+                        "pendingCommitExpirationTime": 0,
+                        "pendingContext": null,
+                        "pendingInteractionMap": Map {},
+                        "pingCache": null,
+                        "timeoutHandle": -1,
+                      },
+                      "tag": 3,
+                      "treeBaseDuration": 0,
+                      "type": null,
+                      "updateQueue": Object {
+                        "baseState": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={Object {}}
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "firstCapturedEffect": null,
+                        "firstCapturedUpdate": null,
+                        "firstEffect": null,
+                        "firstUpdate": null,
+                        "lastCapturedEffect": null,
+                        "lastCapturedUpdate": null,
+                        "lastEffect": null,
+                        "lastUpdate": null,
+                      },
+                    },
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": WrapperComponent {
+                      "_reactInternalFiber": [Circular],
+                      "_reactInternalInstance": Object {},
+                      "context": Object {},
+                      "props": Object {
+                        "Component": [Function],
+                        "context": null,
+                        "props": Object {},
+                        "wrappingComponentProps": null,
+                      },
+                      "refs": Object {},
+                      "rootFinderInstance": null,
+                      "state": Object {
+                        "context": null,
+                        "mount": true,
+                        "props": Object {},
+                        "wrappingComponentProps": null,
+                      },
+                      "updater": Object {
+                        "enqueueForceUpdate": [Function],
+                        "enqueueReplaceState": [Function],
+                        "enqueueSetState": [Function],
+                        "isMounted": [Function],
+                      },
+                    },
+                    "tag": 1,
+                    "treeBaseDuration": 0,
+                    "type": [Function],
+                    "updateQueue": null,
+                  },
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": Dashboard {
+                    "_reactInternalFiber": [Circular],
+                    "_reactInternalInstance": Object {},
+                    "context": Object {},
+                    "props": Object {},
+                    "refs": Object {},
+                    "renderUpselling": [Function],
+                    "state": null,
+                    "updater": Object {
+                      "enqueueForceUpdate": [Function],
+                      "enqueueReplaceState": [Function],
+                      "enqueueSetState": [Function],
+                      "isMounted": [Function],
+                    },
+                  },
+                  "tag": 1,
+                  "treeBaseDuration": 0,
+                  "type": [Function],
+                  "updateQueue": null,
+                },
+                "selfBaseDuration": 0,
+                "sibling": null,
+                "stateNode": Card {
+                  "_reactInternalFiber": [Circular],
+                  "_reactInternalInstance": Object {},
+                  "context": Object {},
+                  "props": Object {
+                    "classes": "upselling",
+                    "component": [Function],
+                    "title": "Upselling Partners",
+                  },
+                  "refs": Object {},
+                  "state": null,
+                  "updater": Object {
+                    "enqueueForceUpdate": [Function],
+                    "enqueueReplaceState": [Function],
+                    "enqueueSetState": [Function],
+                    "isMounted": [Function],
+                  },
+                },
+                "tag": 1,
+                "treeBaseDuration": 0,
+                "type": [Function],
+                "updateQueue": null,
+              },
+              "stateNode": [Circular],
+              "tag": 1,
+              "treeBaseDuration": 0,
+              "type": [Function],
+              "updateQueue": null,
+            },
+            "_reactInternalInstance": Object {},
+            "context": Object {},
+            "props": Object {
+              "classes": "engagement",
+              "component": [Function],
+              "title": "Engagement Trends",
+            },
+            "refs": Object {},
+            "state": null,
+            "updater": Object {
+              "enqueueForceUpdate": [Function],
+              "enqueueReplaceState": [Function],
+              "enqueueSetState": [Function],
+              "isMounted": [Function],
+            },
+          },
+          "key": undefined,
+          "nodeType": "class",
+          "props": Object {
+            "classes": "engagement",
+            "component": [Function],
+            "title": "Engagement Trends",
+          },
+          "ref": null,
+          "rendered": Object {
+            "instance": <div
+              class="dashboard-card engagement"
+            >
+              <div
+                class="title"
+              >
+                Engagement Trends
+              </div>
+            </div>,
+            "key": undefined,
+            "nodeType": "host",
+            "props": Object {
+              "children": Array [
+                <div
+                  className="title"
+                >
+                  Engagement Trends
+                </div>,
+                undefined,
+              ],
+              "className": "dashboard-card engagement",
+            },
+            "ref": null,
+            "rendered": Array [
+              Object {
+                "instance": <div
+                  class="title"
+                >
+                  Engagement Trends
+                </div>,
+                "key": undefined,
+                "nodeType": "host",
+                "props": Object {
+                  "children": "Engagement Trends",
+                  "className": "title",
+                },
+                "ref": null,
+                "rendered": Array [
+                  "Engagement Trends",
+                ],
+                "type": "div",
+              },
+            ],
+            "type": "div",
+          },
+          "type": [Function],
+        },
+        Object {
+          "instance": Card {
+            "_reactInternalFiber": FiberNode {
+              "_debugHookTypes": null,
+              "_debugID": 65,
+              "_debugIsCurrentlyTiming": false,
+              "_debugOwner": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 63,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 62,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": null,
+                  "_debugSource": null,
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": null,
+                  "child": [Circular],
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 1,
+                  "elementType": [Function],
+                  "expirationTime": 0,
+                  "firstEffect": null,
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": null,
+                  "memoizedProps": Object {
+                    "Component": [Function],
+                    "context": null,
+                    "props": Object {},
+                    "wrappingComponentProps": null,
+                  },
+                  "memoizedState": Object {
+                    "context": null,
+                    "mount": true,
+                    "props": Object {},
+                    "wrappingComponentProps": null,
+                  },
+                  "mode": 0,
+                  "nextEffect": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 60,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": null,
+                    "_debugSource": null,
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": FiberNode {
+                      "_debugHookTypes": null,
+                      "_debugID": 60,
+                      "_debugIsCurrentlyTiming": false,
+                      "_debugOwner": null,
+                      "_debugSource": null,
+                      "actualDuration": 0,
+                      "actualStartTime": -1,
+                      "alternate": [Circular],
+                      "child": null,
+                      "childExpirationTime": 0,
+                      "contextDependencies": null,
+                      "effectTag": 0,
+                      "elementType": null,
+                      "expirationTime": 1073741823,
+                      "firstEffect": null,
+                      "index": 0,
+                      "key": null,
+                      "lastEffect": null,
+                      "memoizedProps": null,
+                      "memoizedState": null,
+                      "mode": 0,
+                      "nextEffect": null,
+                      "pendingProps": null,
+                      "ref": null,
+                      "return": null,
+                      "selfBaseDuration": 0,
+                      "sibling": null,
+                      "stateNode": Object {
+                        "containerInfo": <div>
+                          <div
+                            class="dashboard-card engagement"
+                          >
+                            <div
+                              class="title"
+                            >
+                              Engagement Trends
+                            </div>
+                          </div>
+                          <div
+                            class="dashboard-card upselling"
+                          >
+                            <div
+                              class="title"
+                            >
+                              Upselling Partners
+                            </div>
+                            <div>
+                              upselling component
+                            </div>
+                          </div>
+                        </div>,
+                        "context": Object {},
+                        "current": [Circular],
+                        "didError": false,
+                        "earliestPendingTime": 0,
+                        "earliestSuspendedTime": 0,
+                        "expirationTime": 0,
+                        "finishedWork": null,
+                        "firstBatch": null,
+                        "hydrate": false,
+                        "interactionThreadID": 15,
+                        "latestPendingTime": 0,
+                        "latestPingedTime": 0,
+                        "latestSuspendedTime": 0,
+                        "memoizedInteractions": Set {},
+                        "nextExpirationTimeToWorkOn": 0,
+                        "nextScheduledRoot": null,
+                        "pendingChildren": null,
+                        "pendingCommitExpirationTime": 0,
+                        "pendingContext": null,
+                        "pendingInteractionMap": Map {},
+                        "pingCache": null,
+                        "timeoutHandle": -1,
+                      },
+                      "tag": 3,
+                      "treeBaseDuration": 0,
+                      "type": null,
+                      "updateQueue": Object {
+                        "baseState": null,
+                        "firstCapturedEffect": null,
+                        "firstCapturedUpdate": null,
+                        "firstEffect": null,
+                        "firstUpdate": Object {
+                          "callback": null,
+                          "expirationTime": 1073741823,
+                          "next": null,
+                          "nextEffect": null,
+                          "payload": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={Object {}}
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "tag": 0,
+                        },
+                        "lastCapturedEffect": null,
+                        "lastCapturedUpdate": null,
+                        "lastEffect": null,
+                        "lastUpdate": Object {
+                          "callback": null,
+                          "expirationTime": 1073741823,
+                          "next": null,
+                          "nextEffect": null,
+                          "payload": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={Object {}}
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "tag": 0,
+                        },
+                      },
+                    },
+                    "child": [Circular],
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 32,
+                    "elementType": null,
+                    "expirationTime": 0,
+                    "firstEffect": [Circular],
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": [Circular],
+                    "memoizedProps": null,
+                    "memoizedState": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={Object {}}
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": null,
+                    "ref": null,
+                    "return": null,
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": Object {
+                      "containerInfo": <div>
+                        <div
+                          class="dashboard-card engagement"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Engagement Trends
+                          </div>
+                        </div>
+                        <div
+                          class="dashboard-card upselling"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Upselling Partners
+                          </div>
+                          <div>
+                            upselling component
+                          </div>
+                        </div>
+                      </div>,
+                      "context": Object {},
+                      "current": [Circular],
+                      "didError": false,
+                      "earliestPendingTime": 0,
+                      "earliestSuspendedTime": 0,
+                      "expirationTime": 0,
+                      "finishedWork": null,
+                      "firstBatch": null,
+                      "hydrate": false,
+                      "interactionThreadID": 15,
+                      "latestPendingTime": 0,
+                      "latestPingedTime": 0,
+                      "latestSuspendedTime": 0,
+                      "memoizedInteractions": Set {},
+                      "nextExpirationTimeToWorkOn": 0,
+                      "nextScheduledRoot": null,
+                      "pendingChildren": null,
+                      "pendingCommitExpirationTime": 0,
+                      "pendingContext": null,
+                      "pendingInteractionMap": Map {},
+                      "pingCache": null,
+                      "timeoutHandle": -1,
+                    },
+                    "tag": 3,
+                    "treeBaseDuration": 0,
+                    "type": null,
+                    "updateQueue": Object {
+                      "baseState": Object {
+                        "element": <WrapperComponent
+                          Component={[Function]}
+                          context={null}
+                          props={Object {}}
+                          wrappingComponentProps={null}
+                        />,
+                      },
+                      "firstCapturedEffect": null,
+                      "firstCapturedUpdate": null,
+                      "firstEffect": null,
+                      "firstUpdate": null,
+                      "lastCapturedEffect": null,
+                      "lastCapturedUpdate": null,
+                      "lastEffect": null,
+                      "lastUpdate": null,
+                    },
+                  },
+                  "pendingProps": Object {
+                    "Component": [Function],
+                    "context": null,
+                    "props": Object {},
+                    "wrappingComponentProps": null,
+                  },
+                  "ref": null,
+                  "return": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 60,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": null,
+                    "_debugSource": null,
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": FiberNode {
+                      "_debugHookTypes": null,
+                      "_debugID": 60,
+                      "_debugIsCurrentlyTiming": false,
+                      "_debugOwner": null,
+                      "_debugSource": null,
+                      "actualDuration": 0,
+                      "actualStartTime": -1,
+                      "alternate": [Circular],
+                      "child": null,
+                      "childExpirationTime": 0,
+                      "contextDependencies": null,
+                      "effectTag": 0,
+                      "elementType": null,
+                      "expirationTime": 1073741823,
+                      "firstEffect": null,
+                      "index": 0,
+                      "key": null,
+                      "lastEffect": null,
+                      "memoizedProps": null,
+                      "memoizedState": null,
+                      "mode": 0,
+                      "nextEffect": null,
+                      "pendingProps": null,
+                      "ref": null,
+                      "return": null,
+                      "selfBaseDuration": 0,
+                      "sibling": null,
+                      "stateNode": Object {
+                        "containerInfo": <div>
+                          <div
+                            class="dashboard-card engagement"
+                          >
+                            <div
+                              class="title"
+                            >
+                              Engagement Trends
+                            </div>
+                          </div>
+                          <div
+                            class="dashboard-card upselling"
+                          >
+                            <div
+                              class="title"
+                            >
+                              Upselling Partners
+                            </div>
+                            <div>
+                              upselling component
+                            </div>
+                          </div>
+                        </div>,
+                        "context": Object {},
+                        "current": [Circular],
+                        "didError": false,
+                        "earliestPendingTime": 0,
+                        "earliestSuspendedTime": 0,
+                        "expirationTime": 0,
+                        "finishedWork": null,
+                        "firstBatch": null,
+                        "hydrate": false,
+                        "interactionThreadID": 15,
+                        "latestPendingTime": 0,
+                        "latestPingedTime": 0,
+                        "latestSuspendedTime": 0,
+                        "memoizedInteractions": Set {},
+                        "nextExpirationTimeToWorkOn": 0,
+                        "nextScheduledRoot": null,
+                        "pendingChildren": null,
+                        "pendingCommitExpirationTime": 0,
+                        "pendingContext": null,
+                        "pendingInteractionMap": Map {},
+                        "pingCache": null,
+                        "timeoutHandle": -1,
+                      },
+                      "tag": 3,
+                      "treeBaseDuration": 0,
+                      "type": null,
+                      "updateQueue": Object {
+                        "baseState": null,
+                        "firstCapturedEffect": null,
+                        "firstCapturedUpdate": null,
+                        "firstEffect": null,
+                        "firstUpdate": Object {
+                          "callback": null,
+                          "expirationTime": 1073741823,
+                          "next": null,
+                          "nextEffect": null,
+                          "payload": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={Object {}}
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "tag": 0,
+                        },
+                        "lastCapturedEffect": null,
+                        "lastCapturedUpdate": null,
+                        "lastEffect": null,
+                        "lastUpdate": Object {
+                          "callback": null,
+                          "expirationTime": 1073741823,
+                          "next": null,
+                          "nextEffect": null,
+                          "payload": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={Object {}}
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "tag": 0,
+                        },
+                      },
+                    },
+                    "child": [Circular],
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 32,
+                    "elementType": null,
+                    "expirationTime": 0,
+                    "firstEffect": [Circular],
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": [Circular],
+                    "memoizedProps": null,
+                    "memoizedState": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={Object {}}
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": null,
+                    "ref": null,
+                    "return": null,
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": Object {
+                      "containerInfo": <div>
+                        <div
+                          class="dashboard-card engagement"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Engagement Trends
+                          </div>
+                        </div>
+                        <div
+                          class="dashboard-card upselling"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Upselling Partners
+                          </div>
+                          <div>
+                            upselling component
+                          </div>
+                        </div>
+                      </div>,
+                      "context": Object {},
+                      "current": [Circular],
+                      "didError": false,
+                      "earliestPendingTime": 0,
+                      "earliestSuspendedTime": 0,
+                      "expirationTime": 0,
+                      "finishedWork": null,
+                      "firstBatch": null,
+                      "hydrate": false,
+                      "interactionThreadID": 15,
+                      "latestPendingTime": 0,
+                      "latestPingedTime": 0,
+                      "latestSuspendedTime": 0,
+                      "memoizedInteractions": Set {},
+                      "nextExpirationTimeToWorkOn": 0,
+                      "nextScheduledRoot": null,
+                      "pendingChildren": null,
+                      "pendingCommitExpirationTime": 0,
+                      "pendingContext": null,
+                      "pendingInteractionMap": Map {},
+                      "pingCache": null,
+                      "timeoutHandle": -1,
+                    },
+                    "tag": 3,
+                    "treeBaseDuration": 0,
+                    "type": null,
+                    "updateQueue": Object {
+                      "baseState": Object {
+                        "element": <WrapperComponent
+                          Component={[Function]}
+                          context={null}
+                          props={Object {}}
+                          wrappingComponentProps={null}
+                        />,
+                      },
+                      "firstCapturedEffect": null,
+                      "firstCapturedUpdate": null,
+                      "firstEffect": null,
+                      "firstUpdate": null,
+                      "lastCapturedEffect": null,
+                      "lastCapturedUpdate": null,
+                      "lastEffect": null,
+                      "lastUpdate": null,
+                    },
+                  },
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": WrapperComponent {
+                    "_reactInternalFiber": [Circular],
+                    "_reactInternalInstance": Object {},
+                    "context": Object {},
+                    "props": Object {
+                      "Component": [Function],
+                      "context": null,
+                      "props": Object {},
+                      "wrappingComponentProps": null,
+                    },
+                    "refs": Object {},
+                    "rootFinderInstance": null,
+                    "state": Object {
+                      "context": null,
+                      "mount": true,
+                      "props": Object {},
+                      "wrappingComponentProps": null,
+                    },
+                    "updater": Object {
+                      "enqueueForceUpdate": [Function],
+                      "enqueueReplaceState": [Function],
+                      "enqueueSetState": [Function],
+                      "isMounted": [Function],
+                    },
+                  },
+                  "tag": 1,
+                  "treeBaseDuration": 0,
+                  "type": [Function],
+                  "updateQueue": null,
+                },
+                "_debugSource": null,
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": null,
+                "child": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 64,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": [Circular],
+                  "_debugSource": Object {
+                    "fileName": "/Users/kevinkoech/Documents/bp-esa-frontend/src/components/Dashboard/index.jsx",
+                    "lineNumber": 23,
+                  },
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": null,
+                  "child": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 66,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": [Circular],
+                    "_debugSource": Object {
+                      "fileName": "/Users/kevinkoech/Documents/bp-esa-frontend/src/components/Dashboard/Card.jsx",
+                      "lineNumber": 20,
+                    },
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": null,
+                    "child": FiberNode {
+                      "_debugHookTypes": null,
+                      "_debugID": 67,
+                      "_debugIsCurrentlyTiming": false,
+                      "_debugOwner": [Circular],
+                      "_debugSource": Object {
+                        "fileName": "/Users/kevinkoech/Documents/bp-esa-frontend/src/components/Dashboard/Card.jsx",
+                        "lineNumber": 21,
+                      },
+                      "actualDuration": 0,
+                      "actualStartTime": -1,
+                      "alternate": null,
+                      "child": null,
+                      "childExpirationTime": 0,
+                      "contextDependencies": null,
+                      "effectTag": 0,
+                      "elementType": "div",
+                      "expirationTime": 0,
+                      "firstEffect": null,
+                      "index": 0,
+                      "key": null,
+                      "lastEffect": null,
+                      "memoizedProps": Object {
+                        "children": "Engagement Trends",
+                        "className": "title",
+                      },
+                      "memoizedState": null,
+                      "mode": 0,
+                      "nextEffect": null,
+                      "pendingProps": Object {
+                        "children": "Engagement Trends",
+                        "className": "title",
+                      },
+                      "ref": null,
+                      "return": [Circular],
+                      "selfBaseDuration": 0,
+                      "sibling": null,
+                      "stateNode": <div
+                        class="title"
+                      >
+                        Engagement Trends
+                      </div>,
+                      "tag": 5,
+                      "treeBaseDuration": 0,
+                      "type": "div",
+                      "updateQueue": null,
+                    },
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 0,
+                    "elementType": "div",
+                    "expirationTime": 0,
+                    "firstEffect": null,
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": null,
+                    "memoizedProps": Object {
+                      "children": Array [
+                        <div
+                          className="title"
+                        >
+                          Engagement Trends
+                        </div>,
+                        undefined,
+                      ],
+                      "className": "dashboard-card engagement",
+                    },
+                    "memoizedState": null,
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": Object {
+                      "children": Array [
+                        <div
+                          className="title"
+                        >
+                          Engagement Trends
+                        </div>,
+                        undefined,
+                      ],
+                      "className": "dashboard-card engagement",
+                    },
+                    "ref": null,
+                    "return": [Circular],
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": <div
+                      class="dashboard-card engagement"
+                    >
+                      <div
+                        class="title"
+                      >
+                        Engagement Trends
+                      </div>
+                    </div>,
+                    "tag": 5,
+                    "treeBaseDuration": 0,
+                    "type": "div",
+                    "updateQueue": null,
+                  },
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 1,
+                  "elementType": [Function],
+                  "expirationTime": 0,
+                  "firstEffect": null,
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": null,
+                  "memoizedProps": Object {
+                    "classes": "engagement",
+                    "component": [Function],
+                    "title": "Engagement Trends",
+                  },
+                  "memoizedState": null,
+                  "mode": 0,
+                  "nextEffect": null,
+                  "pendingProps": Object {
+                    "classes": "engagement",
+                    "component": [Function],
+                    "title": "Engagement Trends",
+                  },
+                  "ref": null,
+                  "return": [Circular],
+                  "selfBaseDuration": 0,
+                  "sibling": [Circular],
+                  "stateNode": Card {
+                    "_reactInternalFiber": [Circular],
+                    "_reactInternalInstance": Object {},
+                    "context": Object {},
+                    "props": Object {
+                      "classes": "engagement",
+                      "component": [Function],
+                      "title": "Engagement Trends",
+                    },
+                    "refs": Object {},
+                    "state": null,
+                    "updater": Object {
+                      "enqueueForceUpdate": [Function],
+                      "enqueueReplaceState": [Function],
+                      "enqueueSetState": [Function],
+                      "isMounted": [Function],
+                    },
+                  },
+                  "tag": 1,
+                  "treeBaseDuration": 0,
+                  "type": [Function],
+                  "updateQueue": null,
+                },
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 1,
+                "elementType": [Function],
+                "expirationTime": 0,
+                "firstEffect": null,
+                "index": 0,
+                "key": null,
+                "lastEffect": null,
+                "memoizedProps": Object {},
+                "memoizedState": null,
+                "mode": 0,
+                "nextEffect": null,
+                "pendingProps": Object {},
+                "ref": null,
+                "return": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 62,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": null,
+                  "_debugSource": null,
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": null,
+                  "child": [Circular],
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 1,
+                  "elementType": [Function],
+                  "expirationTime": 0,
+                  "firstEffect": null,
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": null,
+                  "memoizedProps": Object {
+                    "Component": [Function],
+                    "context": null,
+                    "props": Object {},
+                    "wrappingComponentProps": null,
+                  },
+                  "memoizedState": Object {
+                    "context": null,
+                    "mount": true,
+                    "props": Object {},
+                    "wrappingComponentProps": null,
+                  },
+                  "mode": 0,
+                  "nextEffect": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 60,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": null,
+                    "_debugSource": null,
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": FiberNode {
+                      "_debugHookTypes": null,
+                      "_debugID": 60,
+                      "_debugIsCurrentlyTiming": false,
+                      "_debugOwner": null,
+                      "_debugSource": null,
+                      "actualDuration": 0,
+                      "actualStartTime": -1,
+                      "alternate": [Circular],
+                      "child": null,
+                      "childExpirationTime": 0,
+                      "contextDependencies": null,
+                      "effectTag": 0,
+                      "elementType": null,
+                      "expirationTime": 1073741823,
+                      "firstEffect": null,
+                      "index": 0,
+                      "key": null,
+                      "lastEffect": null,
+                      "memoizedProps": null,
+                      "memoizedState": null,
+                      "mode": 0,
+                      "nextEffect": null,
+                      "pendingProps": null,
+                      "ref": null,
+                      "return": null,
+                      "selfBaseDuration": 0,
+                      "sibling": null,
+                      "stateNode": Object {
+                        "containerInfo": <div>
+                          <div
+                            class="dashboard-card engagement"
+                          >
+                            <div
+                              class="title"
+                            >
+                              Engagement Trends
+                            </div>
+                          </div>
+                          <div
+                            class="dashboard-card upselling"
+                          >
+                            <div
+                              class="title"
+                            >
+                              Upselling Partners
+                            </div>
+                            <div>
+                              upselling component
+                            </div>
+                          </div>
+                        </div>,
+                        "context": Object {},
+                        "current": [Circular],
+                        "didError": false,
+                        "earliestPendingTime": 0,
+                        "earliestSuspendedTime": 0,
+                        "expirationTime": 0,
+                        "finishedWork": null,
+                        "firstBatch": null,
+                        "hydrate": false,
+                        "interactionThreadID": 15,
+                        "latestPendingTime": 0,
+                        "latestPingedTime": 0,
+                        "latestSuspendedTime": 0,
+                        "memoizedInteractions": Set {},
+                        "nextExpirationTimeToWorkOn": 0,
+                        "nextScheduledRoot": null,
+                        "pendingChildren": null,
+                        "pendingCommitExpirationTime": 0,
+                        "pendingContext": null,
+                        "pendingInteractionMap": Map {},
+                        "pingCache": null,
+                        "timeoutHandle": -1,
+                      },
+                      "tag": 3,
+                      "treeBaseDuration": 0,
+                      "type": null,
+                      "updateQueue": Object {
+                        "baseState": null,
+                        "firstCapturedEffect": null,
+                        "firstCapturedUpdate": null,
+                        "firstEffect": null,
+                        "firstUpdate": Object {
+                          "callback": null,
+                          "expirationTime": 1073741823,
+                          "next": null,
+                          "nextEffect": null,
+                          "payload": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={Object {}}
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "tag": 0,
+                        },
+                        "lastCapturedEffect": null,
+                        "lastCapturedUpdate": null,
+                        "lastEffect": null,
+                        "lastUpdate": Object {
+                          "callback": null,
+                          "expirationTime": 1073741823,
+                          "next": null,
+                          "nextEffect": null,
+                          "payload": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={Object {}}
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "tag": 0,
+                        },
+                      },
+                    },
+                    "child": [Circular],
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 32,
+                    "elementType": null,
+                    "expirationTime": 0,
+                    "firstEffect": [Circular],
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": [Circular],
+                    "memoizedProps": null,
+                    "memoizedState": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={Object {}}
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": null,
+                    "ref": null,
+                    "return": null,
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": Object {
+                      "containerInfo": <div>
+                        <div
+                          class="dashboard-card engagement"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Engagement Trends
+                          </div>
+                        </div>
+                        <div
+                          class="dashboard-card upselling"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Upselling Partners
+                          </div>
+                          <div>
+                            upselling component
+                          </div>
+                        </div>
+                      </div>,
+                      "context": Object {},
+                      "current": [Circular],
+                      "didError": false,
+                      "earliestPendingTime": 0,
+                      "earliestSuspendedTime": 0,
+                      "expirationTime": 0,
+                      "finishedWork": null,
+                      "firstBatch": null,
+                      "hydrate": false,
+                      "interactionThreadID": 15,
+                      "latestPendingTime": 0,
+                      "latestPingedTime": 0,
+                      "latestSuspendedTime": 0,
+                      "memoizedInteractions": Set {},
+                      "nextExpirationTimeToWorkOn": 0,
+                      "nextScheduledRoot": null,
+                      "pendingChildren": null,
+                      "pendingCommitExpirationTime": 0,
+                      "pendingContext": null,
+                      "pendingInteractionMap": Map {},
+                      "pingCache": null,
+                      "timeoutHandle": -1,
+                    },
+                    "tag": 3,
+                    "treeBaseDuration": 0,
+                    "type": null,
+                    "updateQueue": Object {
+                      "baseState": Object {
+                        "element": <WrapperComponent
+                          Component={[Function]}
+                          context={null}
+                          props={Object {}}
+                          wrappingComponentProps={null}
+                        />,
+                      },
+                      "firstCapturedEffect": null,
+                      "firstCapturedUpdate": null,
+                      "firstEffect": null,
+                      "firstUpdate": null,
+                      "lastCapturedEffect": null,
+                      "lastCapturedUpdate": null,
+                      "lastEffect": null,
+                      "lastUpdate": null,
+                    },
+                  },
+                  "pendingProps": Object {
+                    "Component": [Function],
+                    "context": null,
+                    "props": Object {},
+                    "wrappingComponentProps": null,
+                  },
+                  "ref": null,
+                  "return": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 60,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": null,
+                    "_debugSource": null,
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": FiberNode {
+                      "_debugHookTypes": null,
+                      "_debugID": 60,
+                      "_debugIsCurrentlyTiming": false,
+                      "_debugOwner": null,
+                      "_debugSource": null,
+                      "actualDuration": 0,
+                      "actualStartTime": -1,
+                      "alternate": [Circular],
+                      "child": null,
+                      "childExpirationTime": 0,
+                      "contextDependencies": null,
+                      "effectTag": 0,
+                      "elementType": null,
+                      "expirationTime": 1073741823,
+                      "firstEffect": null,
+                      "index": 0,
+                      "key": null,
+                      "lastEffect": null,
+                      "memoizedProps": null,
+                      "memoizedState": null,
+                      "mode": 0,
+                      "nextEffect": null,
+                      "pendingProps": null,
+                      "ref": null,
+                      "return": null,
+                      "selfBaseDuration": 0,
+                      "sibling": null,
+                      "stateNode": Object {
+                        "containerInfo": <div>
+                          <div
+                            class="dashboard-card engagement"
+                          >
+                            <div
+                              class="title"
+                            >
+                              Engagement Trends
+                            </div>
+                          </div>
+                          <div
+                            class="dashboard-card upselling"
+                          >
+                            <div
+                              class="title"
+                            >
+                              Upselling Partners
+                            </div>
+                            <div>
+                              upselling component
+                            </div>
+                          </div>
+                        </div>,
+                        "context": Object {},
+                        "current": [Circular],
+                        "didError": false,
+                        "earliestPendingTime": 0,
+                        "earliestSuspendedTime": 0,
+                        "expirationTime": 0,
+                        "finishedWork": null,
+                        "firstBatch": null,
+                        "hydrate": false,
+                        "interactionThreadID": 15,
+                        "latestPendingTime": 0,
+                        "latestPingedTime": 0,
+                        "latestSuspendedTime": 0,
+                        "memoizedInteractions": Set {},
+                        "nextExpirationTimeToWorkOn": 0,
+                        "nextScheduledRoot": null,
+                        "pendingChildren": null,
+                        "pendingCommitExpirationTime": 0,
+                        "pendingContext": null,
+                        "pendingInteractionMap": Map {},
+                        "pingCache": null,
+                        "timeoutHandle": -1,
+                      },
+                      "tag": 3,
+                      "treeBaseDuration": 0,
+                      "type": null,
+                      "updateQueue": Object {
+                        "baseState": null,
+                        "firstCapturedEffect": null,
+                        "firstCapturedUpdate": null,
+                        "firstEffect": null,
+                        "firstUpdate": Object {
+                          "callback": null,
+                          "expirationTime": 1073741823,
+                          "next": null,
+                          "nextEffect": null,
+                          "payload": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={Object {}}
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "tag": 0,
+                        },
+                        "lastCapturedEffect": null,
+                        "lastCapturedUpdate": null,
+                        "lastEffect": null,
+                        "lastUpdate": Object {
+                          "callback": null,
+                          "expirationTime": 1073741823,
+                          "next": null,
+                          "nextEffect": null,
+                          "payload": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={Object {}}
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "tag": 0,
+                        },
+                      },
+                    },
+                    "child": [Circular],
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 32,
+                    "elementType": null,
+                    "expirationTime": 0,
+                    "firstEffect": [Circular],
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": [Circular],
+                    "memoizedProps": null,
+                    "memoizedState": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={Object {}}
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": null,
+                    "ref": null,
+                    "return": null,
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": Object {
+                      "containerInfo": <div>
+                        <div
+                          class="dashboard-card engagement"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Engagement Trends
+                          </div>
+                        </div>
+                        <div
+                          class="dashboard-card upselling"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Upselling Partners
+                          </div>
+                          <div>
+                            upselling component
+                          </div>
+                        </div>
+                      </div>,
+                      "context": Object {},
+                      "current": [Circular],
+                      "didError": false,
+                      "earliestPendingTime": 0,
+                      "earliestSuspendedTime": 0,
+                      "expirationTime": 0,
+                      "finishedWork": null,
+                      "firstBatch": null,
+                      "hydrate": false,
+                      "interactionThreadID": 15,
+                      "latestPendingTime": 0,
+                      "latestPingedTime": 0,
+                      "latestSuspendedTime": 0,
+                      "memoizedInteractions": Set {},
+                      "nextExpirationTimeToWorkOn": 0,
+                      "nextScheduledRoot": null,
+                      "pendingChildren": null,
+                      "pendingCommitExpirationTime": 0,
+                      "pendingContext": null,
+                      "pendingInteractionMap": Map {},
+                      "pingCache": null,
+                      "timeoutHandle": -1,
+                    },
+                    "tag": 3,
+                    "treeBaseDuration": 0,
+                    "type": null,
+                    "updateQueue": Object {
+                      "baseState": Object {
+                        "element": <WrapperComponent
+                          Component={[Function]}
+                          context={null}
+                          props={Object {}}
+                          wrappingComponentProps={null}
+                        />,
+                      },
+                      "firstCapturedEffect": null,
+                      "firstCapturedUpdate": null,
+                      "firstEffect": null,
+                      "firstUpdate": null,
+                      "lastCapturedEffect": null,
+                      "lastCapturedUpdate": null,
+                      "lastEffect": null,
+                      "lastUpdate": null,
+                    },
+                  },
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": WrapperComponent {
+                    "_reactInternalFiber": [Circular],
+                    "_reactInternalInstance": Object {},
+                    "context": Object {},
+                    "props": Object {
+                      "Component": [Function],
+                      "context": null,
+                      "props": Object {},
+                      "wrappingComponentProps": null,
+                    },
+                    "refs": Object {},
+                    "rootFinderInstance": null,
+                    "state": Object {
+                      "context": null,
+                      "mount": true,
+                      "props": Object {},
+                      "wrappingComponentProps": null,
+                    },
+                    "updater": Object {
+                      "enqueueForceUpdate": [Function],
+                      "enqueueReplaceState": [Function],
+                      "enqueueSetState": [Function],
+                      "isMounted": [Function],
+                    },
+                  },
+                  "tag": 1,
+                  "treeBaseDuration": 0,
+                  "type": [Function],
+                  "updateQueue": null,
+                },
+                "selfBaseDuration": 0,
+                "sibling": null,
+                "stateNode": Dashboard {
+                  "_reactInternalFiber": [Circular],
+                  "_reactInternalInstance": Object {},
+                  "context": Object {},
+                  "props": Object {},
+                  "refs": Object {},
+                  "renderUpselling": [Function],
+                  "state": null,
+                  "updater": Object {
+                    "enqueueForceUpdate": [Function],
+                    "enqueueReplaceState": [Function],
+                    "enqueueSetState": [Function],
+                    "isMounted": [Function],
+                  },
+                },
+                "tag": 1,
+                "treeBaseDuration": 0,
+                "type": [Function],
+                "updateQueue": null,
+              },
+              "_debugSource": Object {
+                "fileName": "/Users/kevinkoech/Documents/bp-esa-frontend/src/components/Dashboard/index.jsx",
+                "lineNumber": 28,
+              },
+              "actualDuration": 0,
+              "actualStartTime": -1,
+              "alternate": null,
+              "child": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 68,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": [Circular],
+                "_debugSource": Object {
+                  "fileName": "/Users/kevinkoech/Documents/bp-esa-frontend/src/components/Dashboard/Card.jsx",
+                  "lineNumber": 20,
+                },
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": null,
+                "child": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 69,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": [Circular],
+                  "_debugSource": Object {
+                    "fileName": "/Users/kevinkoech/Documents/bp-esa-frontend/src/components/Dashboard/Card.jsx",
+                    "lineNumber": 21,
+                  },
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": null,
+                  "child": null,
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 0,
+                  "elementType": "div",
+                  "expirationTime": 0,
+                  "firstEffect": null,
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": null,
+                  "memoizedProps": Object {
+                    "children": "Upselling Partners",
+                    "className": "title",
+                  },
+                  "memoizedState": null,
+                  "mode": 0,
+                  "nextEffect": null,
+                  "pendingProps": Object {
+                    "children": "Upselling Partners",
+                    "className": "title",
+                  },
+                  "ref": null,
+                  "return": [Circular],
+                  "selfBaseDuration": 0,
+                  "sibling": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 70,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": [Circular],
+                    "_debugSource": Object {
+                      "fileName": "/Users/kevinkoech/Documents/bp-esa-frontend/src/components/Dashboard/index.jsx",
+                      "lineNumber": 15,
+                    },
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": null,
+                    "child": null,
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 0,
+                    "elementType": "div",
+                    "expirationTime": 0,
+                    "firstEffect": null,
+                    "index": 1,
+                    "key": null,
+                    "lastEffect": null,
+                    "memoizedProps": Object {
+                      "children": "upselling component",
+                    },
+                    "memoizedState": null,
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": Object {
+                      "children": "upselling component",
+                    },
+                    "ref": null,
+                    "return": [Circular],
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": <div>
+                      upselling component
+                    </div>,
+                    "tag": 5,
+                    "treeBaseDuration": 0,
+                    "type": "div",
+                    "updateQueue": null,
+                  },
+                  "stateNode": <div
+                    class="title"
+                  >
+                    Upselling Partners
+                  </div>,
+                  "tag": 5,
+                  "treeBaseDuration": 0,
+                  "type": "div",
+                  "updateQueue": null,
+                },
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 0,
+                "elementType": "div",
+                "expirationTime": 0,
+                "firstEffect": null,
+                "index": 0,
+                "key": null,
+                "lastEffect": null,
+                "memoizedProps": Object {
+                  "children": Array [
+                    <div
+                      className="title"
+                    >
+                      Upselling Partners
+                    </div>,
+                    <div>
+                      upselling component
+                    </div>,
+                  ],
+                  "className": "dashboard-card upselling",
+                },
+                "memoizedState": null,
+                "mode": 0,
+                "nextEffect": null,
+                "pendingProps": Object {
+                  "children": Array [
+                    <div
+                      className="title"
+                    >
+                      Upselling Partners
+                    </div>,
+                    <div>
+                      upselling component
+                    </div>,
+                  ],
+                  "className": "dashboard-card upselling",
+                },
+                "ref": null,
+                "return": [Circular],
+                "selfBaseDuration": 0,
+                "sibling": null,
+                "stateNode": <div
+                  class="dashboard-card upselling"
+                >
+                  <div
+                    class="title"
+                  >
+                    Upselling Partners
+                  </div>
+                  <div>
+                    upselling component
+                  </div>
+                </div>,
+                "tag": 5,
+                "treeBaseDuration": 0,
+                "type": "div",
+                "updateQueue": null,
+              },
+              "childExpirationTime": 0,
+              "contextDependencies": null,
+              "effectTag": 1,
+              "elementType": [Function],
+              "expirationTime": 0,
+              "firstEffect": null,
+              "index": 1,
+              "key": null,
+              "lastEffect": null,
+              "memoizedProps": Object {
+                "classes": "upselling",
+                "component": [Function],
+                "title": "Upselling Partners",
+              },
+              "memoizedState": null,
+              "mode": 0,
+              "nextEffect": null,
+              "pendingProps": Object {
+                "classes": "upselling",
+                "component": [Function],
+                "title": "Upselling Partners",
+              },
+              "ref": null,
+              "return": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 63,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 62,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": null,
+                  "_debugSource": null,
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": null,
+                  "child": [Circular],
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 1,
+                  "elementType": [Function],
+                  "expirationTime": 0,
+                  "firstEffect": null,
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": null,
+                  "memoizedProps": Object {
+                    "Component": [Function],
+                    "context": null,
+                    "props": Object {},
+                    "wrappingComponentProps": null,
+                  },
+                  "memoizedState": Object {
+                    "context": null,
+                    "mount": true,
+                    "props": Object {},
+                    "wrappingComponentProps": null,
+                  },
+                  "mode": 0,
+                  "nextEffect": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 60,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": null,
+                    "_debugSource": null,
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": FiberNode {
+                      "_debugHookTypes": null,
+                      "_debugID": 60,
+                      "_debugIsCurrentlyTiming": false,
+                      "_debugOwner": null,
+                      "_debugSource": null,
+                      "actualDuration": 0,
+                      "actualStartTime": -1,
+                      "alternate": [Circular],
+                      "child": null,
+                      "childExpirationTime": 0,
+                      "contextDependencies": null,
+                      "effectTag": 0,
+                      "elementType": null,
+                      "expirationTime": 1073741823,
+                      "firstEffect": null,
+                      "index": 0,
+                      "key": null,
+                      "lastEffect": null,
+                      "memoizedProps": null,
+                      "memoizedState": null,
+                      "mode": 0,
+                      "nextEffect": null,
+                      "pendingProps": null,
+                      "ref": null,
+                      "return": null,
+                      "selfBaseDuration": 0,
+                      "sibling": null,
+                      "stateNode": Object {
+                        "containerInfo": <div>
+                          <div
+                            class="dashboard-card engagement"
+                          >
+                            <div
+                              class="title"
+                            >
+                              Engagement Trends
+                            </div>
+                          </div>
+                          <div
+                            class="dashboard-card upselling"
+                          >
+                            <div
+                              class="title"
+                            >
+                              Upselling Partners
+                            </div>
+                            <div>
+                              upselling component
+                            </div>
+                          </div>
+                        </div>,
+                        "context": Object {},
+                        "current": [Circular],
+                        "didError": false,
+                        "earliestPendingTime": 0,
+                        "earliestSuspendedTime": 0,
+                        "expirationTime": 0,
+                        "finishedWork": null,
+                        "firstBatch": null,
+                        "hydrate": false,
+                        "interactionThreadID": 15,
+                        "latestPendingTime": 0,
+                        "latestPingedTime": 0,
+                        "latestSuspendedTime": 0,
+                        "memoizedInteractions": Set {},
+                        "nextExpirationTimeToWorkOn": 0,
+                        "nextScheduledRoot": null,
+                        "pendingChildren": null,
+                        "pendingCommitExpirationTime": 0,
+                        "pendingContext": null,
+                        "pendingInteractionMap": Map {},
+                        "pingCache": null,
+                        "timeoutHandle": -1,
+                      },
+                      "tag": 3,
+                      "treeBaseDuration": 0,
+                      "type": null,
+                      "updateQueue": Object {
+                        "baseState": null,
+                        "firstCapturedEffect": null,
+                        "firstCapturedUpdate": null,
+                        "firstEffect": null,
+                        "firstUpdate": Object {
+                          "callback": null,
+                          "expirationTime": 1073741823,
+                          "next": null,
+                          "nextEffect": null,
+                          "payload": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={Object {}}
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "tag": 0,
+                        },
+                        "lastCapturedEffect": null,
+                        "lastCapturedUpdate": null,
+                        "lastEffect": null,
+                        "lastUpdate": Object {
+                          "callback": null,
+                          "expirationTime": 1073741823,
+                          "next": null,
+                          "nextEffect": null,
+                          "payload": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={Object {}}
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "tag": 0,
+                        },
+                      },
+                    },
+                    "child": [Circular],
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 32,
+                    "elementType": null,
+                    "expirationTime": 0,
+                    "firstEffect": [Circular],
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": [Circular],
+                    "memoizedProps": null,
+                    "memoizedState": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={Object {}}
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": null,
+                    "ref": null,
+                    "return": null,
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": Object {
+                      "containerInfo": <div>
+                        <div
+                          class="dashboard-card engagement"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Engagement Trends
+                          </div>
+                        </div>
+                        <div
+                          class="dashboard-card upselling"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Upselling Partners
+                          </div>
+                          <div>
+                            upselling component
+                          </div>
+                        </div>
+                      </div>,
+                      "context": Object {},
+                      "current": [Circular],
+                      "didError": false,
+                      "earliestPendingTime": 0,
+                      "earliestSuspendedTime": 0,
+                      "expirationTime": 0,
+                      "finishedWork": null,
+                      "firstBatch": null,
+                      "hydrate": false,
+                      "interactionThreadID": 15,
+                      "latestPendingTime": 0,
+                      "latestPingedTime": 0,
+                      "latestSuspendedTime": 0,
+                      "memoizedInteractions": Set {},
+                      "nextExpirationTimeToWorkOn": 0,
+                      "nextScheduledRoot": null,
+                      "pendingChildren": null,
+                      "pendingCommitExpirationTime": 0,
+                      "pendingContext": null,
+                      "pendingInteractionMap": Map {},
+                      "pingCache": null,
+                      "timeoutHandle": -1,
+                    },
+                    "tag": 3,
+                    "treeBaseDuration": 0,
+                    "type": null,
+                    "updateQueue": Object {
+                      "baseState": Object {
+                        "element": <WrapperComponent
+                          Component={[Function]}
+                          context={null}
+                          props={Object {}}
+                          wrappingComponentProps={null}
+                        />,
+                      },
+                      "firstCapturedEffect": null,
+                      "firstCapturedUpdate": null,
+                      "firstEffect": null,
+                      "firstUpdate": null,
+                      "lastCapturedEffect": null,
+                      "lastCapturedUpdate": null,
+                      "lastEffect": null,
+                      "lastUpdate": null,
+                    },
+                  },
+                  "pendingProps": Object {
+                    "Component": [Function],
+                    "context": null,
+                    "props": Object {},
+                    "wrappingComponentProps": null,
+                  },
+                  "ref": null,
+                  "return": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 60,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": null,
+                    "_debugSource": null,
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": FiberNode {
+                      "_debugHookTypes": null,
+                      "_debugID": 60,
+                      "_debugIsCurrentlyTiming": false,
+                      "_debugOwner": null,
+                      "_debugSource": null,
+                      "actualDuration": 0,
+                      "actualStartTime": -1,
+                      "alternate": [Circular],
+                      "child": null,
+                      "childExpirationTime": 0,
+                      "contextDependencies": null,
+                      "effectTag": 0,
+                      "elementType": null,
+                      "expirationTime": 1073741823,
+                      "firstEffect": null,
+                      "index": 0,
+                      "key": null,
+                      "lastEffect": null,
+                      "memoizedProps": null,
+                      "memoizedState": null,
+                      "mode": 0,
+                      "nextEffect": null,
+                      "pendingProps": null,
+                      "ref": null,
+                      "return": null,
+                      "selfBaseDuration": 0,
+                      "sibling": null,
+                      "stateNode": Object {
+                        "containerInfo": <div>
+                          <div
+                            class="dashboard-card engagement"
+                          >
+                            <div
+                              class="title"
+                            >
+                              Engagement Trends
+                            </div>
+                          </div>
+                          <div
+                            class="dashboard-card upselling"
+                          >
+                            <div
+                              class="title"
+                            >
+                              Upselling Partners
+                            </div>
+                            <div>
+                              upselling component
+                            </div>
+                          </div>
+                        </div>,
+                        "context": Object {},
+                        "current": [Circular],
+                        "didError": false,
+                        "earliestPendingTime": 0,
+                        "earliestSuspendedTime": 0,
+                        "expirationTime": 0,
+                        "finishedWork": null,
+                        "firstBatch": null,
+                        "hydrate": false,
+                        "interactionThreadID": 15,
+                        "latestPendingTime": 0,
+                        "latestPingedTime": 0,
+                        "latestSuspendedTime": 0,
+                        "memoizedInteractions": Set {},
+                        "nextExpirationTimeToWorkOn": 0,
+                        "nextScheduledRoot": null,
+                        "pendingChildren": null,
+                        "pendingCommitExpirationTime": 0,
+                        "pendingContext": null,
+                        "pendingInteractionMap": Map {},
+                        "pingCache": null,
+                        "timeoutHandle": -1,
+                      },
+                      "tag": 3,
+                      "treeBaseDuration": 0,
+                      "type": null,
+                      "updateQueue": Object {
+                        "baseState": null,
+                        "firstCapturedEffect": null,
+                        "firstCapturedUpdate": null,
+                        "firstEffect": null,
+                        "firstUpdate": Object {
+                          "callback": null,
+                          "expirationTime": 1073741823,
+                          "next": null,
+                          "nextEffect": null,
+                          "payload": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={Object {}}
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "tag": 0,
+                        },
+                        "lastCapturedEffect": null,
+                        "lastCapturedUpdate": null,
+                        "lastEffect": null,
+                        "lastUpdate": Object {
+                          "callback": null,
+                          "expirationTime": 1073741823,
+                          "next": null,
+                          "nextEffect": null,
+                          "payload": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={Object {}}
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "tag": 0,
+                        },
+                      },
+                    },
+                    "child": [Circular],
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 32,
+                    "elementType": null,
+                    "expirationTime": 0,
+                    "firstEffect": [Circular],
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": [Circular],
+                    "memoizedProps": null,
+                    "memoizedState": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={Object {}}
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": null,
+                    "ref": null,
+                    "return": null,
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": Object {
+                      "containerInfo": <div>
+                        <div
+                          class="dashboard-card engagement"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Engagement Trends
+                          </div>
+                        </div>
+                        <div
+                          class="dashboard-card upselling"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Upselling Partners
+                          </div>
+                          <div>
+                            upselling component
+                          </div>
+                        </div>
+                      </div>,
+                      "context": Object {},
+                      "current": [Circular],
+                      "didError": false,
+                      "earliestPendingTime": 0,
+                      "earliestSuspendedTime": 0,
+                      "expirationTime": 0,
+                      "finishedWork": null,
+                      "firstBatch": null,
+                      "hydrate": false,
+                      "interactionThreadID": 15,
+                      "latestPendingTime": 0,
+                      "latestPingedTime": 0,
+                      "latestSuspendedTime": 0,
+                      "memoizedInteractions": Set {},
+                      "nextExpirationTimeToWorkOn": 0,
+                      "nextScheduledRoot": null,
+                      "pendingChildren": null,
+                      "pendingCommitExpirationTime": 0,
+                      "pendingContext": null,
+                      "pendingInteractionMap": Map {},
+                      "pingCache": null,
+                      "timeoutHandle": -1,
+                    },
+                    "tag": 3,
+                    "treeBaseDuration": 0,
+                    "type": null,
+                    "updateQueue": Object {
+                      "baseState": Object {
+                        "element": <WrapperComponent
+                          Component={[Function]}
+                          context={null}
+                          props={Object {}}
+                          wrappingComponentProps={null}
+                        />,
+                      },
+                      "firstCapturedEffect": null,
+                      "firstCapturedUpdate": null,
+                      "firstEffect": null,
+                      "firstUpdate": null,
+                      "lastCapturedEffect": null,
+                      "lastCapturedUpdate": null,
+                      "lastEffect": null,
+                      "lastUpdate": null,
+                    },
+                  },
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": WrapperComponent {
+                    "_reactInternalFiber": [Circular],
+                    "_reactInternalInstance": Object {},
+                    "context": Object {},
+                    "props": Object {
+                      "Component": [Function],
+                      "context": null,
+                      "props": Object {},
+                      "wrappingComponentProps": null,
+                    },
+                    "refs": Object {},
+                    "rootFinderInstance": null,
+                    "state": Object {
+                      "context": null,
+                      "mount": true,
+                      "props": Object {},
+                      "wrappingComponentProps": null,
+                    },
+                    "updater": Object {
+                      "enqueueForceUpdate": [Function],
+                      "enqueueReplaceState": [Function],
+                      "enqueueSetState": [Function],
+                      "isMounted": [Function],
+                    },
+                  },
+                  "tag": 1,
+                  "treeBaseDuration": 0,
+                  "type": [Function],
+                  "updateQueue": null,
+                },
+                "_debugSource": null,
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": null,
+                "child": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 64,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": [Circular],
+                  "_debugSource": Object {
+                    "fileName": "/Users/kevinkoech/Documents/bp-esa-frontend/src/components/Dashboard/index.jsx",
+                    "lineNumber": 23,
+                  },
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": null,
+                  "child": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 66,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": [Circular],
+                    "_debugSource": Object {
+                      "fileName": "/Users/kevinkoech/Documents/bp-esa-frontend/src/components/Dashboard/Card.jsx",
+                      "lineNumber": 20,
+                    },
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": null,
+                    "child": FiberNode {
+                      "_debugHookTypes": null,
+                      "_debugID": 67,
+                      "_debugIsCurrentlyTiming": false,
+                      "_debugOwner": [Circular],
+                      "_debugSource": Object {
+                        "fileName": "/Users/kevinkoech/Documents/bp-esa-frontend/src/components/Dashboard/Card.jsx",
+                        "lineNumber": 21,
+                      },
+                      "actualDuration": 0,
+                      "actualStartTime": -1,
+                      "alternate": null,
+                      "child": null,
+                      "childExpirationTime": 0,
+                      "contextDependencies": null,
+                      "effectTag": 0,
+                      "elementType": "div",
+                      "expirationTime": 0,
+                      "firstEffect": null,
+                      "index": 0,
+                      "key": null,
+                      "lastEffect": null,
+                      "memoizedProps": Object {
+                        "children": "Engagement Trends",
+                        "className": "title",
+                      },
+                      "memoizedState": null,
+                      "mode": 0,
+                      "nextEffect": null,
+                      "pendingProps": Object {
+                        "children": "Engagement Trends",
+                        "className": "title",
+                      },
+                      "ref": null,
+                      "return": [Circular],
+                      "selfBaseDuration": 0,
+                      "sibling": null,
+                      "stateNode": <div
+                        class="title"
+                      >
+                        Engagement Trends
+                      </div>,
+                      "tag": 5,
+                      "treeBaseDuration": 0,
+                      "type": "div",
+                      "updateQueue": null,
+                    },
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 0,
+                    "elementType": "div",
+                    "expirationTime": 0,
+                    "firstEffect": null,
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": null,
+                    "memoizedProps": Object {
+                      "children": Array [
+                        <div
+                          className="title"
+                        >
+                          Engagement Trends
+                        </div>,
+                        undefined,
+                      ],
+                      "className": "dashboard-card engagement",
+                    },
+                    "memoizedState": null,
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": Object {
+                      "children": Array [
+                        <div
+                          className="title"
+                        >
+                          Engagement Trends
+                        </div>,
+                        undefined,
+                      ],
+                      "className": "dashboard-card engagement",
+                    },
+                    "ref": null,
+                    "return": [Circular],
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": <div
+                      class="dashboard-card engagement"
+                    >
+                      <div
+                        class="title"
+                      >
+                        Engagement Trends
+                      </div>
+                    </div>,
+                    "tag": 5,
+                    "treeBaseDuration": 0,
+                    "type": "div",
+                    "updateQueue": null,
+                  },
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 1,
+                  "elementType": [Function],
+                  "expirationTime": 0,
+                  "firstEffect": null,
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": null,
+                  "memoizedProps": Object {
+                    "classes": "engagement",
+                    "component": [Function],
+                    "title": "Engagement Trends",
+                  },
+                  "memoizedState": null,
+                  "mode": 0,
+                  "nextEffect": null,
+                  "pendingProps": Object {
+                    "classes": "engagement",
+                    "component": [Function],
+                    "title": "Engagement Trends",
+                  },
+                  "ref": null,
+                  "return": [Circular],
+                  "selfBaseDuration": 0,
+                  "sibling": [Circular],
+                  "stateNode": Card {
+                    "_reactInternalFiber": [Circular],
+                    "_reactInternalInstance": Object {},
+                    "context": Object {},
+                    "props": Object {
+                      "classes": "engagement",
+                      "component": [Function],
+                      "title": "Engagement Trends",
+                    },
+                    "refs": Object {},
+                    "state": null,
+                    "updater": Object {
+                      "enqueueForceUpdate": [Function],
+                      "enqueueReplaceState": [Function],
+                      "enqueueSetState": [Function],
+                      "isMounted": [Function],
+                    },
+                  },
+                  "tag": 1,
+                  "treeBaseDuration": 0,
+                  "type": [Function],
+                  "updateQueue": null,
+                },
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 1,
+                "elementType": [Function],
+                "expirationTime": 0,
+                "firstEffect": null,
+                "index": 0,
+                "key": null,
+                "lastEffect": null,
+                "memoizedProps": Object {},
+                "memoizedState": null,
+                "mode": 0,
+                "nextEffect": null,
+                "pendingProps": Object {},
+                "ref": null,
+                "return": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 62,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": null,
+                  "_debugSource": null,
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": null,
+                  "child": [Circular],
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 1,
+                  "elementType": [Function],
+                  "expirationTime": 0,
+                  "firstEffect": null,
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": null,
+                  "memoizedProps": Object {
+                    "Component": [Function],
+                    "context": null,
+                    "props": Object {},
+                    "wrappingComponentProps": null,
+                  },
+                  "memoizedState": Object {
+                    "context": null,
+                    "mount": true,
+                    "props": Object {},
+                    "wrappingComponentProps": null,
+                  },
+                  "mode": 0,
+                  "nextEffect": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 60,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": null,
+                    "_debugSource": null,
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": FiberNode {
+                      "_debugHookTypes": null,
+                      "_debugID": 60,
+                      "_debugIsCurrentlyTiming": false,
+                      "_debugOwner": null,
+                      "_debugSource": null,
+                      "actualDuration": 0,
+                      "actualStartTime": -1,
+                      "alternate": [Circular],
+                      "child": null,
+                      "childExpirationTime": 0,
+                      "contextDependencies": null,
+                      "effectTag": 0,
+                      "elementType": null,
+                      "expirationTime": 1073741823,
+                      "firstEffect": null,
+                      "index": 0,
+                      "key": null,
+                      "lastEffect": null,
+                      "memoizedProps": null,
+                      "memoizedState": null,
+                      "mode": 0,
+                      "nextEffect": null,
+                      "pendingProps": null,
+                      "ref": null,
+                      "return": null,
+                      "selfBaseDuration": 0,
+                      "sibling": null,
+                      "stateNode": Object {
+                        "containerInfo": <div>
+                          <div
+                            class="dashboard-card engagement"
+                          >
+                            <div
+                              class="title"
+                            >
+                              Engagement Trends
+                            </div>
+                          </div>
+                          <div
+                            class="dashboard-card upselling"
+                          >
+                            <div
+                              class="title"
+                            >
+                              Upselling Partners
+                            </div>
+                            <div>
+                              upselling component
+                            </div>
+                          </div>
+                        </div>,
+                        "context": Object {},
+                        "current": [Circular],
+                        "didError": false,
+                        "earliestPendingTime": 0,
+                        "earliestSuspendedTime": 0,
+                        "expirationTime": 0,
+                        "finishedWork": null,
+                        "firstBatch": null,
+                        "hydrate": false,
+                        "interactionThreadID": 15,
+                        "latestPendingTime": 0,
+                        "latestPingedTime": 0,
+                        "latestSuspendedTime": 0,
+                        "memoizedInteractions": Set {},
+                        "nextExpirationTimeToWorkOn": 0,
+                        "nextScheduledRoot": null,
+                        "pendingChildren": null,
+                        "pendingCommitExpirationTime": 0,
+                        "pendingContext": null,
+                        "pendingInteractionMap": Map {},
+                        "pingCache": null,
+                        "timeoutHandle": -1,
+                      },
+                      "tag": 3,
+                      "treeBaseDuration": 0,
+                      "type": null,
+                      "updateQueue": Object {
+                        "baseState": null,
+                        "firstCapturedEffect": null,
+                        "firstCapturedUpdate": null,
+                        "firstEffect": null,
+                        "firstUpdate": Object {
+                          "callback": null,
+                          "expirationTime": 1073741823,
+                          "next": null,
+                          "nextEffect": null,
+                          "payload": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={Object {}}
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "tag": 0,
+                        },
+                        "lastCapturedEffect": null,
+                        "lastCapturedUpdate": null,
+                        "lastEffect": null,
+                        "lastUpdate": Object {
+                          "callback": null,
+                          "expirationTime": 1073741823,
+                          "next": null,
+                          "nextEffect": null,
+                          "payload": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={Object {}}
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "tag": 0,
+                        },
+                      },
+                    },
+                    "child": [Circular],
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 32,
+                    "elementType": null,
+                    "expirationTime": 0,
+                    "firstEffect": [Circular],
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": [Circular],
+                    "memoizedProps": null,
+                    "memoizedState": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={Object {}}
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": null,
+                    "ref": null,
+                    "return": null,
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": Object {
+                      "containerInfo": <div>
+                        <div
+                          class="dashboard-card engagement"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Engagement Trends
+                          </div>
+                        </div>
+                        <div
+                          class="dashboard-card upselling"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Upselling Partners
+                          </div>
+                          <div>
+                            upselling component
+                          </div>
+                        </div>
+                      </div>,
+                      "context": Object {},
+                      "current": [Circular],
+                      "didError": false,
+                      "earliestPendingTime": 0,
+                      "earliestSuspendedTime": 0,
+                      "expirationTime": 0,
+                      "finishedWork": null,
+                      "firstBatch": null,
+                      "hydrate": false,
+                      "interactionThreadID": 15,
+                      "latestPendingTime": 0,
+                      "latestPingedTime": 0,
+                      "latestSuspendedTime": 0,
+                      "memoizedInteractions": Set {},
+                      "nextExpirationTimeToWorkOn": 0,
+                      "nextScheduledRoot": null,
+                      "pendingChildren": null,
+                      "pendingCommitExpirationTime": 0,
+                      "pendingContext": null,
+                      "pendingInteractionMap": Map {},
+                      "pingCache": null,
+                      "timeoutHandle": -1,
+                    },
+                    "tag": 3,
+                    "treeBaseDuration": 0,
+                    "type": null,
+                    "updateQueue": Object {
+                      "baseState": Object {
+                        "element": <WrapperComponent
+                          Component={[Function]}
+                          context={null}
+                          props={Object {}}
+                          wrappingComponentProps={null}
+                        />,
+                      },
+                      "firstCapturedEffect": null,
+                      "firstCapturedUpdate": null,
+                      "firstEffect": null,
+                      "firstUpdate": null,
+                      "lastCapturedEffect": null,
+                      "lastCapturedUpdate": null,
+                      "lastEffect": null,
+                      "lastUpdate": null,
+                    },
+                  },
+                  "pendingProps": Object {
+                    "Component": [Function],
+                    "context": null,
+                    "props": Object {},
+                    "wrappingComponentProps": null,
+                  },
+                  "ref": null,
+                  "return": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 60,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": null,
+                    "_debugSource": null,
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": FiberNode {
+                      "_debugHookTypes": null,
+                      "_debugID": 60,
+                      "_debugIsCurrentlyTiming": false,
+                      "_debugOwner": null,
+                      "_debugSource": null,
+                      "actualDuration": 0,
+                      "actualStartTime": -1,
+                      "alternate": [Circular],
+                      "child": null,
+                      "childExpirationTime": 0,
+                      "contextDependencies": null,
+                      "effectTag": 0,
+                      "elementType": null,
+                      "expirationTime": 1073741823,
+                      "firstEffect": null,
+                      "index": 0,
+                      "key": null,
+                      "lastEffect": null,
+                      "memoizedProps": null,
+                      "memoizedState": null,
+                      "mode": 0,
+                      "nextEffect": null,
+                      "pendingProps": null,
+                      "ref": null,
+                      "return": null,
+                      "selfBaseDuration": 0,
+                      "sibling": null,
+                      "stateNode": Object {
+                        "containerInfo": <div>
+                          <div
+                            class="dashboard-card engagement"
+                          >
+                            <div
+                              class="title"
+                            >
+                              Engagement Trends
+                            </div>
+                          </div>
+                          <div
+                            class="dashboard-card upselling"
+                          >
+                            <div
+                              class="title"
+                            >
+                              Upselling Partners
+                            </div>
+                            <div>
+                              upselling component
+                            </div>
+                          </div>
+                        </div>,
+                        "context": Object {},
+                        "current": [Circular],
+                        "didError": false,
+                        "earliestPendingTime": 0,
+                        "earliestSuspendedTime": 0,
+                        "expirationTime": 0,
+                        "finishedWork": null,
+                        "firstBatch": null,
+                        "hydrate": false,
+                        "interactionThreadID": 15,
+                        "latestPendingTime": 0,
+                        "latestPingedTime": 0,
+                        "latestSuspendedTime": 0,
+                        "memoizedInteractions": Set {},
+                        "nextExpirationTimeToWorkOn": 0,
+                        "nextScheduledRoot": null,
+                        "pendingChildren": null,
+                        "pendingCommitExpirationTime": 0,
+                        "pendingContext": null,
+                        "pendingInteractionMap": Map {},
+                        "pingCache": null,
+                        "timeoutHandle": -1,
+                      },
+                      "tag": 3,
+                      "treeBaseDuration": 0,
+                      "type": null,
+                      "updateQueue": Object {
+                        "baseState": null,
+                        "firstCapturedEffect": null,
+                        "firstCapturedUpdate": null,
+                        "firstEffect": null,
+                        "firstUpdate": Object {
+                          "callback": null,
+                          "expirationTime": 1073741823,
+                          "next": null,
+                          "nextEffect": null,
+                          "payload": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={Object {}}
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "tag": 0,
+                        },
+                        "lastCapturedEffect": null,
+                        "lastCapturedUpdate": null,
+                        "lastEffect": null,
+                        "lastUpdate": Object {
+                          "callback": null,
+                          "expirationTime": 1073741823,
+                          "next": null,
+                          "nextEffect": null,
+                          "payload": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={Object {}}
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "tag": 0,
+                        },
+                      },
+                    },
+                    "child": [Circular],
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 32,
+                    "elementType": null,
+                    "expirationTime": 0,
+                    "firstEffect": [Circular],
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": [Circular],
+                    "memoizedProps": null,
+                    "memoizedState": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={Object {}}
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": null,
+                    "ref": null,
+                    "return": null,
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": Object {
+                      "containerInfo": <div>
+                        <div
+                          class="dashboard-card engagement"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Engagement Trends
+                          </div>
+                        </div>
+                        <div
+                          class="dashboard-card upselling"
+                        >
+                          <div
+                            class="title"
+                          >
+                            Upselling Partners
+                          </div>
+                          <div>
+                            upselling component
+                          </div>
+                        </div>
+                      </div>,
+                      "context": Object {},
+                      "current": [Circular],
+                      "didError": false,
+                      "earliestPendingTime": 0,
+                      "earliestSuspendedTime": 0,
+                      "expirationTime": 0,
+                      "finishedWork": null,
+                      "firstBatch": null,
+                      "hydrate": false,
+                      "interactionThreadID": 15,
+                      "latestPendingTime": 0,
+                      "latestPingedTime": 0,
+                      "latestSuspendedTime": 0,
+                      "memoizedInteractions": Set {},
+                      "nextExpirationTimeToWorkOn": 0,
+                      "nextScheduledRoot": null,
+                      "pendingChildren": null,
+                      "pendingCommitExpirationTime": 0,
+                      "pendingContext": null,
+                      "pendingInteractionMap": Map {},
+                      "pingCache": null,
+                      "timeoutHandle": -1,
+                    },
+                    "tag": 3,
+                    "treeBaseDuration": 0,
+                    "type": null,
+                    "updateQueue": Object {
+                      "baseState": Object {
+                        "element": <WrapperComponent
+                          Component={[Function]}
+                          context={null}
+                          props={Object {}}
+                          wrappingComponentProps={null}
+                        />,
+                      },
+                      "firstCapturedEffect": null,
+                      "firstCapturedUpdate": null,
+                      "firstEffect": null,
+                      "firstUpdate": null,
+                      "lastCapturedEffect": null,
+                      "lastCapturedUpdate": null,
+                      "lastEffect": null,
+                      "lastUpdate": null,
+                    },
+                  },
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": WrapperComponent {
+                    "_reactInternalFiber": [Circular],
+                    "_reactInternalInstance": Object {},
+                    "context": Object {},
+                    "props": Object {
+                      "Component": [Function],
+                      "context": null,
+                      "props": Object {},
+                      "wrappingComponentProps": null,
+                    },
+                    "refs": Object {},
+                    "rootFinderInstance": null,
+                    "state": Object {
+                      "context": null,
+                      "mount": true,
+                      "props": Object {},
+                      "wrappingComponentProps": null,
+                    },
+                    "updater": Object {
+                      "enqueueForceUpdate": [Function],
+                      "enqueueReplaceState": [Function],
+                      "enqueueSetState": [Function],
+                      "isMounted": [Function],
+                    },
+                  },
+                  "tag": 1,
+                  "treeBaseDuration": 0,
+                  "type": [Function],
+                  "updateQueue": null,
+                },
+                "selfBaseDuration": 0,
+                "sibling": null,
+                "stateNode": Dashboard {
+                  "_reactInternalFiber": [Circular],
+                  "_reactInternalInstance": Object {},
+                  "context": Object {},
+                  "props": Object {},
+                  "refs": Object {},
+                  "renderUpselling": [Function],
+                  "state": null,
+                  "updater": Object {
+                    "enqueueForceUpdate": [Function],
+                    "enqueueReplaceState": [Function],
+                    "enqueueSetState": [Function],
+                    "isMounted": [Function],
+                  },
+                },
+                "tag": 1,
+                "treeBaseDuration": 0,
+                "type": [Function],
+                "updateQueue": null,
+              },
+              "selfBaseDuration": 0,
+              "sibling": null,
+              "stateNode": [Circular],
+              "tag": 1,
+              "treeBaseDuration": 0,
+              "type": [Function],
+              "updateQueue": null,
+            },
+            "_reactInternalInstance": Object {},
+            "context": Object {},
+            "props": Object {
+              "classes": "upselling",
+              "component": [Function],
+              "title": "Upselling Partners",
+            },
+            "refs": Object {},
+            "state": null,
+            "updater": Object {
+              "enqueueForceUpdate": [Function],
+              "enqueueReplaceState": [Function],
+              "enqueueSetState": [Function],
+              "isMounted": [Function],
+            },
+          },
+          "key": undefined,
+          "nodeType": "class",
+          "props": Object {
+            "classes": "upselling",
+            "component": [Function],
+            "title": "Upselling Partners",
+          },
+          "ref": null,
+          "rendered": Object {
+            "instance": <div
+              class="dashboard-card upselling"
+            >
+              <div
+                class="title"
+              >
+                Upselling Partners
+              </div>
+              <div>
+                upselling component
+              </div>
+            </div>,
+            "key": undefined,
+            "nodeType": "host",
+            "props": Object {
+              "children": Array [
+                <div
+                  className="title"
+                >
+                  Upselling Partners
+                </div>,
+                <div>
+                  upselling component
+                </div>,
+              ],
+              "className": "dashboard-card upselling",
+            },
+            "ref": null,
+            "rendered": Array [
+              Object {
+                "instance": <div
+                  class="title"
+                >
+                  Upselling Partners
+                </div>,
+                "key": undefined,
+                "nodeType": "host",
+                "props": Object {
+                  "children": "Upselling Partners",
+                  "className": "title",
+                },
+                "ref": null,
+                "rendered": Array [
+                  "Upselling Partners",
+                ],
+                "type": "div",
+              },
+              Object {
+                "instance": <div>
+                  upselling component
+                </div>,
+                "key": undefined,
+                "nodeType": "host",
+                "props": Object {
+                  "children": "upselling component",
+                },
+                "ref": null,
+                "rendered": Array [
+                  "upselling component",
+                ],
+                "type": "div",
+              },
+            ],
+            "type": "div",
+          },
+          "type": [Function],
+        },
+      ],
+      "type": [Function],
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+        "legacyContextMode": "parent",
+        "lifecycles": Object {
+          "componentDidUpdate": Object {
+            "onSetState": true,
+          },
+          "getChildContext": Object {
+            "calledByRenderer": false,
+          },
+          "getDerivedStateFromError": true,
+          "getDerivedStateFromProps": Object {
+            "hasShouldComponentUpdateBug": false,
+          },
+          "getSnapshotBeforeUpdate": true,
+          "setState": Object {
+            "skipsComponentDidUpdateOnNullish": true,
+          },
+        },
+      },
+    },
+  },
+}
+`;

--- a/src/__tests__/components/Dashboard/index.test.js
+++ b/src/__tests__/components/Dashboard/index.test.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import Dashboard from '../../../components/Dashboard';
+
+describe('test dashboard', () => {
+  it('renders a card', () => {
+    // eslint-disable-next-line react/jsx-filename-extension
+    const wrapper = mount(<Dashboard />);
+    expect(wrapper).toMatchSnapshot();
+    wrapper.unmount();
+  });
+});

--- a/src/__tests__/components/developerCard/developerCard.test.js
+++ b/src/__tests__/components/developerCard/developerCard.test.js
@@ -14,7 +14,6 @@ const props = {
     partnerName: "Hammes, O'Keefe and Hilll",
     slackAutomations: { status: 'failure', slackActivities: [7] },
   }],
-  isLoading: false,
   retryingAutomation: false,
   handleRetryAutomation: jest.fn(),
 };
@@ -23,6 +22,7 @@ describe('rendering', () => {
   let wrapper;
 
   beforeEach(() => {
+    // eslint-disable-next-line react/jsx-filename-extension
     wrapper = mount(<DeveloperCardComponent {...props} />);
   });
 

--- a/src/components/Dashboard/Card.jsx
+++ b/src/components/Dashboard/Card.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+class Card extends React.Component {
+  static propTypes = {
+    classes: PropTypes.string.isRequired,
+    title: PropTypes.string,
+    component: PropTypes.func.isRequired,
+  };
+
+  static defaultProps = {
+    title: '',
+  };
+
+  render() {
+    const {
+      classes, title, component,
+    } = this.props;
+    return (
+      <div className={`dashboard-card ${classes}`}>
+        <div className="title">
+          {title}
+        </div>
+        {
+          component()
+        }
+      </div>
+    );
+  }
+}
+
+export default Card;

--- a/src/components/Dashboard/dashboard.scss
+++ b/src/components/Dashboard/dashboard.scss
@@ -1,0 +1,14 @@
+.dashboard-card {
+  background-color: white;
+  padding: 16px;
+  overflow: auto;
+}
+.title {
+  color: #667;
+  font-family: DinPro;
+  font-weight: normal;
+  text-align: left;
+  line-height: 24px;
+  letter-spacing: -0.11px;
+  font-size: 20px;
+}

--- a/src/components/Dashboard/index.jsx
+++ b/src/components/Dashboard/index.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import './dashboard.scss';
+import Card from './Card';
+
+class Dashboard extends React.Component {
+  /*
+  Use case Example for dashboard card
+  component is a function that returns a component
+  Suppose you are working on Upselling Partners task
+  and you have created a class component named Upselling.
+  You will create a function renderUpselling that returns
+  your Upselling jsx component and pass it as props.
+   */
+  renderUpselling = () => (
+    <div>
+        upselling component
+    </div>
+  );
+
+  render() {
+    return (
+      <>
+        <Card
+          classes="engagement"
+          title="Engagement Trends"
+          component={() => {}}
+        />
+        <Card
+          classes="upselling"
+          title="Upselling Partners"
+          component={this.renderUpselling}
+        />
+      </>
+    );
+  }
+}
+
+export default Dashboard;

--- a/src/components/Header/styles.scss
+++ b/src/components/Header/styles.scss
@@ -147,7 +147,7 @@
         &.visible {
           z-index: 10;
         }
-        
+
         .signout-dropdown {
           font-size: 0.7em;
           position: absolute;

--- a/src/index.css
+++ b/src/index.css
@@ -130,3 +130,6 @@ table .report_table, th, td {
     font-family: 'DIN Pro', sans-serif;
     box-sizing: border-box;
 }
+body {
+    background-color: #fafafa;
+}


### PR DESCRIPTION
#### What does this PR do?
 - Adds a card that houses other components
#### Description of Task to be completed?
- Creates a Card component that accepts children and accepts height, title and width props
- gives a padding of 16px to the card as per the mock ups
#### How should this be manually tested?
On your code use the Card component as shown below.
```
import React from 'react';
import './dashboard.scss';
import Card from './DashboardCard';

class Dashboard extends React.Component {
  /*
  Use case Example for dashboard card
  component is a function that returns a component
  Suppose you are working on Upselling Partners task
  and you have created a class component named Upselling.
  You will create a function renderUpselling that returns
  your Upselling jsx component and pass it as props.
   */
  renderUpselling = () => (
    <div>
        upselling component
    </div>
  );

  render() {
    return (
      <>
        <Card
          classes="engagement"
          title="Engagement Trends"
          component={() => {}}
        />
        <Card
          classes="upselling"
          title="Upselling Partners"
          component={this.renderUpselling}
        />
      </>
    );
  }
}

export default Dashboard;
```
 The above code would generate  a card of width 1060px and height 40vh with the title Engagement Trends. The contents of the card can be passed as children
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
[#165879813](https://www.pivotaltracker.com/story/show/165879813)

#### Postman Documentation
- N/A
#### Screenshots (If applicable)
N/A
