### PR TITLE
#167294631: Add email recipient

### DIFF
--- a/cypress/integration/automationCard_spec.js
+++ b/cypress/integration/automationCard_spec.js
@@ -99,6 +99,10 @@ describe('Automation Card', () => {
       .get('.toast')
       .should('be.visible')
       .contains('Successfully fetched individual automation')
+      .get('.channels-tab-background > #email')
+      .click()
+      .get(':nth-child(1) > .automation-content > .name')
+      .should('be.visible')
       .wait(2000)
       .get('.close')
       .click();

--- a/src/__tests__/components/AutomationDetails.test.jsx
+++ b/src/__tests__/components/AutomationDetails.test.jsx
@@ -191,4 +191,42 @@ describe('Automation details', () => {
     component.find('#email').simulate('click');
     expect(component.instance().state.modalType).toEqual('email');
   });
+
+  it('should render email details with activities including the recipient', () => {
+    const prop = {
+      formatDates: jest.fn(),
+      isModalOpen: false,
+      closeModal: jest.fn(),
+      modalContent: {
+        id: 1,
+        fellowName: 'Tunmise, Tunmise',
+        partnerName: 'Andela',
+        type: 'Onboarding',
+        slackAutomations: {
+          status: 'success',
+        },
+        nokoAutomations: {
+          status: 'failure',
+        },
+        emailAutomations: {
+          status: 'success',
+          emailActivities: [{
+            id: 1,
+            recipient: 'Tunmise.ogunniyi@andela.com',
+            subject: 'Onboarding',
+            status: 'success',
+          },
+          ],
+        },
+        date: '2017-09-29 01:22',
+      },
+    };
+    const component = mount(<AutomationDetails {...prop} />);
+    component.setState({
+      updatedModalContext: component.props().modalContent,
+    });
+    component.find('#email').simulate('click');
+    const recipient = component.find('.automation-content .content-row').at(0);
+    expect(recipient.text()).toEqual('Tunmise.ogunniyi@andela.com');
+  });
 });

--- a/src/components/AutomationDetails/index.jsx
+++ b/src/components/AutomationDetails/index.jsx
@@ -142,7 +142,7 @@ class AutomationDetails extends Component {
           modalContent,
           'emailAutomations',
           'emailActivities',
-          'emailTo',
+          'recipient',
           'subject',
         )}
       {modalType === 'noko'


### PR DESCRIPTION
#### What does this PR do?
It ensures that the email recipient is displayed for a specific automation 

#### Description of Task to be completed?
##### Current Behavior
The email recipient field in the details modal is blank when viewing the details of an automation

##### Expected Behavior
The email recipient field should display the email address for that automation step/action


#### How should this be manually tested?
* clone the backend repo and the frontend repo
* Login to the front end
* Open the details modal of the automation and switch to the Email tab
* You will see the email recipient displayed

#### Any background context you want to provide?

- N/A
#### What are the relevant pivotal tracker stories?
[167294631](https://www.pivotaltracker.com/story/show/167294631)

#### Postman Documentation


#### Screenshots (If applicable)
<img width="554" alt="Screen Shot 2019-07-25 at 11 35 26" src="https://user-images.githubusercontent.com/29975767/61859200-5b515c00-aed0-11e9-84e2-a147ba44d6ee.png">
