### PR TITLE
#167101210: Fix developer card component

### DIFF
--- a/cypress/integration/automationCard_spec.js
+++ b/cypress/integration/automationCard_spec.js
@@ -81,6 +81,12 @@ describe('Automation Card', () => {
     // .contains('0/0');
   });
 
+  it('should contain more than one DeveloperCard component', () => {
+    cy.getReactComponent('DeveloperCard').should(($developerCard) => {
+      expect($developerCard.length).to.be.greaterThan(3);
+    });
+  });
+
   it('should ensure that the retry automations button works', () => {
     cy.get(':nth-child(1) > .status-band > #failure > .retry-btn')
       .click()

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,6 +1,9 @@
+import cypressGetReactComponent from 'cypress-get-react-component';
 /* eslint-disable no-undef */
 const userState = Cypress.env('state');
 const apiUrl = Cypress.env('apiUrl');
+
+cypressGetReactComponent.install();
 
 Cypress.Commands.add('authenticateUser', (state = userState) => {
   window.localStorage.setItem('state', JSON.stringify(state));

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "classnames": "^2.2.6",
     "css-loader": "0.28.7",
     "cypress": "^3.3.1",
+    "cypress-get-react-component": "^1.0.0-dev4",
     "d3": "^5.0.0",
     "dotenv": "4.0.0",
     "enzyme": "^3.3.0",

--- a/src/__tests__/components/ReportPage.test.jsx
+++ b/src/__tests__/components/ReportPage.test.jsx
@@ -62,6 +62,11 @@ describe('ReportPage Component', () => {
     expect(title.text()).toEqual('ESA');
   });
 
+  it('should render as two difference developerCard components', () => {
+    const card = component.find('DeveloperCard');
+    expect(card.length).toEqual(2);
+  });
+
   it('should redirect to the AIS page when you click the engineer\'s name', () => {
     component.setState({ viewMode: 'listView' });
     const redirectToAIS = component.find('.table-body')
@@ -131,7 +136,7 @@ describe('ReportPage Component', () => {
       wrapper = mount(<ReportPage {...props} />);
       const instance = wrapper.instance();
       jest.spyOn(instance, 'handleRetryAutomation');
-      const button = wrapper.find('#retry-automation');
+      const button = wrapper.find('#retry-automation').at(0);
       button.simulate('click');
       // eslint-disable-next-line no-unused-expressions
       expect(instance.handleRetryAutomation).toBeCalled;

--- a/src/__tests__/components/developerCard/developerCard.test.js
+++ b/src/__tests__/components/developerCard/developerCard.test.js
@@ -7,7 +7,7 @@ const props = {
   isLoading: false,
   openModal: jest.fn(),
   changeModalTypes: jest.fn(),
-  data: [{
+  card: {
     id: '10516',
     emailAutomations: { emailActivities: [13] },
     fellowName: 'Reyes, Kozey',
@@ -33,7 +33,7 @@ const props = {
           channelName: null,
         }],
     },
-  }],
+  },
   retryingAutomation: false,
   handleRetryAutomation: jest.fn(),
 };
@@ -51,7 +51,7 @@ describe('rendering', () => {
   });
 
   it('should render DeveloperCard correctly', () => {
-    const cardContainer = wrapper.find('.cont');
+    const cardContainer = wrapper.find('.card');
     expect(cardContainer.length).toEqual(1);
   });
 

--- a/src/components/AutomationDetails/index.jsx
+++ b/src/components/AutomationDetails/index.jsx
@@ -166,7 +166,7 @@ class AutomationDetails extends Component {
     const automations = modalContent[automationType];
     const appActivities = (automations && automations[automationActivities]) || [];
     return appActivities.map(content => (
-      <div key={content.slackUserId}>
+      <div key={content.id}>
         <div className="automation-content">
           <div className="content-row name">{content[contentData]}</div>
           <div className="content-row type">{content[contentType]}</div>

--- a/src/components/ReportPage/index.jsx
+++ b/src/components/ReportPage/index.jsx
@@ -307,6 +307,32 @@ export class ReportPage extends Component {
     );
   }
 
+  renderDeveloperCard = (
+    data,
+    isLoading,
+    toggleModal,
+    changeModalTypes,
+    retryingAutomation,
+    handleRetryAutomation,
+  ) => {
+    const dataDetails = data.map(cardData => (
+      <DeveloperCard
+        key={cardData.id}
+        card={cardData}
+        isLoading={isLoading}
+        openModal={this.toggleModal}
+        changeModalTypes={changeModalTypes}
+        retryingAutomation={retryingAutomation}
+        handleRetryAutomation={handleRetryAutomation}
+      />
+    ));
+    return (
+      <div className="cont">
+        {dataDetails}
+      </div>
+    );
+  }
+
   renderListCard = () => {
     const { viewMode, isModalOpen, modalContent } = this.state;
     const { automation: { data, isLoading, retryingAutomation } } = this.props;
@@ -353,14 +379,15 @@ export class ReportPage extends Component {
         : (
           <div>
             {this.renderUpdateTab()}
-            <DeveloperCard
-              data={data}
-              isLoading={isLoading}
-              openModal={this.toggleModal}
-              changeModalTypes={this.changeModalTypes}
-              retryingAutomation={retryingAutomation}
-              handleRetryAutomation={this.handleRetryAutomation}
-            />
+            {this.renderDeveloperCard(
+              data,
+              isLoading,
+              this.toggleModal,
+              this.changeModalTypes,
+              retryingAutomation,
+              this.handleRetryAutomation,
+            )}
+
             <AutomationDetails
               data={data}
               isModalOpen={isModalOpen}

--- a/src/components/developerCards/index.jsx
+++ b/src/components/developerCards/index.jsx
@@ -19,7 +19,7 @@ class DeveloperCard extends Component {
   );
 
   renderStatusBand = (className, status, cardId) => {
-    const { retryingAutomation, handleRetryAutomation, data } = this.props;
+    const { retryingAutomation, handleRetryAutomation } = this.props;
     return (
       <div className={className}>
         <span id={`${status.toLowerCase()}`}>
@@ -30,7 +30,6 @@ class DeveloperCard extends Component {
               <RetryButton
                 retryingAutomation={retryingAutomation}
                 handleRetryAutomation={() => handleRetryAutomation(cardId)}
-                data={data}
                 id="retry-automation"
               />
             )
@@ -71,7 +70,7 @@ class DeveloperCard extends Component {
   );
 
   renderCards = () => {
-    const { data, openModal, changeModalTypes } = this.props;
+    const { card, openModal, changeModalTypes } = this.props;
     const automation = length => length !== 0;
     const automationMetric = (activities, status) => (
       _.filter(activities, { status }).length
@@ -79,59 +78,53 @@ class DeveloperCard extends Component {
     const metric = (activities, status) => (
       automation(activities.length) ? automationMetric(activities, status) : 0
     );
-    return data.map((card, index) => {
-      const name = card.fellowName;
-      const newName = _.split(name, ',');
-      const firstInitials = newName[0].charAt(0);
-      const secondInitials = newName[1] && newName[1].charAt(1);
-      return (
-        <div className="card" key={card.id}>
-          <div className="info-cont">
-            {card.type === 'onboarding'
-              ? (
-                <div className="tooltip-container" id="onboarding-info-icon">
-                  <img className="info-icon onBoarding-icon" src={onboarding} alt="onboarding icon" />
-                  <span className="tooltiptext">On-boarding</span>
-                </div>
-              ) : (
-                <div className="tooltip-container" id="offboarding-info-icon">
-                  <img className="info-icon onBoarding-icon" src={offboarding} alt="offboarding icon" />
-                  <span className="tooltiptext">Off-boarding</span>
-                </div>
-              )}
-            <div id="more-info-icon" className="tooltip-container" onClick={() => { openModal(); changeModalTypes(card); }}>
-              <img className="info-icon" src={InfoIcon} alt="info icon" role="presentation" id={`${index}-id`} />
-              <span className="tooltiptext">Details</span>
-            </div>
+    const name = card.fellowName;
+    const newName = _.split(name, ',');
+    const firstInitials = newName[0].charAt(0);
+    const secondInitials = newName[1].charAt(1);
+    return (
+      <div className="card" key={card.id}>
+        <div className="info-cont">
+          {card.type === 'onboarding'
+            ? (
+              <div className="tooltip-container" id="onboarding-info-icon">
+                <img className="info-icon onBoarding-icon" src={onboarding} alt="onboarding icon" />
+                <span className="tooltiptext">On-boarding</span>
+              </div>
+            ) : (
+              <div className="tooltip-container" id="offboarding-info-icon">
+                <img className="info-icon onBoarding-icon" src={offboarding} alt="offboarding icon" />
+                <span className="tooltiptext">Off-boarding</span>
+              </div>
+            )}
+          <div id="more-info-icon" className="tooltip-container" onClick={() => { openModal(); changeModalTypes(card); }}>
+            <img className="info-icon" src={InfoIcon} alt="info icon" role="presentation" id={`${card.id}-id`} />
+            <span className="tooltiptext">Details</span>
           </div>
-          {this.renderDeveloperPic(firstInitials, secondInitials)}
-          <div className="clickableCardContent tooltip-container" id="fellow-name" onClick={() => window.open(`https://ais.andela.com/people/${card.fellowId}`)}>
-            {this.renderDetails('developerDetails', 'developerName', card.fellowName)}
-            <span className="tooltip-icon">
-              <i className="fas fa-external-link-alt" />
-            </span>
-          </div>
-          {this.renderDetails('partnerName', '', card.partnerName)}
-          {this.renderDetails('developerDetails', 'date', moment(card.updatedAt).format('MM/DD/YYYY, h:mm a'))}
-          {this.renderStatusBand('status-band', card.nokoAutomations.status.toUpperCase(), card.id)}
-          {this.renderActivity(['slack', 'email', 'noko'], metric, card)}
         </div>
-      );
-    });
+        {this.renderDeveloperPic(firstInitials, secondInitials)}
+        <div className="clickableCardContent tooltip-container" id="fellow-name" onClick={() => window.open(`https://ais.andela.com/people/${card.fellowId}`)}>
+          {this.renderDetails('developerDetails', 'developerName', card.fellowName)}
+          <span className="tooltip-icon">
+            <i className="fas fa-external-link-alt" />
+          </span>
+        </div>
+        {this.renderDetails('partnerName', '', card.partnerName)}
+        {this.renderDetails('developerDetails', 'date', moment(card.updatedAt).format('MM/DD/YYYY, h:mm a'))}
+        {this.renderStatusBand('status-band', card.nokoAutomations.status.toUpperCase(), card.id)}
+        {this.renderActivity(['slack', 'email', 'noko'], metric, card)}
+      </div>
+    );
   };
 
   render() {
     const { isLoading } = this.props;
-    return (
-      <div className="cont">
-        {isLoading ? <Spinner /> : this.renderCards()}
-      </div>
-    );
+    return (isLoading ? <Spinner /> : this.renderCards());
   }
 }
 
 DeveloperCard.propTypes = {
-  data: PropTypes.array.isRequired,
+  card: PropTypes.object.isRequired,
   openModal: PropTypes.func.isRequired,
   changeModalTypes: PropTypes.func.isRequired,
   isLoading: PropTypes.bool,

--- a/src/fixtures/fixtures.js
+++ b/src/fixtures/fixtures.js
@@ -9,9 +9,9 @@ const sampleReports = {
         status: 'failure',
         slackActivities: [14],
       },
-     nokoAutomations: {
+      nokoAutomations: {
         status: 'failure',
-       nokoActivities: [{
+        nokoActivities: [{
           projectId: 34,
           type: 'projectCreation',
           status: 'failure',
@@ -22,6 +22,63 @@ const sampleReports = {
         emailActivities: [10],
       },
       updatedAt: '2017-09-29 ',
+    },
+    {
+      id: 8631,
+      fellowId: '07a88f54-d195-4431-bb14-5b287826188f',
+      email: 'uchesuber@gmail.com',
+      fellowName: 'Alta, Willms',
+      partnerId: '-KXGyJcC1oimjQgFj18Q',
+      partnerName: 'Accounteer',
+      type: 'offboarding',
+      createdAt: '2019-07-15T09:03:18.558Z',
+      updatedAt: '2019-07-15T09:03:18.558Z',
+      slackAutomations: {
+        status: 'success',
+        slackActivities: [
+          {
+            id: 21294,
+            status: 'success',
+            statusMessage: 'uchesuber@gmail.com kicked from channel',
+            type: 'kick',
+            channelId: 'GKQHNTD0C',
+            channelName: 'client-accounteer',
+            slackUserId: 'UJD3ALBK6',
+          },
+          {
+            id: 21293,
+            status: 'success',
+            statusMessage: 'uchesuber@gmail.com invited to channel',
+            type: 'invite',
+            channelId: 'CJFG3JWCX',
+            channelName: 'available-developers',
+            slackUserId: 'UJD3ALBK6',
+          },
+        ],
+      },
+      emailAutomations: {
+        status: 'success',
+        emailActivities: [
+          {
+            id: 10435,
+            status: 'success',
+            statusMessage: 'Email sent succesfully',
+            recipient: 'example@andela.com',
+            subject: 'Alta, Willms Placed with Accounteer',
+          },
+          {
+            id: 10436,
+            status: 'success',
+            statusMessage: 'Email sent succesfully',
+            recipient: 'example@andela.com',
+            subject: 'Alta, Willms Engagement Roll Off (Lake Micah)',
+          },
+        ],
+      },
+      nokoAutomations: {
+        status: 'failure',
+        nokoActivities: [],
+      },
     },
   ],
   pagination: {
@@ -47,7 +104,7 @@ const stats = {
       success: 1,
       total: 191,
     },
-   noko: {
+    noko: {
       success: 1,
       total: 191,
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3298,6 +3298,13 @@ cyclist@~0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-0.2.2.tgz#1b33792e11e914a2fd6d6ed6447464444e5fa640"
 
+
+cypress-get-react-component@^1.0.0-dev4:
+  version "1.0.0-dev4"
+  resolved "https://registry.yarnpkg.com/cypress-get-react-component/-/cypress-get-react-component-1.0.0-dev4.tgz#64cd6c0af1c880bebfce714479f064be8df54109"
+  integrity sha512-+26irD2NTUbNNsLaCVehH7T9wkUDGI5yoAC1ZNuWvsJZn/odXW2BAJl7aXhAN0JawEbPCzEOaaUMjmFMJfZ6PQ==
+
+
 cypress@^3.3.1:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/cypress/-/cypress-3.4.0.tgz#8053ee107eb6309f26abd57e882d05578bdc3391"


### PR DESCRIPTION
#### What does this PR do?
This PR fixes the `developerCard` Component

#### Description of Task to be completed?
#####  Current behaviour
- There is only one developer-card component ever in the cards view, which then renders each automation as a div within itself.
- After viewing the details of automation, subsequent automation details get mixed up with previously viewed automation details
##### Expected
- Each (visual) card should be a developer-card component
- The details in the modal should match the details of the automation being viewed
#### How should this be manually tested?
##### First 
- Run `yarn` in the frontend to install new dependencies
- Log in to the application and click on the card view
- Inspect and go to react developer tools
- Search for `DeveloperCard` component and you will realize that there are individual `developerCard` components for each card.
##### second
- Click on info icon for different cards and you will realize that details in the modal match the details of the automation being viewed.
#### Any background context you want to provide?
- The PR works with this [backend PR](https://github.com/andela/bp-esa-backend/pull/118)

#### What are the relevant pivotal tracker stories?
[167101210](https://www.pivotaltracker.com/story/show/167101210)
#### Postman Documentation
- N/A

#### Screenshots (If applicable)
<img width="1440" alt="Screen Shot 2019-07-16 at 12 11 26" src="https://user-images.githubusercontent.com/29975767/61281788-e640a100-a7c2-11e9-97b7-b1290b0294ba.png">
