### PR TITLE
167486117-Make the app dashboard mobile responsive.

### DIFF
--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -99,7 +99,6 @@ describe.only('checkAuthorization() method', () => {
       value: 'jwt-token=wrongToken',
     });
     sinon.spy(renderedComponent, 'setCurrentUser');
-    renderedComponent.checkAuthorization();
     expect(renderedComponent.setCurrentUser.calledOnce).toEqual(false);
   });
 });
@@ -116,7 +115,7 @@ describe('decodeToken() method', () => {
   });
 });
 
-describe.only('Authenticate route', () => {
+describe('Authenticate route', () => {
   it('should run the authenticated route component', () => {
     const authenticateRouteWrapper = mount(
       <BrowserRouter>

--- a/src/__snapshots__/App.test.jsx.snap
+++ b/src/__snapshots__/App.test.jsx.snap
@@ -1,0 +1,18793 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Authenticate route should run the authenticated route component 1`] = `
+ReactWrapper {
+  Symbol(enzyme.__unrendered__): <BrowserRouter>
+    <AuthenticatedRoute
+      authenticated={true}
+      component={[Function]}
+      path="/dashboard"
+    />
+  </BrowserRouter>,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "getNode": [Function],
+    "getWrappingComponentRenderer": [Function],
+    "render": [Function],
+    "simulateError": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__node__): Object {
+    "instance": BrowserRouter {
+      "_reactInternalFiber": FiberNode {
+        "_debugHookTypes": null,
+        "_debugID": 63,
+        "_debugIsCurrentlyTiming": false,
+        "_debugOwner": FiberNode {
+          "_debugHookTypes": null,
+          "_debugID": 62,
+          "_debugIsCurrentlyTiming": false,
+          "_debugOwner": null,
+          "_debugSource": null,
+          "actualDuration": 0,
+          "actualStartTime": -1,
+          "alternate": null,
+          "child": [Circular],
+          "childExpirationTime": 0,
+          "contextDependencies": null,
+          "effectTag": 1,
+          "elementType": [Function],
+          "expirationTime": 0,
+          "firstEffect": null,
+          "index": 0,
+          "key": null,
+          "lastEffect": null,
+          "memoizedProps": Object {
+            "Component": [Function],
+            "context": null,
+            "props": Object {
+              "children": <AuthenticatedRoute
+                authenticated={true}
+                component={[Function]}
+                path="/dashboard"
+              />,
+            },
+            "wrappingComponentProps": null,
+          },
+          "memoizedState": Object {
+            "context": null,
+            "mount": true,
+            "props": Object {
+              "children": <AuthenticatedRoute
+                authenticated={true}
+                component={[Function]}
+                path="/dashboard"
+              />,
+            },
+            "wrappingComponentProps": null,
+          },
+          "mode": 0,
+          "nextEffect": FiberNode {
+            "_debugHookTypes": null,
+            "_debugID": 60,
+            "_debugIsCurrentlyTiming": false,
+            "_debugOwner": null,
+            "_debugSource": null,
+            "actualDuration": 0,
+            "actualStartTime": -1,
+            "alternate": FiberNode {
+              "_debugHookTypes": null,
+              "_debugID": 60,
+              "_debugIsCurrentlyTiming": false,
+              "_debugOwner": null,
+              "_debugSource": null,
+              "actualDuration": 0,
+              "actualStartTime": -1,
+              "alternate": [Circular],
+              "child": null,
+              "childExpirationTime": 0,
+              "contextDependencies": null,
+              "effectTag": 0,
+              "elementType": null,
+              "expirationTime": 1073741823,
+              "firstEffect": null,
+              "index": 0,
+              "key": null,
+              "lastEffect": null,
+              "memoizedProps": null,
+              "memoizedState": null,
+              "mode": 0,
+              "nextEffect": null,
+              "pendingProps": null,
+              "ref": null,
+              "return": null,
+              "selfBaseDuration": 0,
+              "sibling": null,
+              "stateNode": Object {
+                "containerInfo": <div />,
+                "context": Object {},
+                "current": [Circular],
+                "didError": false,
+                "earliestPendingTime": 0,
+                "earliestSuspendedTime": 0,
+                "expirationTime": 0,
+                "finishedWork": null,
+                "firstBatch": null,
+                "hydrate": false,
+                "interactionThreadID": 15,
+                "latestPendingTime": 0,
+                "latestPingedTime": 0,
+                "latestSuspendedTime": 0,
+                "memoizedInteractions": Set {},
+                "nextExpirationTimeToWorkOn": 0,
+                "nextScheduledRoot": null,
+                "pendingChildren": null,
+                "pendingCommitExpirationTime": 0,
+                "pendingContext": null,
+                "pendingInteractionMap": Map {},
+                "pingCache": null,
+                "timeoutHandle": -1,
+              },
+              "tag": 3,
+              "treeBaseDuration": 0,
+              "type": null,
+              "updateQueue": Object {
+                "baseState": null,
+                "firstCapturedEffect": null,
+                "firstCapturedUpdate": null,
+                "firstEffect": null,
+                "firstUpdate": Object {
+                  "callback": null,
+                  "expirationTime": 1073741823,
+                  "next": null,
+                  "nextEffect": null,
+                  "payload": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={
+                        Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        }
+                      }
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "tag": 0,
+                },
+                "lastCapturedEffect": null,
+                "lastCapturedUpdate": null,
+                "lastEffect": null,
+                "lastUpdate": Object {
+                  "callback": null,
+                  "expirationTime": 1073741823,
+                  "next": null,
+                  "nextEffect": null,
+                  "payload": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={
+                        Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        }
+                      }
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "tag": 0,
+                },
+              },
+            },
+            "child": [Circular],
+            "childExpirationTime": 0,
+            "contextDependencies": null,
+            "effectTag": 32,
+            "elementType": null,
+            "expirationTime": 0,
+            "firstEffect": [Circular],
+            "index": 0,
+            "key": null,
+            "lastEffect": [Circular],
+            "memoizedProps": null,
+            "memoizedState": Object {
+              "element": <WrapperComponent
+                Component={[Function]}
+                context={null}
+                props={
+                  Object {
+                    "children": <AuthenticatedRoute
+                      authenticated={true}
+                      component={[Function]}
+                      path="/dashboard"
+                    />,
+                  }
+                }
+                wrappingComponentProps={null}
+              />,
+            },
+            "mode": 0,
+            "nextEffect": null,
+            "pendingProps": null,
+            "ref": null,
+            "return": null,
+            "selfBaseDuration": 0,
+            "sibling": null,
+            "stateNode": Object {
+              "containerInfo": <div />,
+              "context": Object {},
+              "current": [Circular],
+              "didError": false,
+              "earliestPendingTime": 0,
+              "earliestSuspendedTime": 0,
+              "expirationTime": 0,
+              "finishedWork": null,
+              "firstBatch": null,
+              "hydrate": false,
+              "interactionThreadID": 15,
+              "latestPendingTime": 0,
+              "latestPingedTime": 0,
+              "latestSuspendedTime": 0,
+              "memoizedInteractions": Set {},
+              "nextExpirationTimeToWorkOn": 0,
+              "nextScheduledRoot": null,
+              "pendingChildren": null,
+              "pendingCommitExpirationTime": 0,
+              "pendingContext": null,
+              "pendingInteractionMap": Map {},
+              "pingCache": null,
+              "timeoutHandle": -1,
+            },
+            "tag": 3,
+            "treeBaseDuration": 0,
+            "type": null,
+            "updateQueue": Object {
+              "baseState": Object {
+                "element": <WrapperComponent
+                  Component={[Function]}
+                  context={null}
+                  props={
+                    Object {
+                      "children": <AuthenticatedRoute
+                        authenticated={true}
+                        component={[Function]}
+                        path="/dashboard"
+                      />,
+                    }
+                  }
+                  wrappingComponentProps={null}
+                />,
+              },
+              "firstCapturedEffect": null,
+              "firstCapturedUpdate": null,
+              "firstEffect": null,
+              "firstUpdate": null,
+              "lastCapturedEffect": null,
+              "lastCapturedUpdate": null,
+              "lastEffect": null,
+              "lastUpdate": null,
+            },
+          },
+          "pendingProps": Object {
+            "Component": [Function],
+            "context": null,
+            "props": Object {
+              "children": <AuthenticatedRoute
+                authenticated={true}
+                component={[Function]}
+                path="/dashboard"
+              />,
+            },
+            "wrappingComponentProps": null,
+          },
+          "ref": null,
+          "return": FiberNode {
+            "_debugHookTypes": null,
+            "_debugID": 60,
+            "_debugIsCurrentlyTiming": false,
+            "_debugOwner": null,
+            "_debugSource": null,
+            "actualDuration": 0,
+            "actualStartTime": -1,
+            "alternate": FiberNode {
+              "_debugHookTypes": null,
+              "_debugID": 60,
+              "_debugIsCurrentlyTiming": false,
+              "_debugOwner": null,
+              "_debugSource": null,
+              "actualDuration": 0,
+              "actualStartTime": -1,
+              "alternate": [Circular],
+              "child": null,
+              "childExpirationTime": 0,
+              "contextDependencies": null,
+              "effectTag": 0,
+              "elementType": null,
+              "expirationTime": 1073741823,
+              "firstEffect": null,
+              "index": 0,
+              "key": null,
+              "lastEffect": null,
+              "memoizedProps": null,
+              "memoizedState": null,
+              "mode": 0,
+              "nextEffect": null,
+              "pendingProps": null,
+              "ref": null,
+              "return": null,
+              "selfBaseDuration": 0,
+              "sibling": null,
+              "stateNode": Object {
+                "containerInfo": <div />,
+                "context": Object {},
+                "current": [Circular],
+                "didError": false,
+                "earliestPendingTime": 0,
+                "earliestSuspendedTime": 0,
+                "expirationTime": 0,
+                "finishedWork": null,
+                "firstBatch": null,
+                "hydrate": false,
+                "interactionThreadID": 15,
+                "latestPendingTime": 0,
+                "latestPingedTime": 0,
+                "latestSuspendedTime": 0,
+                "memoizedInteractions": Set {},
+                "nextExpirationTimeToWorkOn": 0,
+                "nextScheduledRoot": null,
+                "pendingChildren": null,
+                "pendingCommitExpirationTime": 0,
+                "pendingContext": null,
+                "pendingInteractionMap": Map {},
+                "pingCache": null,
+                "timeoutHandle": -1,
+              },
+              "tag": 3,
+              "treeBaseDuration": 0,
+              "type": null,
+              "updateQueue": Object {
+                "baseState": null,
+                "firstCapturedEffect": null,
+                "firstCapturedUpdate": null,
+                "firstEffect": null,
+                "firstUpdate": Object {
+                  "callback": null,
+                  "expirationTime": 1073741823,
+                  "next": null,
+                  "nextEffect": null,
+                  "payload": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={
+                        Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        }
+                      }
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "tag": 0,
+                },
+                "lastCapturedEffect": null,
+                "lastCapturedUpdate": null,
+                "lastEffect": null,
+                "lastUpdate": Object {
+                  "callback": null,
+                  "expirationTime": 1073741823,
+                  "next": null,
+                  "nextEffect": null,
+                  "payload": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={
+                        Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        }
+                      }
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "tag": 0,
+                },
+              },
+            },
+            "child": [Circular],
+            "childExpirationTime": 0,
+            "contextDependencies": null,
+            "effectTag": 32,
+            "elementType": null,
+            "expirationTime": 0,
+            "firstEffect": [Circular],
+            "index": 0,
+            "key": null,
+            "lastEffect": [Circular],
+            "memoizedProps": null,
+            "memoizedState": Object {
+              "element": <WrapperComponent
+                Component={[Function]}
+                context={null}
+                props={
+                  Object {
+                    "children": <AuthenticatedRoute
+                      authenticated={true}
+                      component={[Function]}
+                      path="/dashboard"
+                    />,
+                  }
+                }
+                wrappingComponentProps={null}
+              />,
+            },
+            "mode": 0,
+            "nextEffect": null,
+            "pendingProps": null,
+            "ref": null,
+            "return": null,
+            "selfBaseDuration": 0,
+            "sibling": null,
+            "stateNode": Object {
+              "containerInfo": <div />,
+              "context": Object {},
+              "current": [Circular],
+              "didError": false,
+              "earliestPendingTime": 0,
+              "earliestSuspendedTime": 0,
+              "expirationTime": 0,
+              "finishedWork": null,
+              "firstBatch": null,
+              "hydrate": false,
+              "interactionThreadID": 15,
+              "latestPendingTime": 0,
+              "latestPingedTime": 0,
+              "latestSuspendedTime": 0,
+              "memoizedInteractions": Set {},
+              "nextExpirationTimeToWorkOn": 0,
+              "nextScheduledRoot": null,
+              "pendingChildren": null,
+              "pendingCommitExpirationTime": 0,
+              "pendingContext": null,
+              "pendingInteractionMap": Map {},
+              "pingCache": null,
+              "timeoutHandle": -1,
+            },
+            "tag": 3,
+            "treeBaseDuration": 0,
+            "type": null,
+            "updateQueue": Object {
+              "baseState": Object {
+                "element": <WrapperComponent
+                  Component={[Function]}
+                  context={null}
+                  props={
+                    Object {
+                      "children": <AuthenticatedRoute
+                        authenticated={true}
+                        component={[Function]}
+                        path="/dashboard"
+                      />,
+                    }
+                  }
+                  wrappingComponentProps={null}
+                />,
+              },
+              "firstCapturedEffect": null,
+              "firstCapturedUpdate": null,
+              "firstEffect": null,
+              "firstUpdate": null,
+              "lastCapturedEffect": null,
+              "lastCapturedUpdate": null,
+              "lastEffect": null,
+              "lastUpdate": null,
+            },
+          },
+          "selfBaseDuration": 0,
+          "sibling": null,
+          "stateNode": WrapperComponent {
+            "_reactInternalFiber": [Circular],
+            "_reactInternalInstance": Object {},
+            "context": Object {},
+            "props": Object {
+              "Component": [Function],
+              "context": null,
+              "props": Object {
+                "children": <AuthenticatedRoute
+                  authenticated={true}
+                  component={[Function]}
+                  path="/dashboard"
+                />,
+              },
+              "wrappingComponentProps": null,
+            },
+            "refs": Object {},
+            "rootFinderInstance": null,
+            "state": Object {
+              "context": null,
+              "mount": true,
+              "props": Object {
+                "children": <AuthenticatedRoute
+                  authenticated={true}
+                  component={[Function]}
+                  path="/dashboard"
+                />,
+              },
+              "wrappingComponentProps": null,
+            },
+            "updater": Object {
+              "enqueueForceUpdate": [Function],
+              "enqueueReplaceState": [Function],
+              "enqueueSetState": [Function],
+              "isMounted": [Function],
+            },
+          },
+          "tag": 1,
+          "treeBaseDuration": 0,
+          "type": [Function],
+          "updateQueue": null,
+        },
+        "_debugSource": null,
+        "actualDuration": 0,
+        "actualStartTime": -1,
+        "alternate": null,
+        "child": FiberNode {
+          "_debugHookTypes": null,
+          "_debugID": 64,
+          "_debugIsCurrentlyTiming": false,
+          "_debugOwner": [Circular],
+          "_debugSource": null,
+          "actualDuration": 0,
+          "actualStartTime": -1,
+          "alternate": null,
+          "child": FiberNode {
+            "_debugHookTypes": null,
+            "_debugID": 65,
+            "_debugIsCurrentlyTiming": false,
+            "_debugOwner": null,
+            "_debugSource": Object {
+              "fileName": "/Users/chucky/Code/Bench/bp-esa-frontend/src/App.test.jsx",
+              "lineNumber": 123,
+            },
+            "actualDuration": 0,
+            "actualStartTime": -1,
+            "alternate": null,
+            "child": FiberNode {
+              "_debugHookTypes": null,
+              "_debugID": 66,
+              "_debugIsCurrentlyTiming": false,
+              "_debugOwner": [Circular],
+              "_debugSource": Object {
+                "fileName": "/Users/chucky/Code/Bench/bp-esa-frontend/src/App.jsx",
+                "lineNumber": 15,
+              },
+              "actualDuration": 0,
+              "actualStartTime": -1,
+              "alternate": null,
+              "child": null,
+              "childExpirationTime": 0,
+              "contextDependencies": null,
+              "effectTag": 1,
+              "elementType": [Function],
+              "expirationTime": 0,
+              "firstEffect": null,
+              "index": 0,
+              "key": null,
+              "lastEffect": null,
+              "memoizedProps": Object {
+                "path": "/dashboard",
+                "render": [Function],
+              },
+              "memoizedState": Object {
+                "match": null,
+              },
+              "mode": 0,
+              "nextEffect": null,
+              "pendingProps": Object {
+                "path": "/dashboard",
+                "render": [Function],
+              },
+              "ref": null,
+              "return": [Circular],
+              "selfBaseDuration": 0,
+              "sibling": null,
+              "stateNode": Route {
+                "__reactInternalMemoizedMaskedChildContext": Object {
+                  "router": Object {
+                    "history": Object {
+                      "action": "POP",
+                      "block": [Function],
+                      "createHref": [Function],
+                      "go": [Function],
+                      "goBack": [Function],
+                      "goForward": [Function],
+                      "length": 1,
+                      "listen": [Function],
+                      "location": Object {
+                        "hash": "",
+                        "pathname": "/",
+                        "search": "",
+                        "state": undefined,
+                      },
+                      "push": [Function],
+                      "replace": [Function],
+                    },
+                    "route": Object {
+                      "location": Object {
+                        "hash": "",
+                        "pathname": "/",
+                        "search": "",
+                        "state": undefined,
+                      },
+                      "match": Object {
+                        "isExact": true,
+                        "params": Object {},
+                        "path": "/",
+                        "url": "/",
+                      },
+                    },
+                  },
+                },
+                "__reactInternalMemoizedMergedChildContext": Object {
+                  "router": Object {
+                    "history": Object {
+                      "action": "POP",
+                      "block": [Function],
+                      "createHref": [Function],
+                      "go": [Function],
+                      "goBack": [Function],
+                      "goForward": [Function],
+                      "length": 1,
+                      "listen": [Function],
+                      "location": Object {
+                        "hash": "",
+                        "pathname": "/",
+                        "search": "",
+                        "state": undefined,
+                      },
+                      "push": [Function],
+                      "replace": [Function],
+                    },
+                    "route": Object {
+                      "location": Object {
+                        "hash": "",
+                        "pathname": "/",
+                        "search": "",
+                        "state": undefined,
+                      },
+                      "match": null,
+                    },
+                  },
+                },
+                "__reactInternalMemoizedUnmaskedChildContext": Object {
+                  "router": Object {
+                    "history": Object {
+                      "action": "POP",
+                      "block": [Function],
+                      "createHref": [Function],
+                      "go": [Function],
+                      "goBack": [Function],
+                      "goForward": [Function],
+                      "length": 1,
+                      "listen": [Function],
+                      "location": Object {
+                        "hash": "",
+                        "pathname": "/",
+                        "search": "",
+                        "state": undefined,
+                      },
+                      "push": [Function],
+                      "replace": [Function],
+                    },
+                    "route": Object {
+                      "location": Object {
+                        "hash": "",
+                        "pathname": "/",
+                        "search": "",
+                        "state": undefined,
+                      },
+                      "match": Object {
+                        "isExact": true,
+                        "params": Object {},
+                        "path": "/",
+                        "url": "/",
+                      },
+                    },
+                  },
+                },
+                "_reactInternalFiber": [Circular],
+                "_reactInternalInstance": Object {},
+                "context": Object {
+                  "router": Object {
+                    "history": Object {
+                      "action": "POP",
+                      "block": [Function],
+                      "createHref": [Function],
+                      "go": [Function],
+                      "goBack": [Function],
+                      "goForward": [Function],
+                      "length": 1,
+                      "listen": [Function],
+                      "location": Object {
+                        "hash": "",
+                        "pathname": "/",
+                        "search": "",
+                        "state": undefined,
+                      },
+                      "push": [Function],
+                      "replace": [Function],
+                    },
+                    "route": Object {
+                      "location": Object {
+                        "hash": "",
+                        "pathname": "/",
+                        "search": "",
+                        "state": undefined,
+                      },
+                      "match": Object {
+                        "isExact": true,
+                        "params": Object {},
+                        "path": "/",
+                        "url": "/",
+                      },
+                    },
+                  },
+                },
+                "props": Object {
+                  "path": "/dashboard",
+                  "render": [Function],
+                },
+                "refs": Object {},
+                "state": Object {
+                  "match": null,
+                },
+                "updater": Object {
+                  "enqueueForceUpdate": [Function],
+                  "enqueueReplaceState": [Function],
+                  "enqueueSetState": [Function],
+                  "isMounted": [Function],
+                },
+              },
+              "tag": 1,
+              "treeBaseDuration": 0,
+              "type": [Function],
+              "updateQueue": null,
+            },
+            "childExpirationTime": 0,
+            "contextDependencies": null,
+            "effectTag": 1,
+            "elementType": [Function],
+            "expirationTime": 0,
+            "firstEffect": null,
+            "index": 0,
+            "key": null,
+            "lastEffect": null,
+            "memoizedProps": Object {
+              "authenticated": true,
+              "component": [Function],
+              "path": "/dashboard",
+            },
+            "memoizedState": null,
+            "mode": 0,
+            "nextEffect": null,
+            "pendingProps": Object {
+              "authenticated": true,
+              "component": [Function],
+              "path": "/dashboard",
+            },
+            "ref": null,
+            "return": [Circular],
+            "selfBaseDuration": 0,
+            "sibling": null,
+            "stateNode": null,
+            "tag": 0,
+            "treeBaseDuration": 0,
+            "type": [Function],
+            "updateQueue": null,
+          },
+          "childExpirationTime": 0,
+          "contextDependencies": null,
+          "effectTag": 1,
+          "elementType": [Function],
+          "expirationTime": 0,
+          "firstEffect": null,
+          "index": 0,
+          "key": null,
+          "lastEffect": null,
+          "memoizedProps": Object {
+            "children": <AuthenticatedRoute
+              authenticated={true}
+              component={[Function]}
+              path="/dashboard"
+            />,
+            "history": Object {
+              "action": "POP",
+              "block": [Function],
+              "createHref": [Function],
+              "go": [Function],
+              "goBack": [Function],
+              "goForward": [Function],
+              "length": 1,
+              "listen": [Function],
+              "location": Object {
+                "hash": "",
+                "pathname": "/",
+                "search": "",
+                "state": undefined,
+              },
+              "push": [Function],
+              "replace": [Function],
+            },
+          },
+          "memoizedState": Object {
+            "match": Object {
+              "isExact": true,
+              "params": Object {},
+              "path": "/",
+              "url": "/",
+            },
+          },
+          "mode": 0,
+          "nextEffect": null,
+          "pendingProps": Object {
+            "children": <AuthenticatedRoute
+              authenticated={true}
+              component={[Function]}
+              path="/dashboard"
+            />,
+            "history": Object {
+              "action": "POP",
+              "block": [Function],
+              "createHref": [Function],
+              "go": [Function],
+              "goBack": [Function],
+              "goForward": [Function],
+              "length": 1,
+              "listen": [Function],
+              "location": Object {
+                "hash": "",
+                "pathname": "/",
+                "search": "",
+                "state": undefined,
+              },
+              "push": [Function],
+              "replace": [Function],
+            },
+          },
+          "ref": null,
+          "return": [Circular],
+          "selfBaseDuration": 0,
+          "sibling": null,
+          "stateNode": Router {
+            "__reactInternalMemoizedMaskedChildContext": Object {
+              "router": undefined,
+            },
+            "__reactInternalMemoizedMergedChildContext": Object {
+              "router": Object {
+                "history": Object {
+                  "action": "POP",
+                  "block": [Function],
+                  "createHref": [Function],
+                  "go": [Function],
+                  "goBack": [Function],
+                  "goForward": [Function],
+                  "length": 1,
+                  "listen": [Function],
+                  "location": Object {
+                    "hash": "",
+                    "pathname": "/",
+                    "search": "",
+                    "state": undefined,
+                  },
+                  "push": [Function],
+                  "replace": [Function],
+                },
+                "route": Object {
+                  "location": Object {
+                    "hash": "",
+                    "pathname": "/",
+                    "search": "",
+                    "state": undefined,
+                  },
+                  "match": Object {
+                    "isExact": true,
+                    "params": Object {},
+                    "path": "/",
+                    "url": "/",
+                  },
+                },
+              },
+            },
+            "__reactInternalMemoizedUnmaskedChildContext": Object {},
+            "_reactInternalFiber": [Circular],
+            "_reactInternalInstance": Object {},
+            "context": Object {
+              "router": undefined,
+            },
+            "props": Object {
+              "children": <AuthenticatedRoute
+                authenticated={true}
+                component={[Function]}
+                path="/dashboard"
+              />,
+              "history": Object {
+                "action": "POP",
+                "block": [Function],
+                "createHref": [Function],
+                "go": [Function],
+                "goBack": [Function],
+                "goForward": [Function],
+                "length": 1,
+                "listen": [Function],
+                "location": Object {
+                  "hash": "",
+                  "pathname": "/",
+                  "search": "",
+                  "state": undefined,
+                },
+                "push": [Function],
+                "replace": [Function],
+              },
+            },
+            "refs": Object {},
+            "state": Object {
+              "match": Object {
+                "isExact": true,
+                "params": Object {},
+                "path": "/",
+                "url": "/",
+              },
+            },
+            "unlisten": [Function],
+            "updater": Object {
+              "enqueueForceUpdate": [Function],
+              "enqueueReplaceState": [Function],
+              "enqueueSetState": [Function],
+              "isMounted": [Function],
+            },
+          },
+          "tag": 1,
+          "treeBaseDuration": 0,
+          "type": [Function],
+          "updateQueue": null,
+        },
+        "childExpirationTime": 0,
+        "contextDependencies": null,
+        "effectTag": 1,
+        "elementType": [Function],
+        "expirationTime": 0,
+        "firstEffect": null,
+        "index": 0,
+        "key": null,
+        "lastEffect": null,
+        "memoizedProps": Object {
+          "children": <AuthenticatedRoute
+            authenticated={true}
+            component={[Function]}
+            path="/dashboard"
+          />,
+        },
+        "memoizedState": null,
+        "mode": 0,
+        "nextEffect": null,
+        "pendingProps": Object {
+          "children": <AuthenticatedRoute
+            authenticated={true}
+            component={[Function]}
+            path="/dashboard"
+          />,
+        },
+        "ref": null,
+        "return": FiberNode {
+          "_debugHookTypes": null,
+          "_debugID": 62,
+          "_debugIsCurrentlyTiming": false,
+          "_debugOwner": null,
+          "_debugSource": null,
+          "actualDuration": 0,
+          "actualStartTime": -1,
+          "alternate": null,
+          "child": [Circular],
+          "childExpirationTime": 0,
+          "contextDependencies": null,
+          "effectTag": 1,
+          "elementType": [Function],
+          "expirationTime": 0,
+          "firstEffect": null,
+          "index": 0,
+          "key": null,
+          "lastEffect": null,
+          "memoizedProps": Object {
+            "Component": [Function],
+            "context": null,
+            "props": Object {
+              "children": <AuthenticatedRoute
+                authenticated={true}
+                component={[Function]}
+                path="/dashboard"
+              />,
+            },
+            "wrappingComponentProps": null,
+          },
+          "memoizedState": Object {
+            "context": null,
+            "mount": true,
+            "props": Object {
+              "children": <AuthenticatedRoute
+                authenticated={true}
+                component={[Function]}
+                path="/dashboard"
+              />,
+            },
+            "wrappingComponentProps": null,
+          },
+          "mode": 0,
+          "nextEffect": FiberNode {
+            "_debugHookTypes": null,
+            "_debugID": 60,
+            "_debugIsCurrentlyTiming": false,
+            "_debugOwner": null,
+            "_debugSource": null,
+            "actualDuration": 0,
+            "actualStartTime": -1,
+            "alternate": FiberNode {
+              "_debugHookTypes": null,
+              "_debugID": 60,
+              "_debugIsCurrentlyTiming": false,
+              "_debugOwner": null,
+              "_debugSource": null,
+              "actualDuration": 0,
+              "actualStartTime": -1,
+              "alternate": [Circular],
+              "child": null,
+              "childExpirationTime": 0,
+              "contextDependencies": null,
+              "effectTag": 0,
+              "elementType": null,
+              "expirationTime": 1073741823,
+              "firstEffect": null,
+              "index": 0,
+              "key": null,
+              "lastEffect": null,
+              "memoizedProps": null,
+              "memoizedState": null,
+              "mode": 0,
+              "nextEffect": null,
+              "pendingProps": null,
+              "ref": null,
+              "return": null,
+              "selfBaseDuration": 0,
+              "sibling": null,
+              "stateNode": Object {
+                "containerInfo": <div />,
+                "context": Object {},
+                "current": [Circular],
+                "didError": false,
+                "earliestPendingTime": 0,
+                "earliestSuspendedTime": 0,
+                "expirationTime": 0,
+                "finishedWork": null,
+                "firstBatch": null,
+                "hydrate": false,
+                "interactionThreadID": 15,
+                "latestPendingTime": 0,
+                "latestPingedTime": 0,
+                "latestSuspendedTime": 0,
+                "memoizedInteractions": Set {},
+                "nextExpirationTimeToWorkOn": 0,
+                "nextScheduledRoot": null,
+                "pendingChildren": null,
+                "pendingCommitExpirationTime": 0,
+                "pendingContext": null,
+                "pendingInteractionMap": Map {},
+                "pingCache": null,
+                "timeoutHandle": -1,
+              },
+              "tag": 3,
+              "treeBaseDuration": 0,
+              "type": null,
+              "updateQueue": Object {
+                "baseState": null,
+                "firstCapturedEffect": null,
+                "firstCapturedUpdate": null,
+                "firstEffect": null,
+                "firstUpdate": Object {
+                  "callback": null,
+                  "expirationTime": 1073741823,
+                  "next": null,
+                  "nextEffect": null,
+                  "payload": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={
+                        Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        }
+                      }
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "tag": 0,
+                },
+                "lastCapturedEffect": null,
+                "lastCapturedUpdate": null,
+                "lastEffect": null,
+                "lastUpdate": Object {
+                  "callback": null,
+                  "expirationTime": 1073741823,
+                  "next": null,
+                  "nextEffect": null,
+                  "payload": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={
+                        Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        }
+                      }
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "tag": 0,
+                },
+              },
+            },
+            "child": [Circular],
+            "childExpirationTime": 0,
+            "contextDependencies": null,
+            "effectTag": 32,
+            "elementType": null,
+            "expirationTime": 0,
+            "firstEffect": [Circular],
+            "index": 0,
+            "key": null,
+            "lastEffect": [Circular],
+            "memoizedProps": null,
+            "memoizedState": Object {
+              "element": <WrapperComponent
+                Component={[Function]}
+                context={null}
+                props={
+                  Object {
+                    "children": <AuthenticatedRoute
+                      authenticated={true}
+                      component={[Function]}
+                      path="/dashboard"
+                    />,
+                  }
+                }
+                wrappingComponentProps={null}
+              />,
+            },
+            "mode": 0,
+            "nextEffect": null,
+            "pendingProps": null,
+            "ref": null,
+            "return": null,
+            "selfBaseDuration": 0,
+            "sibling": null,
+            "stateNode": Object {
+              "containerInfo": <div />,
+              "context": Object {},
+              "current": [Circular],
+              "didError": false,
+              "earliestPendingTime": 0,
+              "earliestSuspendedTime": 0,
+              "expirationTime": 0,
+              "finishedWork": null,
+              "firstBatch": null,
+              "hydrate": false,
+              "interactionThreadID": 15,
+              "latestPendingTime": 0,
+              "latestPingedTime": 0,
+              "latestSuspendedTime": 0,
+              "memoizedInteractions": Set {},
+              "nextExpirationTimeToWorkOn": 0,
+              "nextScheduledRoot": null,
+              "pendingChildren": null,
+              "pendingCommitExpirationTime": 0,
+              "pendingContext": null,
+              "pendingInteractionMap": Map {},
+              "pingCache": null,
+              "timeoutHandle": -1,
+            },
+            "tag": 3,
+            "treeBaseDuration": 0,
+            "type": null,
+            "updateQueue": Object {
+              "baseState": Object {
+                "element": <WrapperComponent
+                  Component={[Function]}
+                  context={null}
+                  props={
+                    Object {
+                      "children": <AuthenticatedRoute
+                        authenticated={true}
+                        component={[Function]}
+                        path="/dashboard"
+                      />,
+                    }
+                  }
+                  wrappingComponentProps={null}
+                />,
+              },
+              "firstCapturedEffect": null,
+              "firstCapturedUpdate": null,
+              "firstEffect": null,
+              "firstUpdate": null,
+              "lastCapturedEffect": null,
+              "lastCapturedUpdate": null,
+              "lastEffect": null,
+              "lastUpdate": null,
+            },
+          },
+          "pendingProps": Object {
+            "Component": [Function],
+            "context": null,
+            "props": Object {
+              "children": <AuthenticatedRoute
+                authenticated={true}
+                component={[Function]}
+                path="/dashboard"
+              />,
+            },
+            "wrappingComponentProps": null,
+          },
+          "ref": null,
+          "return": FiberNode {
+            "_debugHookTypes": null,
+            "_debugID": 60,
+            "_debugIsCurrentlyTiming": false,
+            "_debugOwner": null,
+            "_debugSource": null,
+            "actualDuration": 0,
+            "actualStartTime": -1,
+            "alternate": FiberNode {
+              "_debugHookTypes": null,
+              "_debugID": 60,
+              "_debugIsCurrentlyTiming": false,
+              "_debugOwner": null,
+              "_debugSource": null,
+              "actualDuration": 0,
+              "actualStartTime": -1,
+              "alternate": [Circular],
+              "child": null,
+              "childExpirationTime": 0,
+              "contextDependencies": null,
+              "effectTag": 0,
+              "elementType": null,
+              "expirationTime": 1073741823,
+              "firstEffect": null,
+              "index": 0,
+              "key": null,
+              "lastEffect": null,
+              "memoizedProps": null,
+              "memoizedState": null,
+              "mode": 0,
+              "nextEffect": null,
+              "pendingProps": null,
+              "ref": null,
+              "return": null,
+              "selfBaseDuration": 0,
+              "sibling": null,
+              "stateNode": Object {
+                "containerInfo": <div />,
+                "context": Object {},
+                "current": [Circular],
+                "didError": false,
+                "earliestPendingTime": 0,
+                "earliestSuspendedTime": 0,
+                "expirationTime": 0,
+                "finishedWork": null,
+                "firstBatch": null,
+                "hydrate": false,
+                "interactionThreadID": 15,
+                "latestPendingTime": 0,
+                "latestPingedTime": 0,
+                "latestSuspendedTime": 0,
+                "memoizedInteractions": Set {},
+                "nextExpirationTimeToWorkOn": 0,
+                "nextScheduledRoot": null,
+                "pendingChildren": null,
+                "pendingCommitExpirationTime": 0,
+                "pendingContext": null,
+                "pendingInteractionMap": Map {},
+                "pingCache": null,
+                "timeoutHandle": -1,
+              },
+              "tag": 3,
+              "treeBaseDuration": 0,
+              "type": null,
+              "updateQueue": Object {
+                "baseState": null,
+                "firstCapturedEffect": null,
+                "firstCapturedUpdate": null,
+                "firstEffect": null,
+                "firstUpdate": Object {
+                  "callback": null,
+                  "expirationTime": 1073741823,
+                  "next": null,
+                  "nextEffect": null,
+                  "payload": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={
+                        Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        }
+                      }
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "tag": 0,
+                },
+                "lastCapturedEffect": null,
+                "lastCapturedUpdate": null,
+                "lastEffect": null,
+                "lastUpdate": Object {
+                  "callback": null,
+                  "expirationTime": 1073741823,
+                  "next": null,
+                  "nextEffect": null,
+                  "payload": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={
+                        Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        }
+                      }
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "tag": 0,
+                },
+              },
+            },
+            "child": [Circular],
+            "childExpirationTime": 0,
+            "contextDependencies": null,
+            "effectTag": 32,
+            "elementType": null,
+            "expirationTime": 0,
+            "firstEffect": [Circular],
+            "index": 0,
+            "key": null,
+            "lastEffect": [Circular],
+            "memoizedProps": null,
+            "memoizedState": Object {
+              "element": <WrapperComponent
+                Component={[Function]}
+                context={null}
+                props={
+                  Object {
+                    "children": <AuthenticatedRoute
+                      authenticated={true}
+                      component={[Function]}
+                      path="/dashboard"
+                    />,
+                  }
+                }
+                wrappingComponentProps={null}
+              />,
+            },
+            "mode": 0,
+            "nextEffect": null,
+            "pendingProps": null,
+            "ref": null,
+            "return": null,
+            "selfBaseDuration": 0,
+            "sibling": null,
+            "stateNode": Object {
+              "containerInfo": <div />,
+              "context": Object {},
+              "current": [Circular],
+              "didError": false,
+              "earliestPendingTime": 0,
+              "earliestSuspendedTime": 0,
+              "expirationTime": 0,
+              "finishedWork": null,
+              "firstBatch": null,
+              "hydrate": false,
+              "interactionThreadID": 15,
+              "latestPendingTime": 0,
+              "latestPingedTime": 0,
+              "latestSuspendedTime": 0,
+              "memoizedInteractions": Set {},
+              "nextExpirationTimeToWorkOn": 0,
+              "nextScheduledRoot": null,
+              "pendingChildren": null,
+              "pendingCommitExpirationTime": 0,
+              "pendingContext": null,
+              "pendingInteractionMap": Map {},
+              "pingCache": null,
+              "timeoutHandle": -1,
+            },
+            "tag": 3,
+            "treeBaseDuration": 0,
+            "type": null,
+            "updateQueue": Object {
+              "baseState": Object {
+                "element": <WrapperComponent
+                  Component={[Function]}
+                  context={null}
+                  props={
+                    Object {
+                      "children": <AuthenticatedRoute
+                        authenticated={true}
+                        component={[Function]}
+                        path="/dashboard"
+                      />,
+                    }
+                  }
+                  wrappingComponentProps={null}
+                />,
+              },
+              "firstCapturedEffect": null,
+              "firstCapturedUpdate": null,
+              "firstEffect": null,
+              "firstUpdate": null,
+              "lastCapturedEffect": null,
+              "lastCapturedUpdate": null,
+              "lastEffect": null,
+              "lastUpdate": null,
+            },
+          },
+          "selfBaseDuration": 0,
+          "sibling": null,
+          "stateNode": WrapperComponent {
+            "_reactInternalFiber": [Circular],
+            "_reactInternalInstance": Object {},
+            "context": Object {},
+            "props": Object {
+              "Component": [Function],
+              "context": null,
+              "props": Object {
+                "children": <AuthenticatedRoute
+                  authenticated={true}
+                  component={[Function]}
+                  path="/dashboard"
+                />,
+              },
+              "wrappingComponentProps": null,
+            },
+            "refs": Object {},
+            "rootFinderInstance": null,
+            "state": Object {
+              "context": null,
+              "mount": true,
+              "props": Object {
+                "children": <AuthenticatedRoute
+                  authenticated={true}
+                  component={[Function]}
+                  path="/dashboard"
+                />,
+              },
+              "wrappingComponentProps": null,
+            },
+            "updater": Object {
+              "enqueueForceUpdate": [Function],
+              "enqueueReplaceState": [Function],
+              "enqueueSetState": [Function],
+              "isMounted": [Function],
+            },
+          },
+          "tag": 1,
+          "treeBaseDuration": 0,
+          "type": [Function],
+          "updateQueue": null,
+        },
+        "selfBaseDuration": 0,
+        "sibling": null,
+        "stateNode": [Circular],
+        "tag": 1,
+        "treeBaseDuration": 0,
+        "type": [Function],
+        "updateQueue": null,
+      },
+      "_reactInternalInstance": Object {},
+      "context": Object {},
+      "history": Object {
+        "action": "POP",
+        "block": [Function],
+        "createHref": [Function],
+        "go": [Function],
+        "goBack": [Function],
+        "goForward": [Function],
+        "length": 1,
+        "listen": [Function],
+        "location": Object {
+          "hash": "",
+          "pathname": "/",
+          "search": "",
+          "state": undefined,
+        },
+        "push": [Function],
+        "replace": [Function],
+      },
+      "props": Object {
+        "children": <AuthenticatedRoute
+          authenticated={true}
+          component={[Function]}
+          path="/dashboard"
+        />,
+      },
+      "refs": Object {},
+      "state": null,
+      "updater": Object {
+        "enqueueForceUpdate": [Function],
+        "enqueueReplaceState": [Function],
+        "enqueueSetState": [Function],
+        "isMounted": [Function],
+      },
+    },
+    "key": undefined,
+    "nodeType": "class",
+    "props": Object {
+      "children": <AuthenticatedRoute
+        authenticated={true}
+        component={[Function]}
+        path="/dashboard"
+      />,
+    },
+    "ref": null,
+    "rendered": Object {
+      "instance": Router {
+        "__reactInternalMemoizedMaskedChildContext": Object {
+          "router": undefined,
+        },
+        "__reactInternalMemoizedMergedChildContext": Object {
+          "router": Object {
+            "history": Object {
+              "action": "POP",
+              "block": [Function],
+              "createHref": [Function],
+              "go": [Function],
+              "goBack": [Function],
+              "goForward": [Function],
+              "length": 1,
+              "listen": [Function],
+              "location": Object {
+                "hash": "",
+                "pathname": "/",
+                "search": "",
+                "state": undefined,
+              },
+              "push": [Function],
+              "replace": [Function],
+            },
+            "route": Object {
+              "location": Object {
+                "hash": "",
+                "pathname": "/",
+                "search": "",
+                "state": undefined,
+              },
+              "match": Object {
+                "isExact": true,
+                "params": Object {},
+                "path": "/",
+                "url": "/",
+              },
+            },
+          },
+        },
+        "__reactInternalMemoizedUnmaskedChildContext": Object {},
+        "_reactInternalFiber": FiberNode {
+          "_debugHookTypes": null,
+          "_debugID": 64,
+          "_debugIsCurrentlyTiming": false,
+          "_debugOwner": FiberNode {
+            "_debugHookTypes": null,
+            "_debugID": 63,
+            "_debugIsCurrentlyTiming": false,
+            "_debugOwner": FiberNode {
+              "_debugHookTypes": null,
+              "_debugID": 62,
+              "_debugIsCurrentlyTiming": false,
+              "_debugOwner": null,
+              "_debugSource": null,
+              "actualDuration": 0,
+              "actualStartTime": -1,
+              "alternate": null,
+              "child": [Circular],
+              "childExpirationTime": 0,
+              "contextDependencies": null,
+              "effectTag": 1,
+              "elementType": [Function],
+              "expirationTime": 0,
+              "firstEffect": null,
+              "index": 0,
+              "key": null,
+              "lastEffect": null,
+              "memoizedProps": Object {
+                "Component": [Function],
+                "context": null,
+                "props": Object {
+                  "children": <AuthenticatedRoute
+                    authenticated={true}
+                    component={[Function]}
+                    path="/dashboard"
+                  />,
+                },
+                "wrappingComponentProps": null,
+              },
+              "memoizedState": Object {
+                "context": null,
+                "mount": true,
+                "props": Object {
+                  "children": <AuthenticatedRoute
+                    authenticated={true}
+                    component={[Function]}
+                    path="/dashboard"
+                  />,
+                },
+                "wrappingComponentProps": null,
+              },
+              "mode": 0,
+              "nextEffect": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 60,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": null,
+                "_debugSource": null,
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 60,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": null,
+                  "_debugSource": null,
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": [Circular],
+                  "child": null,
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 0,
+                  "elementType": null,
+                  "expirationTime": 1073741823,
+                  "firstEffect": null,
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": null,
+                  "memoizedProps": null,
+                  "memoizedState": null,
+                  "mode": 0,
+                  "nextEffect": null,
+                  "pendingProps": null,
+                  "ref": null,
+                  "return": null,
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": Object {
+                    "containerInfo": <div />,
+                    "context": Object {},
+                    "current": [Circular],
+                    "didError": false,
+                    "earliestPendingTime": 0,
+                    "earliestSuspendedTime": 0,
+                    "expirationTime": 0,
+                    "finishedWork": null,
+                    "firstBatch": null,
+                    "hydrate": false,
+                    "interactionThreadID": 15,
+                    "latestPendingTime": 0,
+                    "latestPingedTime": 0,
+                    "latestSuspendedTime": 0,
+                    "memoizedInteractions": Set {},
+                    "nextExpirationTimeToWorkOn": 0,
+                    "nextScheduledRoot": null,
+                    "pendingChildren": null,
+                    "pendingCommitExpirationTime": 0,
+                    "pendingContext": null,
+                    "pendingInteractionMap": Map {},
+                    "pingCache": null,
+                    "timeoutHandle": -1,
+                  },
+                  "tag": 3,
+                  "treeBaseDuration": 0,
+                  "type": null,
+                  "updateQueue": Object {
+                    "baseState": null,
+                    "firstCapturedEffect": null,
+                    "firstCapturedUpdate": null,
+                    "firstEffect": null,
+                    "firstUpdate": Object {
+                      "callback": null,
+                      "expirationTime": 1073741823,
+                      "next": null,
+                      "nextEffect": null,
+                      "payload": Object {
+                        "element": <WrapperComponent
+                          Component={[Function]}
+                          context={null}
+                          props={
+                            Object {
+                              "children": <AuthenticatedRoute
+                                authenticated={true}
+                                component={[Function]}
+                                path="/dashboard"
+                              />,
+                            }
+                          }
+                          wrappingComponentProps={null}
+                        />,
+                      },
+                      "tag": 0,
+                    },
+                    "lastCapturedEffect": null,
+                    "lastCapturedUpdate": null,
+                    "lastEffect": null,
+                    "lastUpdate": Object {
+                      "callback": null,
+                      "expirationTime": 1073741823,
+                      "next": null,
+                      "nextEffect": null,
+                      "payload": Object {
+                        "element": <WrapperComponent
+                          Component={[Function]}
+                          context={null}
+                          props={
+                            Object {
+                              "children": <AuthenticatedRoute
+                                authenticated={true}
+                                component={[Function]}
+                                path="/dashboard"
+                              />,
+                            }
+                          }
+                          wrappingComponentProps={null}
+                        />,
+                      },
+                      "tag": 0,
+                    },
+                  },
+                },
+                "child": [Circular],
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 32,
+                "elementType": null,
+                "expirationTime": 0,
+                "firstEffect": [Circular],
+                "index": 0,
+                "key": null,
+                "lastEffect": [Circular],
+                "memoizedProps": null,
+                "memoizedState": Object {
+                  "element": <WrapperComponent
+                    Component={[Function]}
+                    context={null}
+                    props={
+                      Object {
+                        "children": <AuthenticatedRoute
+                          authenticated={true}
+                          component={[Function]}
+                          path="/dashboard"
+                        />,
+                      }
+                    }
+                    wrappingComponentProps={null}
+                  />,
+                },
+                "mode": 0,
+                "nextEffect": null,
+                "pendingProps": null,
+                "ref": null,
+                "return": null,
+                "selfBaseDuration": 0,
+                "sibling": null,
+                "stateNode": Object {
+                  "containerInfo": <div />,
+                  "context": Object {},
+                  "current": [Circular],
+                  "didError": false,
+                  "earliestPendingTime": 0,
+                  "earliestSuspendedTime": 0,
+                  "expirationTime": 0,
+                  "finishedWork": null,
+                  "firstBatch": null,
+                  "hydrate": false,
+                  "interactionThreadID": 15,
+                  "latestPendingTime": 0,
+                  "latestPingedTime": 0,
+                  "latestSuspendedTime": 0,
+                  "memoizedInteractions": Set {},
+                  "nextExpirationTimeToWorkOn": 0,
+                  "nextScheduledRoot": null,
+                  "pendingChildren": null,
+                  "pendingCommitExpirationTime": 0,
+                  "pendingContext": null,
+                  "pendingInteractionMap": Map {},
+                  "pingCache": null,
+                  "timeoutHandle": -1,
+                },
+                "tag": 3,
+                "treeBaseDuration": 0,
+                "type": null,
+                "updateQueue": Object {
+                  "baseState": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={
+                        Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        }
+                      }
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "firstCapturedEffect": null,
+                  "firstCapturedUpdate": null,
+                  "firstEffect": null,
+                  "firstUpdate": null,
+                  "lastCapturedEffect": null,
+                  "lastCapturedUpdate": null,
+                  "lastEffect": null,
+                  "lastUpdate": null,
+                },
+              },
+              "pendingProps": Object {
+                "Component": [Function],
+                "context": null,
+                "props": Object {
+                  "children": <AuthenticatedRoute
+                    authenticated={true}
+                    component={[Function]}
+                    path="/dashboard"
+                  />,
+                },
+                "wrappingComponentProps": null,
+              },
+              "ref": null,
+              "return": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 60,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": null,
+                "_debugSource": null,
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 60,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": null,
+                  "_debugSource": null,
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": [Circular],
+                  "child": null,
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 0,
+                  "elementType": null,
+                  "expirationTime": 1073741823,
+                  "firstEffect": null,
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": null,
+                  "memoizedProps": null,
+                  "memoizedState": null,
+                  "mode": 0,
+                  "nextEffect": null,
+                  "pendingProps": null,
+                  "ref": null,
+                  "return": null,
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": Object {
+                    "containerInfo": <div />,
+                    "context": Object {},
+                    "current": [Circular],
+                    "didError": false,
+                    "earliestPendingTime": 0,
+                    "earliestSuspendedTime": 0,
+                    "expirationTime": 0,
+                    "finishedWork": null,
+                    "firstBatch": null,
+                    "hydrate": false,
+                    "interactionThreadID": 15,
+                    "latestPendingTime": 0,
+                    "latestPingedTime": 0,
+                    "latestSuspendedTime": 0,
+                    "memoizedInteractions": Set {},
+                    "nextExpirationTimeToWorkOn": 0,
+                    "nextScheduledRoot": null,
+                    "pendingChildren": null,
+                    "pendingCommitExpirationTime": 0,
+                    "pendingContext": null,
+                    "pendingInteractionMap": Map {},
+                    "pingCache": null,
+                    "timeoutHandle": -1,
+                  },
+                  "tag": 3,
+                  "treeBaseDuration": 0,
+                  "type": null,
+                  "updateQueue": Object {
+                    "baseState": null,
+                    "firstCapturedEffect": null,
+                    "firstCapturedUpdate": null,
+                    "firstEffect": null,
+                    "firstUpdate": Object {
+                      "callback": null,
+                      "expirationTime": 1073741823,
+                      "next": null,
+                      "nextEffect": null,
+                      "payload": Object {
+                        "element": <WrapperComponent
+                          Component={[Function]}
+                          context={null}
+                          props={
+                            Object {
+                              "children": <AuthenticatedRoute
+                                authenticated={true}
+                                component={[Function]}
+                                path="/dashboard"
+                              />,
+                            }
+                          }
+                          wrappingComponentProps={null}
+                        />,
+                      },
+                      "tag": 0,
+                    },
+                    "lastCapturedEffect": null,
+                    "lastCapturedUpdate": null,
+                    "lastEffect": null,
+                    "lastUpdate": Object {
+                      "callback": null,
+                      "expirationTime": 1073741823,
+                      "next": null,
+                      "nextEffect": null,
+                      "payload": Object {
+                        "element": <WrapperComponent
+                          Component={[Function]}
+                          context={null}
+                          props={
+                            Object {
+                              "children": <AuthenticatedRoute
+                                authenticated={true}
+                                component={[Function]}
+                                path="/dashboard"
+                              />,
+                            }
+                          }
+                          wrappingComponentProps={null}
+                        />,
+                      },
+                      "tag": 0,
+                    },
+                  },
+                },
+                "child": [Circular],
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 32,
+                "elementType": null,
+                "expirationTime": 0,
+                "firstEffect": [Circular],
+                "index": 0,
+                "key": null,
+                "lastEffect": [Circular],
+                "memoizedProps": null,
+                "memoizedState": Object {
+                  "element": <WrapperComponent
+                    Component={[Function]}
+                    context={null}
+                    props={
+                      Object {
+                        "children": <AuthenticatedRoute
+                          authenticated={true}
+                          component={[Function]}
+                          path="/dashboard"
+                        />,
+                      }
+                    }
+                    wrappingComponentProps={null}
+                  />,
+                },
+                "mode": 0,
+                "nextEffect": null,
+                "pendingProps": null,
+                "ref": null,
+                "return": null,
+                "selfBaseDuration": 0,
+                "sibling": null,
+                "stateNode": Object {
+                  "containerInfo": <div />,
+                  "context": Object {},
+                  "current": [Circular],
+                  "didError": false,
+                  "earliestPendingTime": 0,
+                  "earliestSuspendedTime": 0,
+                  "expirationTime": 0,
+                  "finishedWork": null,
+                  "firstBatch": null,
+                  "hydrate": false,
+                  "interactionThreadID": 15,
+                  "latestPendingTime": 0,
+                  "latestPingedTime": 0,
+                  "latestSuspendedTime": 0,
+                  "memoizedInteractions": Set {},
+                  "nextExpirationTimeToWorkOn": 0,
+                  "nextScheduledRoot": null,
+                  "pendingChildren": null,
+                  "pendingCommitExpirationTime": 0,
+                  "pendingContext": null,
+                  "pendingInteractionMap": Map {},
+                  "pingCache": null,
+                  "timeoutHandle": -1,
+                },
+                "tag": 3,
+                "treeBaseDuration": 0,
+                "type": null,
+                "updateQueue": Object {
+                  "baseState": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={
+                        Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        }
+                      }
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "firstCapturedEffect": null,
+                  "firstCapturedUpdate": null,
+                  "firstEffect": null,
+                  "firstUpdate": null,
+                  "lastCapturedEffect": null,
+                  "lastCapturedUpdate": null,
+                  "lastEffect": null,
+                  "lastUpdate": null,
+                },
+              },
+              "selfBaseDuration": 0,
+              "sibling": null,
+              "stateNode": WrapperComponent {
+                "_reactInternalFiber": [Circular],
+                "_reactInternalInstance": Object {},
+                "context": Object {},
+                "props": Object {
+                  "Component": [Function],
+                  "context": null,
+                  "props": Object {
+                    "children": <AuthenticatedRoute
+                      authenticated={true}
+                      component={[Function]}
+                      path="/dashboard"
+                    />,
+                  },
+                  "wrappingComponentProps": null,
+                },
+                "refs": Object {},
+                "rootFinderInstance": null,
+                "state": Object {
+                  "context": null,
+                  "mount": true,
+                  "props": Object {
+                    "children": <AuthenticatedRoute
+                      authenticated={true}
+                      component={[Function]}
+                      path="/dashboard"
+                    />,
+                  },
+                  "wrappingComponentProps": null,
+                },
+                "updater": Object {
+                  "enqueueForceUpdate": [Function],
+                  "enqueueReplaceState": [Function],
+                  "enqueueSetState": [Function],
+                  "isMounted": [Function],
+                },
+              },
+              "tag": 1,
+              "treeBaseDuration": 0,
+              "type": [Function],
+              "updateQueue": null,
+            },
+            "_debugSource": null,
+            "actualDuration": 0,
+            "actualStartTime": -1,
+            "alternate": null,
+            "child": [Circular],
+            "childExpirationTime": 0,
+            "contextDependencies": null,
+            "effectTag": 1,
+            "elementType": [Function],
+            "expirationTime": 0,
+            "firstEffect": null,
+            "index": 0,
+            "key": null,
+            "lastEffect": null,
+            "memoizedProps": Object {
+              "children": <AuthenticatedRoute
+                authenticated={true}
+                component={[Function]}
+                path="/dashboard"
+              />,
+            },
+            "memoizedState": null,
+            "mode": 0,
+            "nextEffect": null,
+            "pendingProps": Object {
+              "children": <AuthenticatedRoute
+                authenticated={true}
+                component={[Function]}
+                path="/dashboard"
+              />,
+            },
+            "ref": null,
+            "return": FiberNode {
+              "_debugHookTypes": null,
+              "_debugID": 62,
+              "_debugIsCurrentlyTiming": false,
+              "_debugOwner": null,
+              "_debugSource": null,
+              "actualDuration": 0,
+              "actualStartTime": -1,
+              "alternate": null,
+              "child": [Circular],
+              "childExpirationTime": 0,
+              "contextDependencies": null,
+              "effectTag": 1,
+              "elementType": [Function],
+              "expirationTime": 0,
+              "firstEffect": null,
+              "index": 0,
+              "key": null,
+              "lastEffect": null,
+              "memoizedProps": Object {
+                "Component": [Function],
+                "context": null,
+                "props": Object {
+                  "children": <AuthenticatedRoute
+                    authenticated={true}
+                    component={[Function]}
+                    path="/dashboard"
+                  />,
+                },
+                "wrappingComponentProps": null,
+              },
+              "memoizedState": Object {
+                "context": null,
+                "mount": true,
+                "props": Object {
+                  "children": <AuthenticatedRoute
+                    authenticated={true}
+                    component={[Function]}
+                    path="/dashboard"
+                  />,
+                },
+                "wrappingComponentProps": null,
+              },
+              "mode": 0,
+              "nextEffect": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 60,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": null,
+                "_debugSource": null,
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 60,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": null,
+                  "_debugSource": null,
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": [Circular],
+                  "child": null,
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 0,
+                  "elementType": null,
+                  "expirationTime": 1073741823,
+                  "firstEffect": null,
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": null,
+                  "memoizedProps": null,
+                  "memoizedState": null,
+                  "mode": 0,
+                  "nextEffect": null,
+                  "pendingProps": null,
+                  "ref": null,
+                  "return": null,
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": Object {
+                    "containerInfo": <div />,
+                    "context": Object {},
+                    "current": [Circular],
+                    "didError": false,
+                    "earliestPendingTime": 0,
+                    "earliestSuspendedTime": 0,
+                    "expirationTime": 0,
+                    "finishedWork": null,
+                    "firstBatch": null,
+                    "hydrate": false,
+                    "interactionThreadID": 15,
+                    "latestPendingTime": 0,
+                    "latestPingedTime": 0,
+                    "latestSuspendedTime": 0,
+                    "memoizedInteractions": Set {},
+                    "nextExpirationTimeToWorkOn": 0,
+                    "nextScheduledRoot": null,
+                    "pendingChildren": null,
+                    "pendingCommitExpirationTime": 0,
+                    "pendingContext": null,
+                    "pendingInteractionMap": Map {},
+                    "pingCache": null,
+                    "timeoutHandle": -1,
+                  },
+                  "tag": 3,
+                  "treeBaseDuration": 0,
+                  "type": null,
+                  "updateQueue": Object {
+                    "baseState": null,
+                    "firstCapturedEffect": null,
+                    "firstCapturedUpdate": null,
+                    "firstEffect": null,
+                    "firstUpdate": Object {
+                      "callback": null,
+                      "expirationTime": 1073741823,
+                      "next": null,
+                      "nextEffect": null,
+                      "payload": Object {
+                        "element": <WrapperComponent
+                          Component={[Function]}
+                          context={null}
+                          props={
+                            Object {
+                              "children": <AuthenticatedRoute
+                                authenticated={true}
+                                component={[Function]}
+                                path="/dashboard"
+                              />,
+                            }
+                          }
+                          wrappingComponentProps={null}
+                        />,
+                      },
+                      "tag": 0,
+                    },
+                    "lastCapturedEffect": null,
+                    "lastCapturedUpdate": null,
+                    "lastEffect": null,
+                    "lastUpdate": Object {
+                      "callback": null,
+                      "expirationTime": 1073741823,
+                      "next": null,
+                      "nextEffect": null,
+                      "payload": Object {
+                        "element": <WrapperComponent
+                          Component={[Function]}
+                          context={null}
+                          props={
+                            Object {
+                              "children": <AuthenticatedRoute
+                                authenticated={true}
+                                component={[Function]}
+                                path="/dashboard"
+                              />,
+                            }
+                          }
+                          wrappingComponentProps={null}
+                        />,
+                      },
+                      "tag": 0,
+                    },
+                  },
+                },
+                "child": [Circular],
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 32,
+                "elementType": null,
+                "expirationTime": 0,
+                "firstEffect": [Circular],
+                "index": 0,
+                "key": null,
+                "lastEffect": [Circular],
+                "memoizedProps": null,
+                "memoizedState": Object {
+                  "element": <WrapperComponent
+                    Component={[Function]}
+                    context={null}
+                    props={
+                      Object {
+                        "children": <AuthenticatedRoute
+                          authenticated={true}
+                          component={[Function]}
+                          path="/dashboard"
+                        />,
+                      }
+                    }
+                    wrappingComponentProps={null}
+                  />,
+                },
+                "mode": 0,
+                "nextEffect": null,
+                "pendingProps": null,
+                "ref": null,
+                "return": null,
+                "selfBaseDuration": 0,
+                "sibling": null,
+                "stateNode": Object {
+                  "containerInfo": <div />,
+                  "context": Object {},
+                  "current": [Circular],
+                  "didError": false,
+                  "earliestPendingTime": 0,
+                  "earliestSuspendedTime": 0,
+                  "expirationTime": 0,
+                  "finishedWork": null,
+                  "firstBatch": null,
+                  "hydrate": false,
+                  "interactionThreadID": 15,
+                  "latestPendingTime": 0,
+                  "latestPingedTime": 0,
+                  "latestSuspendedTime": 0,
+                  "memoizedInteractions": Set {},
+                  "nextExpirationTimeToWorkOn": 0,
+                  "nextScheduledRoot": null,
+                  "pendingChildren": null,
+                  "pendingCommitExpirationTime": 0,
+                  "pendingContext": null,
+                  "pendingInteractionMap": Map {},
+                  "pingCache": null,
+                  "timeoutHandle": -1,
+                },
+                "tag": 3,
+                "treeBaseDuration": 0,
+                "type": null,
+                "updateQueue": Object {
+                  "baseState": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={
+                        Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        }
+                      }
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "firstCapturedEffect": null,
+                  "firstCapturedUpdate": null,
+                  "firstEffect": null,
+                  "firstUpdate": null,
+                  "lastCapturedEffect": null,
+                  "lastCapturedUpdate": null,
+                  "lastEffect": null,
+                  "lastUpdate": null,
+                },
+              },
+              "pendingProps": Object {
+                "Component": [Function],
+                "context": null,
+                "props": Object {
+                  "children": <AuthenticatedRoute
+                    authenticated={true}
+                    component={[Function]}
+                    path="/dashboard"
+                  />,
+                },
+                "wrappingComponentProps": null,
+              },
+              "ref": null,
+              "return": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 60,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": null,
+                "_debugSource": null,
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 60,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": null,
+                  "_debugSource": null,
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": [Circular],
+                  "child": null,
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 0,
+                  "elementType": null,
+                  "expirationTime": 1073741823,
+                  "firstEffect": null,
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": null,
+                  "memoizedProps": null,
+                  "memoizedState": null,
+                  "mode": 0,
+                  "nextEffect": null,
+                  "pendingProps": null,
+                  "ref": null,
+                  "return": null,
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": Object {
+                    "containerInfo": <div />,
+                    "context": Object {},
+                    "current": [Circular],
+                    "didError": false,
+                    "earliestPendingTime": 0,
+                    "earliestSuspendedTime": 0,
+                    "expirationTime": 0,
+                    "finishedWork": null,
+                    "firstBatch": null,
+                    "hydrate": false,
+                    "interactionThreadID": 15,
+                    "latestPendingTime": 0,
+                    "latestPingedTime": 0,
+                    "latestSuspendedTime": 0,
+                    "memoizedInteractions": Set {},
+                    "nextExpirationTimeToWorkOn": 0,
+                    "nextScheduledRoot": null,
+                    "pendingChildren": null,
+                    "pendingCommitExpirationTime": 0,
+                    "pendingContext": null,
+                    "pendingInteractionMap": Map {},
+                    "pingCache": null,
+                    "timeoutHandle": -1,
+                  },
+                  "tag": 3,
+                  "treeBaseDuration": 0,
+                  "type": null,
+                  "updateQueue": Object {
+                    "baseState": null,
+                    "firstCapturedEffect": null,
+                    "firstCapturedUpdate": null,
+                    "firstEffect": null,
+                    "firstUpdate": Object {
+                      "callback": null,
+                      "expirationTime": 1073741823,
+                      "next": null,
+                      "nextEffect": null,
+                      "payload": Object {
+                        "element": <WrapperComponent
+                          Component={[Function]}
+                          context={null}
+                          props={
+                            Object {
+                              "children": <AuthenticatedRoute
+                                authenticated={true}
+                                component={[Function]}
+                                path="/dashboard"
+                              />,
+                            }
+                          }
+                          wrappingComponentProps={null}
+                        />,
+                      },
+                      "tag": 0,
+                    },
+                    "lastCapturedEffect": null,
+                    "lastCapturedUpdate": null,
+                    "lastEffect": null,
+                    "lastUpdate": Object {
+                      "callback": null,
+                      "expirationTime": 1073741823,
+                      "next": null,
+                      "nextEffect": null,
+                      "payload": Object {
+                        "element": <WrapperComponent
+                          Component={[Function]}
+                          context={null}
+                          props={
+                            Object {
+                              "children": <AuthenticatedRoute
+                                authenticated={true}
+                                component={[Function]}
+                                path="/dashboard"
+                              />,
+                            }
+                          }
+                          wrappingComponentProps={null}
+                        />,
+                      },
+                      "tag": 0,
+                    },
+                  },
+                },
+                "child": [Circular],
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 32,
+                "elementType": null,
+                "expirationTime": 0,
+                "firstEffect": [Circular],
+                "index": 0,
+                "key": null,
+                "lastEffect": [Circular],
+                "memoizedProps": null,
+                "memoizedState": Object {
+                  "element": <WrapperComponent
+                    Component={[Function]}
+                    context={null}
+                    props={
+                      Object {
+                        "children": <AuthenticatedRoute
+                          authenticated={true}
+                          component={[Function]}
+                          path="/dashboard"
+                        />,
+                      }
+                    }
+                    wrappingComponentProps={null}
+                  />,
+                },
+                "mode": 0,
+                "nextEffect": null,
+                "pendingProps": null,
+                "ref": null,
+                "return": null,
+                "selfBaseDuration": 0,
+                "sibling": null,
+                "stateNode": Object {
+                  "containerInfo": <div />,
+                  "context": Object {},
+                  "current": [Circular],
+                  "didError": false,
+                  "earliestPendingTime": 0,
+                  "earliestSuspendedTime": 0,
+                  "expirationTime": 0,
+                  "finishedWork": null,
+                  "firstBatch": null,
+                  "hydrate": false,
+                  "interactionThreadID": 15,
+                  "latestPendingTime": 0,
+                  "latestPingedTime": 0,
+                  "latestSuspendedTime": 0,
+                  "memoizedInteractions": Set {},
+                  "nextExpirationTimeToWorkOn": 0,
+                  "nextScheduledRoot": null,
+                  "pendingChildren": null,
+                  "pendingCommitExpirationTime": 0,
+                  "pendingContext": null,
+                  "pendingInteractionMap": Map {},
+                  "pingCache": null,
+                  "timeoutHandle": -1,
+                },
+                "tag": 3,
+                "treeBaseDuration": 0,
+                "type": null,
+                "updateQueue": Object {
+                  "baseState": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={
+                        Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        }
+                      }
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "firstCapturedEffect": null,
+                  "firstCapturedUpdate": null,
+                  "firstEffect": null,
+                  "firstUpdate": null,
+                  "lastCapturedEffect": null,
+                  "lastCapturedUpdate": null,
+                  "lastEffect": null,
+                  "lastUpdate": null,
+                },
+              },
+              "selfBaseDuration": 0,
+              "sibling": null,
+              "stateNode": WrapperComponent {
+                "_reactInternalFiber": [Circular],
+                "_reactInternalInstance": Object {},
+                "context": Object {},
+                "props": Object {
+                  "Component": [Function],
+                  "context": null,
+                  "props": Object {
+                    "children": <AuthenticatedRoute
+                      authenticated={true}
+                      component={[Function]}
+                      path="/dashboard"
+                    />,
+                  },
+                  "wrappingComponentProps": null,
+                },
+                "refs": Object {},
+                "rootFinderInstance": null,
+                "state": Object {
+                  "context": null,
+                  "mount": true,
+                  "props": Object {
+                    "children": <AuthenticatedRoute
+                      authenticated={true}
+                      component={[Function]}
+                      path="/dashboard"
+                    />,
+                  },
+                  "wrappingComponentProps": null,
+                },
+                "updater": Object {
+                  "enqueueForceUpdate": [Function],
+                  "enqueueReplaceState": [Function],
+                  "enqueueSetState": [Function],
+                  "isMounted": [Function],
+                },
+              },
+              "tag": 1,
+              "treeBaseDuration": 0,
+              "type": [Function],
+              "updateQueue": null,
+            },
+            "selfBaseDuration": 0,
+            "sibling": null,
+            "stateNode": BrowserRouter {
+              "_reactInternalFiber": [Circular],
+              "_reactInternalInstance": Object {},
+              "context": Object {},
+              "history": Object {
+                "action": "POP",
+                "block": [Function],
+                "createHref": [Function],
+                "go": [Function],
+                "goBack": [Function],
+                "goForward": [Function],
+                "length": 1,
+                "listen": [Function],
+                "location": Object {
+                  "hash": "",
+                  "pathname": "/",
+                  "search": "",
+                  "state": undefined,
+                },
+                "push": [Function],
+                "replace": [Function],
+              },
+              "props": Object {
+                "children": <AuthenticatedRoute
+                  authenticated={true}
+                  component={[Function]}
+                  path="/dashboard"
+                />,
+              },
+              "refs": Object {},
+              "state": null,
+              "updater": Object {
+                "enqueueForceUpdate": [Function],
+                "enqueueReplaceState": [Function],
+                "enqueueSetState": [Function],
+                "isMounted": [Function],
+              },
+            },
+            "tag": 1,
+            "treeBaseDuration": 0,
+            "type": [Function],
+            "updateQueue": null,
+          },
+          "_debugSource": null,
+          "actualDuration": 0,
+          "actualStartTime": -1,
+          "alternate": null,
+          "child": FiberNode {
+            "_debugHookTypes": null,
+            "_debugID": 65,
+            "_debugIsCurrentlyTiming": false,
+            "_debugOwner": null,
+            "_debugSource": Object {
+              "fileName": "/Users/chucky/Code/Bench/bp-esa-frontend/src/App.test.jsx",
+              "lineNumber": 123,
+            },
+            "actualDuration": 0,
+            "actualStartTime": -1,
+            "alternate": null,
+            "child": FiberNode {
+              "_debugHookTypes": null,
+              "_debugID": 66,
+              "_debugIsCurrentlyTiming": false,
+              "_debugOwner": [Circular],
+              "_debugSource": Object {
+                "fileName": "/Users/chucky/Code/Bench/bp-esa-frontend/src/App.jsx",
+                "lineNumber": 15,
+              },
+              "actualDuration": 0,
+              "actualStartTime": -1,
+              "alternate": null,
+              "child": null,
+              "childExpirationTime": 0,
+              "contextDependencies": null,
+              "effectTag": 1,
+              "elementType": [Function],
+              "expirationTime": 0,
+              "firstEffect": null,
+              "index": 0,
+              "key": null,
+              "lastEffect": null,
+              "memoizedProps": Object {
+                "path": "/dashboard",
+                "render": [Function],
+              },
+              "memoizedState": Object {
+                "match": null,
+              },
+              "mode": 0,
+              "nextEffect": null,
+              "pendingProps": Object {
+                "path": "/dashboard",
+                "render": [Function],
+              },
+              "ref": null,
+              "return": [Circular],
+              "selfBaseDuration": 0,
+              "sibling": null,
+              "stateNode": Route {
+                "__reactInternalMemoizedMaskedChildContext": Object {
+                  "router": Object {
+                    "history": Object {
+                      "action": "POP",
+                      "block": [Function],
+                      "createHref": [Function],
+                      "go": [Function],
+                      "goBack": [Function],
+                      "goForward": [Function],
+                      "length": 1,
+                      "listen": [Function],
+                      "location": Object {
+                        "hash": "",
+                        "pathname": "/",
+                        "search": "",
+                        "state": undefined,
+                      },
+                      "push": [Function],
+                      "replace": [Function],
+                    },
+                    "route": Object {
+                      "location": Object {
+                        "hash": "",
+                        "pathname": "/",
+                        "search": "",
+                        "state": undefined,
+                      },
+                      "match": Object {
+                        "isExact": true,
+                        "params": Object {},
+                        "path": "/",
+                        "url": "/",
+                      },
+                    },
+                  },
+                },
+                "__reactInternalMemoizedMergedChildContext": Object {
+                  "router": Object {
+                    "history": Object {
+                      "action": "POP",
+                      "block": [Function],
+                      "createHref": [Function],
+                      "go": [Function],
+                      "goBack": [Function],
+                      "goForward": [Function],
+                      "length": 1,
+                      "listen": [Function],
+                      "location": Object {
+                        "hash": "",
+                        "pathname": "/",
+                        "search": "",
+                        "state": undefined,
+                      },
+                      "push": [Function],
+                      "replace": [Function],
+                    },
+                    "route": Object {
+                      "location": Object {
+                        "hash": "",
+                        "pathname": "/",
+                        "search": "",
+                        "state": undefined,
+                      },
+                      "match": null,
+                    },
+                  },
+                },
+                "__reactInternalMemoizedUnmaskedChildContext": Object {
+                  "router": Object {
+                    "history": Object {
+                      "action": "POP",
+                      "block": [Function],
+                      "createHref": [Function],
+                      "go": [Function],
+                      "goBack": [Function],
+                      "goForward": [Function],
+                      "length": 1,
+                      "listen": [Function],
+                      "location": Object {
+                        "hash": "",
+                        "pathname": "/",
+                        "search": "",
+                        "state": undefined,
+                      },
+                      "push": [Function],
+                      "replace": [Function],
+                    },
+                    "route": Object {
+                      "location": Object {
+                        "hash": "",
+                        "pathname": "/",
+                        "search": "",
+                        "state": undefined,
+                      },
+                      "match": Object {
+                        "isExact": true,
+                        "params": Object {},
+                        "path": "/",
+                        "url": "/",
+                      },
+                    },
+                  },
+                },
+                "_reactInternalFiber": [Circular],
+                "_reactInternalInstance": Object {},
+                "context": Object {
+                  "router": Object {
+                    "history": Object {
+                      "action": "POP",
+                      "block": [Function],
+                      "createHref": [Function],
+                      "go": [Function],
+                      "goBack": [Function],
+                      "goForward": [Function],
+                      "length": 1,
+                      "listen": [Function],
+                      "location": Object {
+                        "hash": "",
+                        "pathname": "/",
+                        "search": "",
+                        "state": undefined,
+                      },
+                      "push": [Function],
+                      "replace": [Function],
+                    },
+                    "route": Object {
+                      "location": Object {
+                        "hash": "",
+                        "pathname": "/",
+                        "search": "",
+                        "state": undefined,
+                      },
+                      "match": Object {
+                        "isExact": true,
+                        "params": Object {},
+                        "path": "/",
+                        "url": "/",
+                      },
+                    },
+                  },
+                },
+                "props": Object {
+                  "path": "/dashboard",
+                  "render": [Function],
+                },
+                "refs": Object {},
+                "state": Object {
+                  "match": null,
+                },
+                "updater": Object {
+                  "enqueueForceUpdate": [Function],
+                  "enqueueReplaceState": [Function],
+                  "enqueueSetState": [Function],
+                  "isMounted": [Function],
+                },
+              },
+              "tag": 1,
+              "treeBaseDuration": 0,
+              "type": [Function],
+              "updateQueue": null,
+            },
+            "childExpirationTime": 0,
+            "contextDependencies": null,
+            "effectTag": 1,
+            "elementType": [Function],
+            "expirationTime": 0,
+            "firstEffect": null,
+            "index": 0,
+            "key": null,
+            "lastEffect": null,
+            "memoizedProps": Object {
+              "authenticated": true,
+              "component": [Function],
+              "path": "/dashboard",
+            },
+            "memoizedState": null,
+            "mode": 0,
+            "nextEffect": null,
+            "pendingProps": Object {
+              "authenticated": true,
+              "component": [Function],
+              "path": "/dashboard",
+            },
+            "ref": null,
+            "return": [Circular],
+            "selfBaseDuration": 0,
+            "sibling": null,
+            "stateNode": null,
+            "tag": 0,
+            "treeBaseDuration": 0,
+            "type": [Function],
+            "updateQueue": null,
+          },
+          "childExpirationTime": 0,
+          "contextDependencies": null,
+          "effectTag": 1,
+          "elementType": [Function],
+          "expirationTime": 0,
+          "firstEffect": null,
+          "index": 0,
+          "key": null,
+          "lastEffect": null,
+          "memoizedProps": Object {
+            "children": <AuthenticatedRoute
+              authenticated={true}
+              component={[Function]}
+              path="/dashboard"
+            />,
+            "history": Object {
+              "action": "POP",
+              "block": [Function],
+              "createHref": [Function],
+              "go": [Function],
+              "goBack": [Function],
+              "goForward": [Function],
+              "length": 1,
+              "listen": [Function],
+              "location": Object {
+                "hash": "",
+                "pathname": "/",
+                "search": "",
+                "state": undefined,
+              },
+              "push": [Function],
+              "replace": [Function],
+            },
+          },
+          "memoizedState": Object {
+            "match": Object {
+              "isExact": true,
+              "params": Object {},
+              "path": "/",
+              "url": "/",
+            },
+          },
+          "mode": 0,
+          "nextEffect": null,
+          "pendingProps": Object {
+            "children": <AuthenticatedRoute
+              authenticated={true}
+              component={[Function]}
+              path="/dashboard"
+            />,
+            "history": Object {
+              "action": "POP",
+              "block": [Function],
+              "createHref": [Function],
+              "go": [Function],
+              "goBack": [Function],
+              "goForward": [Function],
+              "length": 1,
+              "listen": [Function],
+              "location": Object {
+                "hash": "",
+                "pathname": "/",
+                "search": "",
+                "state": undefined,
+              },
+              "push": [Function],
+              "replace": [Function],
+            },
+          },
+          "ref": null,
+          "return": FiberNode {
+            "_debugHookTypes": null,
+            "_debugID": 63,
+            "_debugIsCurrentlyTiming": false,
+            "_debugOwner": FiberNode {
+              "_debugHookTypes": null,
+              "_debugID": 62,
+              "_debugIsCurrentlyTiming": false,
+              "_debugOwner": null,
+              "_debugSource": null,
+              "actualDuration": 0,
+              "actualStartTime": -1,
+              "alternate": null,
+              "child": [Circular],
+              "childExpirationTime": 0,
+              "contextDependencies": null,
+              "effectTag": 1,
+              "elementType": [Function],
+              "expirationTime": 0,
+              "firstEffect": null,
+              "index": 0,
+              "key": null,
+              "lastEffect": null,
+              "memoizedProps": Object {
+                "Component": [Function],
+                "context": null,
+                "props": Object {
+                  "children": <AuthenticatedRoute
+                    authenticated={true}
+                    component={[Function]}
+                    path="/dashboard"
+                  />,
+                },
+                "wrappingComponentProps": null,
+              },
+              "memoizedState": Object {
+                "context": null,
+                "mount": true,
+                "props": Object {
+                  "children": <AuthenticatedRoute
+                    authenticated={true}
+                    component={[Function]}
+                    path="/dashboard"
+                  />,
+                },
+                "wrappingComponentProps": null,
+              },
+              "mode": 0,
+              "nextEffect": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 60,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": null,
+                "_debugSource": null,
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 60,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": null,
+                  "_debugSource": null,
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": [Circular],
+                  "child": null,
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 0,
+                  "elementType": null,
+                  "expirationTime": 1073741823,
+                  "firstEffect": null,
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": null,
+                  "memoizedProps": null,
+                  "memoizedState": null,
+                  "mode": 0,
+                  "nextEffect": null,
+                  "pendingProps": null,
+                  "ref": null,
+                  "return": null,
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": Object {
+                    "containerInfo": <div />,
+                    "context": Object {},
+                    "current": [Circular],
+                    "didError": false,
+                    "earliestPendingTime": 0,
+                    "earliestSuspendedTime": 0,
+                    "expirationTime": 0,
+                    "finishedWork": null,
+                    "firstBatch": null,
+                    "hydrate": false,
+                    "interactionThreadID": 15,
+                    "latestPendingTime": 0,
+                    "latestPingedTime": 0,
+                    "latestSuspendedTime": 0,
+                    "memoizedInteractions": Set {},
+                    "nextExpirationTimeToWorkOn": 0,
+                    "nextScheduledRoot": null,
+                    "pendingChildren": null,
+                    "pendingCommitExpirationTime": 0,
+                    "pendingContext": null,
+                    "pendingInteractionMap": Map {},
+                    "pingCache": null,
+                    "timeoutHandle": -1,
+                  },
+                  "tag": 3,
+                  "treeBaseDuration": 0,
+                  "type": null,
+                  "updateQueue": Object {
+                    "baseState": null,
+                    "firstCapturedEffect": null,
+                    "firstCapturedUpdate": null,
+                    "firstEffect": null,
+                    "firstUpdate": Object {
+                      "callback": null,
+                      "expirationTime": 1073741823,
+                      "next": null,
+                      "nextEffect": null,
+                      "payload": Object {
+                        "element": <WrapperComponent
+                          Component={[Function]}
+                          context={null}
+                          props={
+                            Object {
+                              "children": <AuthenticatedRoute
+                                authenticated={true}
+                                component={[Function]}
+                                path="/dashboard"
+                              />,
+                            }
+                          }
+                          wrappingComponentProps={null}
+                        />,
+                      },
+                      "tag": 0,
+                    },
+                    "lastCapturedEffect": null,
+                    "lastCapturedUpdate": null,
+                    "lastEffect": null,
+                    "lastUpdate": Object {
+                      "callback": null,
+                      "expirationTime": 1073741823,
+                      "next": null,
+                      "nextEffect": null,
+                      "payload": Object {
+                        "element": <WrapperComponent
+                          Component={[Function]}
+                          context={null}
+                          props={
+                            Object {
+                              "children": <AuthenticatedRoute
+                                authenticated={true}
+                                component={[Function]}
+                                path="/dashboard"
+                              />,
+                            }
+                          }
+                          wrappingComponentProps={null}
+                        />,
+                      },
+                      "tag": 0,
+                    },
+                  },
+                },
+                "child": [Circular],
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 32,
+                "elementType": null,
+                "expirationTime": 0,
+                "firstEffect": [Circular],
+                "index": 0,
+                "key": null,
+                "lastEffect": [Circular],
+                "memoizedProps": null,
+                "memoizedState": Object {
+                  "element": <WrapperComponent
+                    Component={[Function]}
+                    context={null}
+                    props={
+                      Object {
+                        "children": <AuthenticatedRoute
+                          authenticated={true}
+                          component={[Function]}
+                          path="/dashboard"
+                        />,
+                      }
+                    }
+                    wrappingComponentProps={null}
+                  />,
+                },
+                "mode": 0,
+                "nextEffect": null,
+                "pendingProps": null,
+                "ref": null,
+                "return": null,
+                "selfBaseDuration": 0,
+                "sibling": null,
+                "stateNode": Object {
+                  "containerInfo": <div />,
+                  "context": Object {},
+                  "current": [Circular],
+                  "didError": false,
+                  "earliestPendingTime": 0,
+                  "earliestSuspendedTime": 0,
+                  "expirationTime": 0,
+                  "finishedWork": null,
+                  "firstBatch": null,
+                  "hydrate": false,
+                  "interactionThreadID": 15,
+                  "latestPendingTime": 0,
+                  "latestPingedTime": 0,
+                  "latestSuspendedTime": 0,
+                  "memoizedInteractions": Set {},
+                  "nextExpirationTimeToWorkOn": 0,
+                  "nextScheduledRoot": null,
+                  "pendingChildren": null,
+                  "pendingCommitExpirationTime": 0,
+                  "pendingContext": null,
+                  "pendingInteractionMap": Map {},
+                  "pingCache": null,
+                  "timeoutHandle": -1,
+                },
+                "tag": 3,
+                "treeBaseDuration": 0,
+                "type": null,
+                "updateQueue": Object {
+                  "baseState": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={
+                        Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        }
+                      }
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "firstCapturedEffect": null,
+                  "firstCapturedUpdate": null,
+                  "firstEffect": null,
+                  "firstUpdate": null,
+                  "lastCapturedEffect": null,
+                  "lastCapturedUpdate": null,
+                  "lastEffect": null,
+                  "lastUpdate": null,
+                },
+              },
+              "pendingProps": Object {
+                "Component": [Function],
+                "context": null,
+                "props": Object {
+                  "children": <AuthenticatedRoute
+                    authenticated={true}
+                    component={[Function]}
+                    path="/dashboard"
+                  />,
+                },
+                "wrappingComponentProps": null,
+              },
+              "ref": null,
+              "return": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 60,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": null,
+                "_debugSource": null,
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 60,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": null,
+                  "_debugSource": null,
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": [Circular],
+                  "child": null,
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 0,
+                  "elementType": null,
+                  "expirationTime": 1073741823,
+                  "firstEffect": null,
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": null,
+                  "memoizedProps": null,
+                  "memoizedState": null,
+                  "mode": 0,
+                  "nextEffect": null,
+                  "pendingProps": null,
+                  "ref": null,
+                  "return": null,
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": Object {
+                    "containerInfo": <div />,
+                    "context": Object {},
+                    "current": [Circular],
+                    "didError": false,
+                    "earliestPendingTime": 0,
+                    "earliestSuspendedTime": 0,
+                    "expirationTime": 0,
+                    "finishedWork": null,
+                    "firstBatch": null,
+                    "hydrate": false,
+                    "interactionThreadID": 15,
+                    "latestPendingTime": 0,
+                    "latestPingedTime": 0,
+                    "latestSuspendedTime": 0,
+                    "memoizedInteractions": Set {},
+                    "nextExpirationTimeToWorkOn": 0,
+                    "nextScheduledRoot": null,
+                    "pendingChildren": null,
+                    "pendingCommitExpirationTime": 0,
+                    "pendingContext": null,
+                    "pendingInteractionMap": Map {},
+                    "pingCache": null,
+                    "timeoutHandle": -1,
+                  },
+                  "tag": 3,
+                  "treeBaseDuration": 0,
+                  "type": null,
+                  "updateQueue": Object {
+                    "baseState": null,
+                    "firstCapturedEffect": null,
+                    "firstCapturedUpdate": null,
+                    "firstEffect": null,
+                    "firstUpdate": Object {
+                      "callback": null,
+                      "expirationTime": 1073741823,
+                      "next": null,
+                      "nextEffect": null,
+                      "payload": Object {
+                        "element": <WrapperComponent
+                          Component={[Function]}
+                          context={null}
+                          props={
+                            Object {
+                              "children": <AuthenticatedRoute
+                                authenticated={true}
+                                component={[Function]}
+                                path="/dashboard"
+                              />,
+                            }
+                          }
+                          wrappingComponentProps={null}
+                        />,
+                      },
+                      "tag": 0,
+                    },
+                    "lastCapturedEffect": null,
+                    "lastCapturedUpdate": null,
+                    "lastEffect": null,
+                    "lastUpdate": Object {
+                      "callback": null,
+                      "expirationTime": 1073741823,
+                      "next": null,
+                      "nextEffect": null,
+                      "payload": Object {
+                        "element": <WrapperComponent
+                          Component={[Function]}
+                          context={null}
+                          props={
+                            Object {
+                              "children": <AuthenticatedRoute
+                                authenticated={true}
+                                component={[Function]}
+                                path="/dashboard"
+                              />,
+                            }
+                          }
+                          wrappingComponentProps={null}
+                        />,
+                      },
+                      "tag": 0,
+                    },
+                  },
+                },
+                "child": [Circular],
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 32,
+                "elementType": null,
+                "expirationTime": 0,
+                "firstEffect": [Circular],
+                "index": 0,
+                "key": null,
+                "lastEffect": [Circular],
+                "memoizedProps": null,
+                "memoizedState": Object {
+                  "element": <WrapperComponent
+                    Component={[Function]}
+                    context={null}
+                    props={
+                      Object {
+                        "children": <AuthenticatedRoute
+                          authenticated={true}
+                          component={[Function]}
+                          path="/dashboard"
+                        />,
+                      }
+                    }
+                    wrappingComponentProps={null}
+                  />,
+                },
+                "mode": 0,
+                "nextEffect": null,
+                "pendingProps": null,
+                "ref": null,
+                "return": null,
+                "selfBaseDuration": 0,
+                "sibling": null,
+                "stateNode": Object {
+                  "containerInfo": <div />,
+                  "context": Object {},
+                  "current": [Circular],
+                  "didError": false,
+                  "earliestPendingTime": 0,
+                  "earliestSuspendedTime": 0,
+                  "expirationTime": 0,
+                  "finishedWork": null,
+                  "firstBatch": null,
+                  "hydrate": false,
+                  "interactionThreadID": 15,
+                  "latestPendingTime": 0,
+                  "latestPingedTime": 0,
+                  "latestSuspendedTime": 0,
+                  "memoizedInteractions": Set {},
+                  "nextExpirationTimeToWorkOn": 0,
+                  "nextScheduledRoot": null,
+                  "pendingChildren": null,
+                  "pendingCommitExpirationTime": 0,
+                  "pendingContext": null,
+                  "pendingInteractionMap": Map {},
+                  "pingCache": null,
+                  "timeoutHandle": -1,
+                },
+                "tag": 3,
+                "treeBaseDuration": 0,
+                "type": null,
+                "updateQueue": Object {
+                  "baseState": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={
+                        Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        }
+                      }
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "firstCapturedEffect": null,
+                  "firstCapturedUpdate": null,
+                  "firstEffect": null,
+                  "firstUpdate": null,
+                  "lastCapturedEffect": null,
+                  "lastCapturedUpdate": null,
+                  "lastEffect": null,
+                  "lastUpdate": null,
+                },
+              },
+              "selfBaseDuration": 0,
+              "sibling": null,
+              "stateNode": WrapperComponent {
+                "_reactInternalFiber": [Circular],
+                "_reactInternalInstance": Object {},
+                "context": Object {},
+                "props": Object {
+                  "Component": [Function],
+                  "context": null,
+                  "props": Object {
+                    "children": <AuthenticatedRoute
+                      authenticated={true}
+                      component={[Function]}
+                      path="/dashboard"
+                    />,
+                  },
+                  "wrappingComponentProps": null,
+                },
+                "refs": Object {},
+                "rootFinderInstance": null,
+                "state": Object {
+                  "context": null,
+                  "mount": true,
+                  "props": Object {
+                    "children": <AuthenticatedRoute
+                      authenticated={true}
+                      component={[Function]}
+                      path="/dashboard"
+                    />,
+                  },
+                  "wrappingComponentProps": null,
+                },
+                "updater": Object {
+                  "enqueueForceUpdate": [Function],
+                  "enqueueReplaceState": [Function],
+                  "enqueueSetState": [Function],
+                  "isMounted": [Function],
+                },
+              },
+              "tag": 1,
+              "treeBaseDuration": 0,
+              "type": [Function],
+              "updateQueue": null,
+            },
+            "_debugSource": null,
+            "actualDuration": 0,
+            "actualStartTime": -1,
+            "alternate": null,
+            "child": [Circular],
+            "childExpirationTime": 0,
+            "contextDependencies": null,
+            "effectTag": 1,
+            "elementType": [Function],
+            "expirationTime": 0,
+            "firstEffect": null,
+            "index": 0,
+            "key": null,
+            "lastEffect": null,
+            "memoizedProps": Object {
+              "children": <AuthenticatedRoute
+                authenticated={true}
+                component={[Function]}
+                path="/dashboard"
+              />,
+            },
+            "memoizedState": null,
+            "mode": 0,
+            "nextEffect": null,
+            "pendingProps": Object {
+              "children": <AuthenticatedRoute
+                authenticated={true}
+                component={[Function]}
+                path="/dashboard"
+              />,
+            },
+            "ref": null,
+            "return": FiberNode {
+              "_debugHookTypes": null,
+              "_debugID": 62,
+              "_debugIsCurrentlyTiming": false,
+              "_debugOwner": null,
+              "_debugSource": null,
+              "actualDuration": 0,
+              "actualStartTime": -1,
+              "alternate": null,
+              "child": [Circular],
+              "childExpirationTime": 0,
+              "contextDependencies": null,
+              "effectTag": 1,
+              "elementType": [Function],
+              "expirationTime": 0,
+              "firstEffect": null,
+              "index": 0,
+              "key": null,
+              "lastEffect": null,
+              "memoizedProps": Object {
+                "Component": [Function],
+                "context": null,
+                "props": Object {
+                  "children": <AuthenticatedRoute
+                    authenticated={true}
+                    component={[Function]}
+                    path="/dashboard"
+                  />,
+                },
+                "wrappingComponentProps": null,
+              },
+              "memoizedState": Object {
+                "context": null,
+                "mount": true,
+                "props": Object {
+                  "children": <AuthenticatedRoute
+                    authenticated={true}
+                    component={[Function]}
+                    path="/dashboard"
+                  />,
+                },
+                "wrappingComponentProps": null,
+              },
+              "mode": 0,
+              "nextEffect": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 60,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": null,
+                "_debugSource": null,
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 60,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": null,
+                  "_debugSource": null,
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": [Circular],
+                  "child": null,
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 0,
+                  "elementType": null,
+                  "expirationTime": 1073741823,
+                  "firstEffect": null,
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": null,
+                  "memoizedProps": null,
+                  "memoizedState": null,
+                  "mode": 0,
+                  "nextEffect": null,
+                  "pendingProps": null,
+                  "ref": null,
+                  "return": null,
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": Object {
+                    "containerInfo": <div />,
+                    "context": Object {},
+                    "current": [Circular],
+                    "didError": false,
+                    "earliestPendingTime": 0,
+                    "earliestSuspendedTime": 0,
+                    "expirationTime": 0,
+                    "finishedWork": null,
+                    "firstBatch": null,
+                    "hydrate": false,
+                    "interactionThreadID": 15,
+                    "latestPendingTime": 0,
+                    "latestPingedTime": 0,
+                    "latestSuspendedTime": 0,
+                    "memoizedInteractions": Set {},
+                    "nextExpirationTimeToWorkOn": 0,
+                    "nextScheduledRoot": null,
+                    "pendingChildren": null,
+                    "pendingCommitExpirationTime": 0,
+                    "pendingContext": null,
+                    "pendingInteractionMap": Map {},
+                    "pingCache": null,
+                    "timeoutHandle": -1,
+                  },
+                  "tag": 3,
+                  "treeBaseDuration": 0,
+                  "type": null,
+                  "updateQueue": Object {
+                    "baseState": null,
+                    "firstCapturedEffect": null,
+                    "firstCapturedUpdate": null,
+                    "firstEffect": null,
+                    "firstUpdate": Object {
+                      "callback": null,
+                      "expirationTime": 1073741823,
+                      "next": null,
+                      "nextEffect": null,
+                      "payload": Object {
+                        "element": <WrapperComponent
+                          Component={[Function]}
+                          context={null}
+                          props={
+                            Object {
+                              "children": <AuthenticatedRoute
+                                authenticated={true}
+                                component={[Function]}
+                                path="/dashboard"
+                              />,
+                            }
+                          }
+                          wrappingComponentProps={null}
+                        />,
+                      },
+                      "tag": 0,
+                    },
+                    "lastCapturedEffect": null,
+                    "lastCapturedUpdate": null,
+                    "lastEffect": null,
+                    "lastUpdate": Object {
+                      "callback": null,
+                      "expirationTime": 1073741823,
+                      "next": null,
+                      "nextEffect": null,
+                      "payload": Object {
+                        "element": <WrapperComponent
+                          Component={[Function]}
+                          context={null}
+                          props={
+                            Object {
+                              "children": <AuthenticatedRoute
+                                authenticated={true}
+                                component={[Function]}
+                                path="/dashboard"
+                              />,
+                            }
+                          }
+                          wrappingComponentProps={null}
+                        />,
+                      },
+                      "tag": 0,
+                    },
+                  },
+                },
+                "child": [Circular],
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 32,
+                "elementType": null,
+                "expirationTime": 0,
+                "firstEffect": [Circular],
+                "index": 0,
+                "key": null,
+                "lastEffect": [Circular],
+                "memoizedProps": null,
+                "memoizedState": Object {
+                  "element": <WrapperComponent
+                    Component={[Function]}
+                    context={null}
+                    props={
+                      Object {
+                        "children": <AuthenticatedRoute
+                          authenticated={true}
+                          component={[Function]}
+                          path="/dashboard"
+                        />,
+                      }
+                    }
+                    wrappingComponentProps={null}
+                  />,
+                },
+                "mode": 0,
+                "nextEffect": null,
+                "pendingProps": null,
+                "ref": null,
+                "return": null,
+                "selfBaseDuration": 0,
+                "sibling": null,
+                "stateNode": Object {
+                  "containerInfo": <div />,
+                  "context": Object {},
+                  "current": [Circular],
+                  "didError": false,
+                  "earliestPendingTime": 0,
+                  "earliestSuspendedTime": 0,
+                  "expirationTime": 0,
+                  "finishedWork": null,
+                  "firstBatch": null,
+                  "hydrate": false,
+                  "interactionThreadID": 15,
+                  "latestPendingTime": 0,
+                  "latestPingedTime": 0,
+                  "latestSuspendedTime": 0,
+                  "memoizedInteractions": Set {},
+                  "nextExpirationTimeToWorkOn": 0,
+                  "nextScheduledRoot": null,
+                  "pendingChildren": null,
+                  "pendingCommitExpirationTime": 0,
+                  "pendingContext": null,
+                  "pendingInteractionMap": Map {},
+                  "pingCache": null,
+                  "timeoutHandle": -1,
+                },
+                "tag": 3,
+                "treeBaseDuration": 0,
+                "type": null,
+                "updateQueue": Object {
+                  "baseState": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={
+                        Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        }
+                      }
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "firstCapturedEffect": null,
+                  "firstCapturedUpdate": null,
+                  "firstEffect": null,
+                  "firstUpdate": null,
+                  "lastCapturedEffect": null,
+                  "lastCapturedUpdate": null,
+                  "lastEffect": null,
+                  "lastUpdate": null,
+                },
+              },
+              "pendingProps": Object {
+                "Component": [Function],
+                "context": null,
+                "props": Object {
+                  "children": <AuthenticatedRoute
+                    authenticated={true}
+                    component={[Function]}
+                    path="/dashboard"
+                  />,
+                },
+                "wrappingComponentProps": null,
+              },
+              "ref": null,
+              "return": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 60,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": null,
+                "_debugSource": null,
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 60,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": null,
+                  "_debugSource": null,
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": [Circular],
+                  "child": null,
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 0,
+                  "elementType": null,
+                  "expirationTime": 1073741823,
+                  "firstEffect": null,
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": null,
+                  "memoizedProps": null,
+                  "memoizedState": null,
+                  "mode": 0,
+                  "nextEffect": null,
+                  "pendingProps": null,
+                  "ref": null,
+                  "return": null,
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": Object {
+                    "containerInfo": <div />,
+                    "context": Object {},
+                    "current": [Circular],
+                    "didError": false,
+                    "earliestPendingTime": 0,
+                    "earliestSuspendedTime": 0,
+                    "expirationTime": 0,
+                    "finishedWork": null,
+                    "firstBatch": null,
+                    "hydrate": false,
+                    "interactionThreadID": 15,
+                    "latestPendingTime": 0,
+                    "latestPingedTime": 0,
+                    "latestSuspendedTime": 0,
+                    "memoizedInteractions": Set {},
+                    "nextExpirationTimeToWorkOn": 0,
+                    "nextScheduledRoot": null,
+                    "pendingChildren": null,
+                    "pendingCommitExpirationTime": 0,
+                    "pendingContext": null,
+                    "pendingInteractionMap": Map {},
+                    "pingCache": null,
+                    "timeoutHandle": -1,
+                  },
+                  "tag": 3,
+                  "treeBaseDuration": 0,
+                  "type": null,
+                  "updateQueue": Object {
+                    "baseState": null,
+                    "firstCapturedEffect": null,
+                    "firstCapturedUpdate": null,
+                    "firstEffect": null,
+                    "firstUpdate": Object {
+                      "callback": null,
+                      "expirationTime": 1073741823,
+                      "next": null,
+                      "nextEffect": null,
+                      "payload": Object {
+                        "element": <WrapperComponent
+                          Component={[Function]}
+                          context={null}
+                          props={
+                            Object {
+                              "children": <AuthenticatedRoute
+                                authenticated={true}
+                                component={[Function]}
+                                path="/dashboard"
+                              />,
+                            }
+                          }
+                          wrappingComponentProps={null}
+                        />,
+                      },
+                      "tag": 0,
+                    },
+                    "lastCapturedEffect": null,
+                    "lastCapturedUpdate": null,
+                    "lastEffect": null,
+                    "lastUpdate": Object {
+                      "callback": null,
+                      "expirationTime": 1073741823,
+                      "next": null,
+                      "nextEffect": null,
+                      "payload": Object {
+                        "element": <WrapperComponent
+                          Component={[Function]}
+                          context={null}
+                          props={
+                            Object {
+                              "children": <AuthenticatedRoute
+                                authenticated={true}
+                                component={[Function]}
+                                path="/dashboard"
+                              />,
+                            }
+                          }
+                          wrappingComponentProps={null}
+                        />,
+                      },
+                      "tag": 0,
+                    },
+                  },
+                },
+                "child": [Circular],
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 32,
+                "elementType": null,
+                "expirationTime": 0,
+                "firstEffect": [Circular],
+                "index": 0,
+                "key": null,
+                "lastEffect": [Circular],
+                "memoizedProps": null,
+                "memoizedState": Object {
+                  "element": <WrapperComponent
+                    Component={[Function]}
+                    context={null}
+                    props={
+                      Object {
+                        "children": <AuthenticatedRoute
+                          authenticated={true}
+                          component={[Function]}
+                          path="/dashboard"
+                        />,
+                      }
+                    }
+                    wrappingComponentProps={null}
+                  />,
+                },
+                "mode": 0,
+                "nextEffect": null,
+                "pendingProps": null,
+                "ref": null,
+                "return": null,
+                "selfBaseDuration": 0,
+                "sibling": null,
+                "stateNode": Object {
+                  "containerInfo": <div />,
+                  "context": Object {},
+                  "current": [Circular],
+                  "didError": false,
+                  "earliestPendingTime": 0,
+                  "earliestSuspendedTime": 0,
+                  "expirationTime": 0,
+                  "finishedWork": null,
+                  "firstBatch": null,
+                  "hydrate": false,
+                  "interactionThreadID": 15,
+                  "latestPendingTime": 0,
+                  "latestPingedTime": 0,
+                  "latestSuspendedTime": 0,
+                  "memoizedInteractions": Set {},
+                  "nextExpirationTimeToWorkOn": 0,
+                  "nextScheduledRoot": null,
+                  "pendingChildren": null,
+                  "pendingCommitExpirationTime": 0,
+                  "pendingContext": null,
+                  "pendingInteractionMap": Map {},
+                  "pingCache": null,
+                  "timeoutHandle": -1,
+                },
+                "tag": 3,
+                "treeBaseDuration": 0,
+                "type": null,
+                "updateQueue": Object {
+                  "baseState": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={
+                        Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        }
+                      }
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "firstCapturedEffect": null,
+                  "firstCapturedUpdate": null,
+                  "firstEffect": null,
+                  "firstUpdate": null,
+                  "lastCapturedEffect": null,
+                  "lastCapturedUpdate": null,
+                  "lastEffect": null,
+                  "lastUpdate": null,
+                },
+              },
+              "selfBaseDuration": 0,
+              "sibling": null,
+              "stateNode": WrapperComponent {
+                "_reactInternalFiber": [Circular],
+                "_reactInternalInstance": Object {},
+                "context": Object {},
+                "props": Object {
+                  "Component": [Function],
+                  "context": null,
+                  "props": Object {
+                    "children": <AuthenticatedRoute
+                      authenticated={true}
+                      component={[Function]}
+                      path="/dashboard"
+                    />,
+                  },
+                  "wrappingComponentProps": null,
+                },
+                "refs": Object {},
+                "rootFinderInstance": null,
+                "state": Object {
+                  "context": null,
+                  "mount": true,
+                  "props": Object {
+                    "children": <AuthenticatedRoute
+                      authenticated={true}
+                      component={[Function]}
+                      path="/dashboard"
+                    />,
+                  },
+                  "wrappingComponentProps": null,
+                },
+                "updater": Object {
+                  "enqueueForceUpdate": [Function],
+                  "enqueueReplaceState": [Function],
+                  "enqueueSetState": [Function],
+                  "isMounted": [Function],
+                },
+              },
+              "tag": 1,
+              "treeBaseDuration": 0,
+              "type": [Function],
+              "updateQueue": null,
+            },
+            "selfBaseDuration": 0,
+            "sibling": null,
+            "stateNode": BrowserRouter {
+              "_reactInternalFiber": [Circular],
+              "_reactInternalInstance": Object {},
+              "context": Object {},
+              "history": Object {
+                "action": "POP",
+                "block": [Function],
+                "createHref": [Function],
+                "go": [Function],
+                "goBack": [Function],
+                "goForward": [Function],
+                "length": 1,
+                "listen": [Function],
+                "location": Object {
+                  "hash": "",
+                  "pathname": "/",
+                  "search": "",
+                  "state": undefined,
+                },
+                "push": [Function],
+                "replace": [Function],
+              },
+              "props": Object {
+                "children": <AuthenticatedRoute
+                  authenticated={true}
+                  component={[Function]}
+                  path="/dashboard"
+                />,
+              },
+              "refs": Object {},
+              "state": null,
+              "updater": Object {
+                "enqueueForceUpdate": [Function],
+                "enqueueReplaceState": [Function],
+                "enqueueSetState": [Function],
+                "isMounted": [Function],
+              },
+            },
+            "tag": 1,
+            "treeBaseDuration": 0,
+            "type": [Function],
+            "updateQueue": null,
+          },
+          "selfBaseDuration": 0,
+          "sibling": null,
+          "stateNode": [Circular],
+          "tag": 1,
+          "treeBaseDuration": 0,
+          "type": [Function],
+          "updateQueue": null,
+        },
+        "_reactInternalInstance": Object {},
+        "context": Object {
+          "router": undefined,
+        },
+        "props": Object {
+          "children": <AuthenticatedRoute
+            authenticated={true}
+            component={[Function]}
+            path="/dashboard"
+          />,
+          "history": Object {
+            "action": "POP",
+            "block": [Function],
+            "createHref": [Function],
+            "go": [Function],
+            "goBack": [Function],
+            "goForward": [Function],
+            "length": 1,
+            "listen": [Function],
+            "location": Object {
+              "hash": "",
+              "pathname": "/",
+              "search": "",
+              "state": undefined,
+            },
+            "push": [Function],
+            "replace": [Function],
+          },
+        },
+        "refs": Object {},
+        "state": Object {
+          "match": Object {
+            "isExact": true,
+            "params": Object {},
+            "path": "/",
+            "url": "/",
+          },
+        },
+        "unlisten": [Function],
+        "updater": Object {
+          "enqueueForceUpdate": [Function],
+          "enqueueReplaceState": [Function],
+          "enqueueSetState": [Function],
+          "isMounted": [Function],
+        },
+      },
+      "key": undefined,
+      "nodeType": "class",
+      "props": Object {
+        "children": <AuthenticatedRoute
+          authenticated={true}
+          component={[Function]}
+          path="/dashboard"
+        />,
+        "history": Object {
+          "action": "POP",
+          "block": [Function],
+          "createHref": [Function],
+          "go": [Function],
+          "goBack": [Function],
+          "goForward": [Function],
+          "length": 1,
+          "listen": [Function],
+          "location": Object {
+            "hash": "",
+            "pathname": "/",
+            "search": "",
+            "state": undefined,
+          },
+          "push": [Function],
+          "replace": [Function],
+        },
+      },
+      "ref": null,
+      "rendered": Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "function",
+        "props": Object {
+          "authenticated": true,
+          "component": [Function],
+          "path": "/dashboard",
+        },
+        "ref": null,
+        "rendered": Object {
+          "instance": Route {
+            "__reactInternalMemoizedMaskedChildContext": Object {
+              "router": Object {
+                "history": Object {
+                  "action": "POP",
+                  "block": [Function],
+                  "createHref": [Function],
+                  "go": [Function],
+                  "goBack": [Function],
+                  "goForward": [Function],
+                  "length": 1,
+                  "listen": [Function],
+                  "location": Object {
+                    "hash": "",
+                    "pathname": "/",
+                    "search": "",
+                    "state": undefined,
+                  },
+                  "push": [Function],
+                  "replace": [Function],
+                },
+                "route": Object {
+                  "location": Object {
+                    "hash": "",
+                    "pathname": "/",
+                    "search": "",
+                    "state": undefined,
+                  },
+                  "match": Object {
+                    "isExact": true,
+                    "params": Object {},
+                    "path": "/",
+                    "url": "/",
+                  },
+                },
+              },
+            },
+            "__reactInternalMemoizedMergedChildContext": Object {
+              "router": Object {
+                "history": Object {
+                  "action": "POP",
+                  "block": [Function],
+                  "createHref": [Function],
+                  "go": [Function],
+                  "goBack": [Function],
+                  "goForward": [Function],
+                  "length": 1,
+                  "listen": [Function],
+                  "location": Object {
+                    "hash": "",
+                    "pathname": "/",
+                    "search": "",
+                    "state": undefined,
+                  },
+                  "push": [Function],
+                  "replace": [Function],
+                },
+                "route": Object {
+                  "location": Object {
+                    "hash": "",
+                    "pathname": "/",
+                    "search": "",
+                    "state": undefined,
+                  },
+                  "match": null,
+                },
+              },
+            },
+            "__reactInternalMemoizedUnmaskedChildContext": Object {
+              "router": Object {
+                "history": Object {
+                  "action": "POP",
+                  "block": [Function],
+                  "createHref": [Function],
+                  "go": [Function],
+                  "goBack": [Function],
+                  "goForward": [Function],
+                  "length": 1,
+                  "listen": [Function],
+                  "location": Object {
+                    "hash": "",
+                    "pathname": "/",
+                    "search": "",
+                    "state": undefined,
+                  },
+                  "push": [Function],
+                  "replace": [Function],
+                },
+                "route": Object {
+                  "location": Object {
+                    "hash": "",
+                    "pathname": "/",
+                    "search": "",
+                    "state": undefined,
+                  },
+                  "match": Object {
+                    "isExact": true,
+                    "params": Object {},
+                    "path": "/",
+                    "url": "/",
+                  },
+                },
+              },
+            },
+            "_reactInternalFiber": FiberNode {
+              "_debugHookTypes": null,
+              "_debugID": 66,
+              "_debugIsCurrentlyTiming": false,
+              "_debugOwner": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 65,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": null,
+                "_debugSource": Object {
+                  "fileName": "/Users/chucky/Code/Bench/bp-esa-frontend/src/App.test.jsx",
+                  "lineNumber": 123,
+                },
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": null,
+                "child": [Circular],
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 1,
+                "elementType": [Function],
+                "expirationTime": 0,
+                "firstEffect": null,
+                "index": 0,
+                "key": null,
+                "lastEffect": null,
+                "memoizedProps": Object {
+                  "authenticated": true,
+                  "component": [Function],
+                  "path": "/dashboard",
+                },
+                "memoizedState": null,
+                "mode": 0,
+                "nextEffect": null,
+                "pendingProps": Object {
+                  "authenticated": true,
+                  "component": [Function],
+                  "path": "/dashboard",
+                },
+                "ref": null,
+                "return": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 64,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 63,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": FiberNode {
+                      "_debugHookTypes": null,
+                      "_debugID": 62,
+                      "_debugIsCurrentlyTiming": false,
+                      "_debugOwner": null,
+                      "_debugSource": null,
+                      "actualDuration": 0,
+                      "actualStartTime": -1,
+                      "alternate": null,
+                      "child": [Circular],
+                      "childExpirationTime": 0,
+                      "contextDependencies": null,
+                      "effectTag": 1,
+                      "elementType": [Function],
+                      "expirationTime": 0,
+                      "firstEffect": null,
+                      "index": 0,
+                      "key": null,
+                      "lastEffect": null,
+                      "memoizedProps": Object {
+                        "Component": [Function],
+                        "context": null,
+                        "props": Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        },
+                        "wrappingComponentProps": null,
+                      },
+                      "memoizedState": Object {
+                        "context": null,
+                        "mount": true,
+                        "props": Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        },
+                        "wrappingComponentProps": null,
+                      },
+                      "mode": 0,
+                      "nextEffect": FiberNode {
+                        "_debugHookTypes": null,
+                        "_debugID": 60,
+                        "_debugIsCurrentlyTiming": false,
+                        "_debugOwner": null,
+                        "_debugSource": null,
+                        "actualDuration": 0,
+                        "actualStartTime": -1,
+                        "alternate": FiberNode {
+                          "_debugHookTypes": null,
+                          "_debugID": 60,
+                          "_debugIsCurrentlyTiming": false,
+                          "_debugOwner": null,
+                          "_debugSource": null,
+                          "actualDuration": 0,
+                          "actualStartTime": -1,
+                          "alternate": [Circular],
+                          "child": null,
+                          "childExpirationTime": 0,
+                          "contextDependencies": null,
+                          "effectTag": 0,
+                          "elementType": null,
+                          "expirationTime": 1073741823,
+                          "firstEffect": null,
+                          "index": 0,
+                          "key": null,
+                          "lastEffect": null,
+                          "memoizedProps": null,
+                          "memoizedState": null,
+                          "mode": 0,
+                          "nextEffect": null,
+                          "pendingProps": null,
+                          "ref": null,
+                          "return": null,
+                          "selfBaseDuration": 0,
+                          "sibling": null,
+                          "stateNode": Object {
+                            "containerInfo": <div />,
+                            "context": Object {},
+                            "current": [Circular],
+                            "didError": false,
+                            "earliestPendingTime": 0,
+                            "earliestSuspendedTime": 0,
+                            "expirationTime": 0,
+                            "finishedWork": null,
+                            "firstBatch": null,
+                            "hydrate": false,
+                            "interactionThreadID": 15,
+                            "latestPendingTime": 0,
+                            "latestPingedTime": 0,
+                            "latestSuspendedTime": 0,
+                            "memoizedInteractions": Set {},
+                            "nextExpirationTimeToWorkOn": 0,
+                            "nextScheduledRoot": null,
+                            "pendingChildren": null,
+                            "pendingCommitExpirationTime": 0,
+                            "pendingContext": null,
+                            "pendingInteractionMap": Map {},
+                            "pingCache": null,
+                            "timeoutHandle": -1,
+                          },
+                          "tag": 3,
+                          "treeBaseDuration": 0,
+                          "type": null,
+                          "updateQueue": Object {
+                            "baseState": null,
+                            "firstCapturedEffect": null,
+                            "firstCapturedUpdate": null,
+                            "firstEffect": null,
+                            "firstUpdate": Object {
+                              "callback": null,
+                              "expirationTime": 1073741823,
+                              "next": null,
+                              "nextEffect": null,
+                              "payload": Object {
+                                "element": <WrapperComponent
+                                  Component={[Function]}
+                                  context={null}
+                                  props={
+                                    Object {
+                                      "children": <AuthenticatedRoute
+                                        authenticated={true}
+                                        component={[Function]}
+                                        path="/dashboard"
+                                      />,
+                                    }
+                                  }
+                                  wrappingComponentProps={null}
+                                />,
+                              },
+                              "tag": 0,
+                            },
+                            "lastCapturedEffect": null,
+                            "lastCapturedUpdate": null,
+                            "lastEffect": null,
+                            "lastUpdate": Object {
+                              "callback": null,
+                              "expirationTime": 1073741823,
+                              "next": null,
+                              "nextEffect": null,
+                              "payload": Object {
+                                "element": <WrapperComponent
+                                  Component={[Function]}
+                                  context={null}
+                                  props={
+                                    Object {
+                                      "children": <AuthenticatedRoute
+                                        authenticated={true}
+                                        component={[Function]}
+                                        path="/dashboard"
+                                      />,
+                                    }
+                                  }
+                                  wrappingComponentProps={null}
+                                />,
+                              },
+                              "tag": 0,
+                            },
+                          },
+                        },
+                        "child": [Circular],
+                        "childExpirationTime": 0,
+                        "contextDependencies": null,
+                        "effectTag": 32,
+                        "elementType": null,
+                        "expirationTime": 0,
+                        "firstEffect": [Circular],
+                        "index": 0,
+                        "key": null,
+                        "lastEffect": [Circular],
+                        "memoizedProps": null,
+                        "memoizedState": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={
+                              Object {
+                                "children": <AuthenticatedRoute
+                                  authenticated={true}
+                                  component={[Function]}
+                                  path="/dashboard"
+                                />,
+                              }
+                            }
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "mode": 0,
+                        "nextEffect": null,
+                        "pendingProps": null,
+                        "ref": null,
+                        "return": null,
+                        "selfBaseDuration": 0,
+                        "sibling": null,
+                        "stateNode": Object {
+                          "containerInfo": <div />,
+                          "context": Object {},
+                          "current": [Circular],
+                          "didError": false,
+                          "earliestPendingTime": 0,
+                          "earliestSuspendedTime": 0,
+                          "expirationTime": 0,
+                          "finishedWork": null,
+                          "firstBatch": null,
+                          "hydrate": false,
+                          "interactionThreadID": 15,
+                          "latestPendingTime": 0,
+                          "latestPingedTime": 0,
+                          "latestSuspendedTime": 0,
+                          "memoizedInteractions": Set {},
+                          "nextExpirationTimeToWorkOn": 0,
+                          "nextScheduledRoot": null,
+                          "pendingChildren": null,
+                          "pendingCommitExpirationTime": 0,
+                          "pendingContext": null,
+                          "pendingInteractionMap": Map {},
+                          "pingCache": null,
+                          "timeoutHandle": -1,
+                        },
+                        "tag": 3,
+                        "treeBaseDuration": 0,
+                        "type": null,
+                        "updateQueue": Object {
+                          "baseState": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={
+                                Object {
+                                  "children": <AuthenticatedRoute
+                                    authenticated={true}
+                                    component={[Function]}
+                                    path="/dashboard"
+                                  />,
+                                }
+                              }
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "firstCapturedEffect": null,
+                          "firstCapturedUpdate": null,
+                          "firstEffect": null,
+                          "firstUpdate": null,
+                          "lastCapturedEffect": null,
+                          "lastCapturedUpdate": null,
+                          "lastEffect": null,
+                          "lastUpdate": null,
+                        },
+                      },
+                      "pendingProps": Object {
+                        "Component": [Function],
+                        "context": null,
+                        "props": Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        },
+                        "wrappingComponentProps": null,
+                      },
+                      "ref": null,
+                      "return": FiberNode {
+                        "_debugHookTypes": null,
+                        "_debugID": 60,
+                        "_debugIsCurrentlyTiming": false,
+                        "_debugOwner": null,
+                        "_debugSource": null,
+                        "actualDuration": 0,
+                        "actualStartTime": -1,
+                        "alternate": FiberNode {
+                          "_debugHookTypes": null,
+                          "_debugID": 60,
+                          "_debugIsCurrentlyTiming": false,
+                          "_debugOwner": null,
+                          "_debugSource": null,
+                          "actualDuration": 0,
+                          "actualStartTime": -1,
+                          "alternate": [Circular],
+                          "child": null,
+                          "childExpirationTime": 0,
+                          "contextDependencies": null,
+                          "effectTag": 0,
+                          "elementType": null,
+                          "expirationTime": 1073741823,
+                          "firstEffect": null,
+                          "index": 0,
+                          "key": null,
+                          "lastEffect": null,
+                          "memoizedProps": null,
+                          "memoizedState": null,
+                          "mode": 0,
+                          "nextEffect": null,
+                          "pendingProps": null,
+                          "ref": null,
+                          "return": null,
+                          "selfBaseDuration": 0,
+                          "sibling": null,
+                          "stateNode": Object {
+                            "containerInfo": <div />,
+                            "context": Object {},
+                            "current": [Circular],
+                            "didError": false,
+                            "earliestPendingTime": 0,
+                            "earliestSuspendedTime": 0,
+                            "expirationTime": 0,
+                            "finishedWork": null,
+                            "firstBatch": null,
+                            "hydrate": false,
+                            "interactionThreadID": 15,
+                            "latestPendingTime": 0,
+                            "latestPingedTime": 0,
+                            "latestSuspendedTime": 0,
+                            "memoizedInteractions": Set {},
+                            "nextExpirationTimeToWorkOn": 0,
+                            "nextScheduledRoot": null,
+                            "pendingChildren": null,
+                            "pendingCommitExpirationTime": 0,
+                            "pendingContext": null,
+                            "pendingInteractionMap": Map {},
+                            "pingCache": null,
+                            "timeoutHandle": -1,
+                          },
+                          "tag": 3,
+                          "treeBaseDuration": 0,
+                          "type": null,
+                          "updateQueue": Object {
+                            "baseState": null,
+                            "firstCapturedEffect": null,
+                            "firstCapturedUpdate": null,
+                            "firstEffect": null,
+                            "firstUpdate": Object {
+                              "callback": null,
+                              "expirationTime": 1073741823,
+                              "next": null,
+                              "nextEffect": null,
+                              "payload": Object {
+                                "element": <WrapperComponent
+                                  Component={[Function]}
+                                  context={null}
+                                  props={
+                                    Object {
+                                      "children": <AuthenticatedRoute
+                                        authenticated={true}
+                                        component={[Function]}
+                                        path="/dashboard"
+                                      />,
+                                    }
+                                  }
+                                  wrappingComponentProps={null}
+                                />,
+                              },
+                              "tag": 0,
+                            },
+                            "lastCapturedEffect": null,
+                            "lastCapturedUpdate": null,
+                            "lastEffect": null,
+                            "lastUpdate": Object {
+                              "callback": null,
+                              "expirationTime": 1073741823,
+                              "next": null,
+                              "nextEffect": null,
+                              "payload": Object {
+                                "element": <WrapperComponent
+                                  Component={[Function]}
+                                  context={null}
+                                  props={
+                                    Object {
+                                      "children": <AuthenticatedRoute
+                                        authenticated={true}
+                                        component={[Function]}
+                                        path="/dashboard"
+                                      />,
+                                    }
+                                  }
+                                  wrappingComponentProps={null}
+                                />,
+                              },
+                              "tag": 0,
+                            },
+                          },
+                        },
+                        "child": [Circular],
+                        "childExpirationTime": 0,
+                        "contextDependencies": null,
+                        "effectTag": 32,
+                        "elementType": null,
+                        "expirationTime": 0,
+                        "firstEffect": [Circular],
+                        "index": 0,
+                        "key": null,
+                        "lastEffect": [Circular],
+                        "memoizedProps": null,
+                        "memoizedState": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={
+                              Object {
+                                "children": <AuthenticatedRoute
+                                  authenticated={true}
+                                  component={[Function]}
+                                  path="/dashboard"
+                                />,
+                              }
+                            }
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "mode": 0,
+                        "nextEffect": null,
+                        "pendingProps": null,
+                        "ref": null,
+                        "return": null,
+                        "selfBaseDuration": 0,
+                        "sibling": null,
+                        "stateNode": Object {
+                          "containerInfo": <div />,
+                          "context": Object {},
+                          "current": [Circular],
+                          "didError": false,
+                          "earliestPendingTime": 0,
+                          "earliestSuspendedTime": 0,
+                          "expirationTime": 0,
+                          "finishedWork": null,
+                          "firstBatch": null,
+                          "hydrate": false,
+                          "interactionThreadID": 15,
+                          "latestPendingTime": 0,
+                          "latestPingedTime": 0,
+                          "latestSuspendedTime": 0,
+                          "memoizedInteractions": Set {},
+                          "nextExpirationTimeToWorkOn": 0,
+                          "nextScheduledRoot": null,
+                          "pendingChildren": null,
+                          "pendingCommitExpirationTime": 0,
+                          "pendingContext": null,
+                          "pendingInteractionMap": Map {},
+                          "pingCache": null,
+                          "timeoutHandle": -1,
+                        },
+                        "tag": 3,
+                        "treeBaseDuration": 0,
+                        "type": null,
+                        "updateQueue": Object {
+                          "baseState": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={
+                                Object {
+                                  "children": <AuthenticatedRoute
+                                    authenticated={true}
+                                    component={[Function]}
+                                    path="/dashboard"
+                                  />,
+                                }
+                              }
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "firstCapturedEffect": null,
+                          "firstCapturedUpdate": null,
+                          "firstEffect": null,
+                          "firstUpdate": null,
+                          "lastCapturedEffect": null,
+                          "lastCapturedUpdate": null,
+                          "lastEffect": null,
+                          "lastUpdate": null,
+                        },
+                      },
+                      "selfBaseDuration": 0,
+                      "sibling": null,
+                      "stateNode": WrapperComponent {
+                        "_reactInternalFiber": [Circular],
+                        "_reactInternalInstance": Object {},
+                        "context": Object {},
+                        "props": Object {
+                          "Component": [Function],
+                          "context": null,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "refs": Object {},
+                        "rootFinderInstance": null,
+                        "state": Object {
+                          "context": null,
+                          "mount": true,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "updater": Object {
+                          "enqueueForceUpdate": [Function],
+                          "enqueueReplaceState": [Function],
+                          "enqueueSetState": [Function],
+                          "isMounted": [Function],
+                        },
+                      },
+                      "tag": 1,
+                      "treeBaseDuration": 0,
+                      "type": [Function],
+                      "updateQueue": null,
+                    },
+                    "_debugSource": null,
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": null,
+                    "child": [Circular],
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 1,
+                    "elementType": [Function],
+                    "expirationTime": 0,
+                    "firstEffect": null,
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": null,
+                    "memoizedProps": Object {
+                      "children": <AuthenticatedRoute
+                        authenticated={true}
+                        component={[Function]}
+                        path="/dashboard"
+                      />,
+                    },
+                    "memoizedState": null,
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": Object {
+                      "children": <AuthenticatedRoute
+                        authenticated={true}
+                        component={[Function]}
+                        path="/dashboard"
+                      />,
+                    },
+                    "ref": null,
+                    "return": FiberNode {
+                      "_debugHookTypes": null,
+                      "_debugID": 62,
+                      "_debugIsCurrentlyTiming": false,
+                      "_debugOwner": null,
+                      "_debugSource": null,
+                      "actualDuration": 0,
+                      "actualStartTime": -1,
+                      "alternate": null,
+                      "child": [Circular],
+                      "childExpirationTime": 0,
+                      "contextDependencies": null,
+                      "effectTag": 1,
+                      "elementType": [Function],
+                      "expirationTime": 0,
+                      "firstEffect": null,
+                      "index": 0,
+                      "key": null,
+                      "lastEffect": null,
+                      "memoizedProps": Object {
+                        "Component": [Function],
+                        "context": null,
+                        "props": Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        },
+                        "wrappingComponentProps": null,
+                      },
+                      "memoizedState": Object {
+                        "context": null,
+                        "mount": true,
+                        "props": Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        },
+                        "wrappingComponentProps": null,
+                      },
+                      "mode": 0,
+                      "nextEffect": FiberNode {
+                        "_debugHookTypes": null,
+                        "_debugID": 60,
+                        "_debugIsCurrentlyTiming": false,
+                        "_debugOwner": null,
+                        "_debugSource": null,
+                        "actualDuration": 0,
+                        "actualStartTime": -1,
+                        "alternate": FiberNode {
+                          "_debugHookTypes": null,
+                          "_debugID": 60,
+                          "_debugIsCurrentlyTiming": false,
+                          "_debugOwner": null,
+                          "_debugSource": null,
+                          "actualDuration": 0,
+                          "actualStartTime": -1,
+                          "alternate": [Circular],
+                          "child": null,
+                          "childExpirationTime": 0,
+                          "contextDependencies": null,
+                          "effectTag": 0,
+                          "elementType": null,
+                          "expirationTime": 1073741823,
+                          "firstEffect": null,
+                          "index": 0,
+                          "key": null,
+                          "lastEffect": null,
+                          "memoizedProps": null,
+                          "memoizedState": null,
+                          "mode": 0,
+                          "nextEffect": null,
+                          "pendingProps": null,
+                          "ref": null,
+                          "return": null,
+                          "selfBaseDuration": 0,
+                          "sibling": null,
+                          "stateNode": Object {
+                            "containerInfo": <div />,
+                            "context": Object {},
+                            "current": [Circular],
+                            "didError": false,
+                            "earliestPendingTime": 0,
+                            "earliestSuspendedTime": 0,
+                            "expirationTime": 0,
+                            "finishedWork": null,
+                            "firstBatch": null,
+                            "hydrate": false,
+                            "interactionThreadID": 15,
+                            "latestPendingTime": 0,
+                            "latestPingedTime": 0,
+                            "latestSuspendedTime": 0,
+                            "memoizedInteractions": Set {},
+                            "nextExpirationTimeToWorkOn": 0,
+                            "nextScheduledRoot": null,
+                            "pendingChildren": null,
+                            "pendingCommitExpirationTime": 0,
+                            "pendingContext": null,
+                            "pendingInteractionMap": Map {},
+                            "pingCache": null,
+                            "timeoutHandle": -1,
+                          },
+                          "tag": 3,
+                          "treeBaseDuration": 0,
+                          "type": null,
+                          "updateQueue": Object {
+                            "baseState": null,
+                            "firstCapturedEffect": null,
+                            "firstCapturedUpdate": null,
+                            "firstEffect": null,
+                            "firstUpdate": Object {
+                              "callback": null,
+                              "expirationTime": 1073741823,
+                              "next": null,
+                              "nextEffect": null,
+                              "payload": Object {
+                                "element": <WrapperComponent
+                                  Component={[Function]}
+                                  context={null}
+                                  props={
+                                    Object {
+                                      "children": <AuthenticatedRoute
+                                        authenticated={true}
+                                        component={[Function]}
+                                        path="/dashboard"
+                                      />,
+                                    }
+                                  }
+                                  wrappingComponentProps={null}
+                                />,
+                              },
+                              "tag": 0,
+                            },
+                            "lastCapturedEffect": null,
+                            "lastCapturedUpdate": null,
+                            "lastEffect": null,
+                            "lastUpdate": Object {
+                              "callback": null,
+                              "expirationTime": 1073741823,
+                              "next": null,
+                              "nextEffect": null,
+                              "payload": Object {
+                                "element": <WrapperComponent
+                                  Component={[Function]}
+                                  context={null}
+                                  props={
+                                    Object {
+                                      "children": <AuthenticatedRoute
+                                        authenticated={true}
+                                        component={[Function]}
+                                        path="/dashboard"
+                                      />,
+                                    }
+                                  }
+                                  wrappingComponentProps={null}
+                                />,
+                              },
+                              "tag": 0,
+                            },
+                          },
+                        },
+                        "child": [Circular],
+                        "childExpirationTime": 0,
+                        "contextDependencies": null,
+                        "effectTag": 32,
+                        "elementType": null,
+                        "expirationTime": 0,
+                        "firstEffect": [Circular],
+                        "index": 0,
+                        "key": null,
+                        "lastEffect": [Circular],
+                        "memoizedProps": null,
+                        "memoizedState": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={
+                              Object {
+                                "children": <AuthenticatedRoute
+                                  authenticated={true}
+                                  component={[Function]}
+                                  path="/dashboard"
+                                />,
+                              }
+                            }
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "mode": 0,
+                        "nextEffect": null,
+                        "pendingProps": null,
+                        "ref": null,
+                        "return": null,
+                        "selfBaseDuration": 0,
+                        "sibling": null,
+                        "stateNode": Object {
+                          "containerInfo": <div />,
+                          "context": Object {},
+                          "current": [Circular],
+                          "didError": false,
+                          "earliestPendingTime": 0,
+                          "earliestSuspendedTime": 0,
+                          "expirationTime": 0,
+                          "finishedWork": null,
+                          "firstBatch": null,
+                          "hydrate": false,
+                          "interactionThreadID": 15,
+                          "latestPendingTime": 0,
+                          "latestPingedTime": 0,
+                          "latestSuspendedTime": 0,
+                          "memoizedInteractions": Set {},
+                          "nextExpirationTimeToWorkOn": 0,
+                          "nextScheduledRoot": null,
+                          "pendingChildren": null,
+                          "pendingCommitExpirationTime": 0,
+                          "pendingContext": null,
+                          "pendingInteractionMap": Map {},
+                          "pingCache": null,
+                          "timeoutHandle": -1,
+                        },
+                        "tag": 3,
+                        "treeBaseDuration": 0,
+                        "type": null,
+                        "updateQueue": Object {
+                          "baseState": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={
+                                Object {
+                                  "children": <AuthenticatedRoute
+                                    authenticated={true}
+                                    component={[Function]}
+                                    path="/dashboard"
+                                  />,
+                                }
+                              }
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "firstCapturedEffect": null,
+                          "firstCapturedUpdate": null,
+                          "firstEffect": null,
+                          "firstUpdate": null,
+                          "lastCapturedEffect": null,
+                          "lastCapturedUpdate": null,
+                          "lastEffect": null,
+                          "lastUpdate": null,
+                        },
+                      },
+                      "pendingProps": Object {
+                        "Component": [Function],
+                        "context": null,
+                        "props": Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        },
+                        "wrappingComponentProps": null,
+                      },
+                      "ref": null,
+                      "return": FiberNode {
+                        "_debugHookTypes": null,
+                        "_debugID": 60,
+                        "_debugIsCurrentlyTiming": false,
+                        "_debugOwner": null,
+                        "_debugSource": null,
+                        "actualDuration": 0,
+                        "actualStartTime": -1,
+                        "alternate": FiberNode {
+                          "_debugHookTypes": null,
+                          "_debugID": 60,
+                          "_debugIsCurrentlyTiming": false,
+                          "_debugOwner": null,
+                          "_debugSource": null,
+                          "actualDuration": 0,
+                          "actualStartTime": -1,
+                          "alternate": [Circular],
+                          "child": null,
+                          "childExpirationTime": 0,
+                          "contextDependencies": null,
+                          "effectTag": 0,
+                          "elementType": null,
+                          "expirationTime": 1073741823,
+                          "firstEffect": null,
+                          "index": 0,
+                          "key": null,
+                          "lastEffect": null,
+                          "memoizedProps": null,
+                          "memoizedState": null,
+                          "mode": 0,
+                          "nextEffect": null,
+                          "pendingProps": null,
+                          "ref": null,
+                          "return": null,
+                          "selfBaseDuration": 0,
+                          "sibling": null,
+                          "stateNode": Object {
+                            "containerInfo": <div />,
+                            "context": Object {},
+                            "current": [Circular],
+                            "didError": false,
+                            "earliestPendingTime": 0,
+                            "earliestSuspendedTime": 0,
+                            "expirationTime": 0,
+                            "finishedWork": null,
+                            "firstBatch": null,
+                            "hydrate": false,
+                            "interactionThreadID": 15,
+                            "latestPendingTime": 0,
+                            "latestPingedTime": 0,
+                            "latestSuspendedTime": 0,
+                            "memoizedInteractions": Set {},
+                            "nextExpirationTimeToWorkOn": 0,
+                            "nextScheduledRoot": null,
+                            "pendingChildren": null,
+                            "pendingCommitExpirationTime": 0,
+                            "pendingContext": null,
+                            "pendingInteractionMap": Map {},
+                            "pingCache": null,
+                            "timeoutHandle": -1,
+                          },
+                          "tag": 3,
+                          "treeBaseDuration": 0,
+                          "type": null,
+                          "updateQueue": Object {
+                            "baseState": null,
+                            "firstCapturedEffect": null,
+                            "firstCapturedUpdate": null,
+                            "firstEffect": null,
+                            "firstUpdate": Object {
+                              "callback": null,
+                              "expirationTime": 1073741823,
+                              "next": null,
+                              "nextEffect": null,
+                              "payload": Object {
+                                "element": <WrapperComponent
+                                  Component={[Function]}
+                                  context={null}
+                                  props={
+                                    Object {
+                                      "children": <AuthenticatedRoute
+                                        authenticated={true}
+                                        component={[Function]}
+                                        path="/dashboard"
+                                      />,
+                                    }
+                                  }
+                                  wrappingComponentProps={null}
+                                />,
+                              },
+                              "tag": 0,
+                            },
+                            "lastCapturedEffect": null,
+                            "lastCapturedUpdate": null,
+                            "lastEffect": null,
+                            "lastUpdate": Object {
+                              "callback": null,
+                              "expirationTime": 1073741823,
+                              "next": null,
+                              "nextEffect": null,
+                              "payload": Object {
+                                "element": <WrapperComponent
+                                  Component={[Function]}
+                                  context={null}
+                                  props={
+                                    Object {
+                                      "children": <AuthenticatedRoute
+                                        authenticated={true}
+                                        component={[Function]}
+                                        path="/dashboard"
+                                      />,
+                                    }
+                                  }
+                                  wrappingComponentProps={null}
+                                />,
+                              },
+                              "tag": 0,
+                            },
+                          },
+                        },
+                        "child": [Circular],
+                        "childExpirationTime": 0,
+                        "contextDependencies": null,
+                        "effectTag": 32,
+                        "elementType": null,
+                        "expirationTime": 0,
+                        "firstEffect": [Circular],
+                        "index": 0,
+                        "key": null,
+                        "lastEffect": [Circular],
+                        "memoizedProps": null,
+                        "memoizedState": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={
+                              Object {
+                                "children": <AuthenticatedRoute
+                                  authenticated={true}
+                                  component={[Function]}
+                                  path="/dashboard"
+                                />,
+                              }
+                            }
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "mode": 0,
+                        "nextEffect": null,
+                        "pendingProps": null,
+                        "ref": null,
+                        "return": null,
+                        "selfBaseDuration": 0,
+                        "sibling": null,
+                        "stateNode": Object {
+                          "containerInfo": <div />,
+                          "context": Object {},
+                          "current": [Circular],
+                          "didError": false,
+                          "earliestPendingTime": 0,
+                          "earliestSuspendedTime": 0,
+                          "expirationTime": 0,
+                          "finishedWork": null,
+                          "firstBatch": null,
+                          "hydrate": false,
+                          "interactionThreadID": 15,
+                          "latestPendingTime": 0,
+                          "latestPingedTime": 0,
+                          "latestSuspendedTime": 0,
+                          "memoizedInteractions": Set {},
+                          "nextExpirationTimeToWorkOn": 0,
+                          "nextScheduledRoot": null,
+                          "pendingChildren": null,
+                          "pendingCommitExpirationTime": 0,
+                          "pendingContext": null,
+                          "pendingInteractionMap": Map {},
+                          "pingCache": null,
+                          "timeoutHandle": -1,
+                        },
+                        "tag": 3,
+                        "treeBaseDuration": 0,
+                        "type": null,
+                        "updateQueue": Object {
+                          "baseState": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={
+                                Object {
+                                  "children": <AuthenticatedRoute
+                                    authenticated={true}
+                                    component={[Function]}
+                                    path="/dashboard"
+                                  />,
+                                }
+                              }
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "firstCapturedEffect": null,
+                          "firstCapturedUpdate": null,
+                          "firstEffect": null,
+                          "firstUpdate": null,
+                          "lastCapturedEffect": null,
+                          "lastCapturedUpdate": null,
+                          "lastEffect": null,
+                          "lastUpdate": null,
+                        },
+                      },
+                      "selfBaseDuration": 0,
+                      "sibling": null,
+                      "stateNode": WrapperComponent {
+                        "_reactInternalFiber": [Circular],
+                        "_reactInternalInstance": Object {},
+                        "context": Object {},
+                        "props": Object {
+                          "Component": [Function],
+                          "context": null,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "refs": Object {},
+                        "rootFinderInstance": null,
+                        "state": Object {
+                          "context": null,
+                          "mount": true,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "updater": Object {
+                          "enqueueForceUpdate": [Function],
+                          "enqueueReplaceState": [Function],
+                          "enqueueSetState": [Function],
+                          "isMounted": [Function],
+                        },
+                      },
+                      "tag": 1,
+                      "treeBaseDuration": 0,
+                      "type": [Function],
+                      "updateQueue": null,
+                    },
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": BrowserRouter {
+                      "_reactInternalFiber": [Circular],
+                      "_reactInternalInstance": Object {},
+                      "context": Object {},
+                      "history": Object {
+                        "action": "POP",
+                        "block": [Function],
+                        "createHref": [Function],
+                        "go": [Function],
+                        "goBack": [Function],
+                        "goForward": [Function],
+                        "length": 1,
+                        "listen": [Function],
+                        "location": Object {
+                          "hash": "",
+                          "pathname": "/",
+                          "search": "",
+                          "state": undefined,
+                        },
+                        "push": [Function],
+                        "replace": [Function],
+                      },
+                      "props": Object {
+                        "children": <AuthenticatedRoute
+                          authenticated={true}
+                          component={[Function]}
+                          path="/dashboard"
+                        />,
+                      },
+                      "refs": Object {},
+                      "state": null,
+                      "updater": Object {
+                        "enqueueForceUpdate": [Function],
+                        "enqueueReplaceState": [Function],
+                        "enqueueSetState": [Function],
+                        "isMounted": [Function],
+                      },
+                    },
+                    "tag": 1,
+                    "treeBaseDuration": 0,
+                    "type": [Function],
+                    "updateQueue": null,
+                  },
+                  "_debugSource": null,
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": null,
+                  "child": [Circular],
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 1,
+                  "elementType": [Function],
+                  "expirationTime": 0,
+                  "firstEffect": null,
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": null,
+                  "memoizedProps": Object {
+                    "children": <AuthenticatedRoute
+                      authenticated={true}
+                      component={[Function]}
+                      path="/dashboard"
+                    />,
+                    "history": Object {
+                      "action": "POP",
+                      "block": [Function],
+                      "createHref": [Function],
+                      "go": [Function],
+                      "goBack": [Function],
+                      "goForward": [Function],
+                      "length": 1,
+                      "listen": [Function],
+                      "location": Object {
+                        "hash": "",
+                        "pathname": "/",
+                        "search": "",
+                        "state": undefined,
+                      },
+                      "push": [Function],
+                      "replace": [Function],
+                    },
+                  },
+                  "memoizedState": Object {
+                    "match": Object {
+                      "isExact": true,
+                      "params": Object {},
+                      "path": "/",
+                      "url": "/",
+                    },
+                  },
+                  "mode": 0,
+                  "nextEffect": null,
+                  "pendingProps": Object {
+                    "children": <AuthenticatedRoute
+                      authenticated={true}
+                      component={[Function]}
+                      path="/dashboard"
+                    />,
+                    "history": Object {
+                      "action": "POP",
+                      "block": [Function],
+                      "createHref": [Function],
+                      "go": [Function],
+                      "goBack": [Function],
+                      "goForward": [Function],
+                      "length": 1,
+                      "listen": [Function],
+                      "location": Object {
+                        "hash": "",
+                        "pathname": "/",
+                        "search": "",
+                        "state": undefined,
+                      },
+                      "push": [Function],
+                      "replace": [Function],
+                    },
+                  },
+                  "ref": null,
+                  "return": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 63,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": FiberNode {
+                      "_debugHookTypes": null,
+                      "_debugID": 62,
+                      "_debugIsCurrentlyTiming": false,
+                      "_debugOwner": null,
+                      "_debugSource": null,
+                      "actualDuration": 0,
+                      "actualStartTime": -1,
+                      "alternate": null,
+                      "child": [Circular],
+                      "childExpirationTime": 0,
+                      "contextDependencies": null,
+                      "effectTag": 1,
+                      "elementType": [Function],
+                      "expirationTime": 0,
+                      "firstEffect": null,
+                      "index": 0,
+                      "key": null,
+                      "lastEffect": null,
+                      "memoizedProps": Object {
+                        "Component": [Function],
+                        "context": null,
+                        "props": Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        },
+                        "wrappingComponentProps": null,
+                      },
+                      "memoizedState": Object {
+                        "context": null,
+                        "mount": true,
+                        "props": Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        },
+                        "wrappingComponentProps": null,
+                      },
+                      "mode": 0,
+                      "nextEffect": FiberNode {
+                        "_debugHookTypes": null,
+                        "_debugID": 60,
+                        "_debugIsCurrentlyTiming": false,
+                        "_debugOwner": null,
+                        "_debugSource": null,
+                        "actualDuration": 0,
+                        "actualStartTime": -1,
+                        "alternate": FiberNode {
+                          "_debugHookTypes": null,
+                          "_debugID": 60,
+                          "_debugIsCurrentlyTiming": false,
+                          "_debugOwner": null,
+                          "_debugSource": null,
+                          "actualDuration": 0,
+                          "actualStartTime": -1,
+                          "alternate": [Circular],
+                          "child": null,
+                          "childExpirationTime": 0,
+                          "contextDependencies": null,
+                          "effectTag": 0,
+                          "elementType": null,
+                          "expirationTime": 1073741823,
+                          "firstEffect": null,
+                          "index": 0,
+                          "key": null,
+                          "lastEffect": null,
+                          "memoizedProps": null,
+                          "memoizedState": null,
+                          "mode": 0,
+                          "nextEffect": null,
+                          "pendingProps": null,
+                          "ref": null,
+                          "return": null,
+                          "selfBaseDuration": 0,
+                          "sibling": null,
+                          "stateNode": Object {
+                            "containerInfo": <div />,
+                            "context": Object {},
+                            "current": [Circular],
+                            "didError": false,
+                            "earliestPendingTime": 0,
+                            "earliestSuspendedTime": 0,
+                            "expirationTime": 0,
+                            "finishedWork": null,
+                            "firstBatch": null,
+                            "hydrate": false,
+                            "interactionThreadID": 15,
+                            "latestPendingTime": 0,
+                            "latestPingedTime": 0,
+                            "latestSuspendedTime": 0,
+                            "memoizedInteractions": Set {},
+                            "nextExpirationTimeToWorkOn": 0,
+                            "nextScheduledRoot": null,
+                            "pendingChildren": null,
+                            "pendingCommitExpirationTime": 0,
+                            "pendingContext": null,
+                            "pendingInteractionMap": Map {},
+                            "pingCache": null,
+                            "timeoutHandle": -1,
+                          },
+                          "tag": 3,
+                          "treeBaseDuration": 0,
+                          "type": null,
+                          "updateQueue": Object {
+                            "baseState": null,
+                            "firstCapturedEffect": null,
+                            "firstCapturedUpdate": null,
+                            "firstEffect": null,
+                            "firstUpdate": Object {
+                              "callback": null,
+                              "expirationTime": 1073741823,
+                              "next": null,
+                              "nextEffect": null,
+                              "payload": Object {
+                                "element": <WrapperComponent
+                                  Component={[Function]}
+                                  context={null}
+                                  props={
+                                    Object {
+                                      "children": <AuthenticatedRoute
+                                        authenticated={true}
+                                        component={[Function]}
+                                        path="/dashboard"
+                                      />,
+                                    }
+                                  }
+                                  wrappingComponentProps={null}
+                                />,
+                              },
+                              "tag": 0,
+                            },
+                            "lastCapturedEffect": null,
+                            "lastCapturedUpdate": null,
+                            "lastEffect": null,
+                            "lastUpdate": Object {
+                              "callback": null,
+                              "expirationTime": 1073741823,
+                              "next": null,
+                              "nextEffect": null,
+                              "payload": Object {
+                                "element": <WrapperComponent
+                                  Component={[Function]}
+                                  context={null}
+                                  props={
+                                    Object {
+                                      "children": <AuthenticatedRoute
+                                        authenticated={true}
+                                        component={[Function]}
+                                        path="/dashboard"
+                                      />,
+                                    }
+                                  }
+                                  wrappingComponentProps={null}
+                                />,
+                              },
+                              "tag": 0,
+                            },
+                          },
+                        },
+                        "child": [Circular],
+                        "childExpirationTime": 0,
+                        "contextDependencies": null,
+                        "effectTag": 32,
+                        "elementType": null,
+                        "expirationTime": 0,
+                        "firstEffect": [Circular],
+                        "index": 0,
+                        "key": null,
+                        "lastEffect": [Circular],
+                        "memoizedProps": null,
+                        "memoizedState": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={
+                              Object {
+                                "children": <AuthenticatedRoute
+                                  authenticated={true}
+                                  component={[Function]}
+                                  path="/dashboard"
+                                />,
+                              }
+                            }
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "mode": 0,
+                        "nextEffect": null,
+                        "pendingProps": null,
+                        "ref": null,
+                        "return": null,
+                        "selfBaseDuration": 0,
+                        "sibling": null,
+                        "stateNode": Object {
+                          "containerInfo": <div />,
+                          "context": Object {},
+                          "current": [Circular],
+                          "didError": false,
+                          "earliestPendingTime": 0,
+                          "earliestSuspendedTime": 0,
+                          "expirationTime": 0,
+                          "finishedWork": null,
+                          "firstBatch": null,
+                          "hydrate": false,
+                          "interactionThreadID": 15,
+                          "latestPendingTime": 0,
+                          "latestPingedTime": 0,
+                          "latestSuspendedTime": 0,
+                          "memoizedInteractions": Set {},
+                          "nextExpirationTimeToWorkOn": 0,
+                          "nextScheduledRoot": null,
+                          "pendingChildren": null,
+                          "pendingCommitExpirationTime": 0,
+                          "pendingContext": null,
+                          "pendingInteractionMap": Map {},
+                          "pingCache": null,
+                          "timeoutHandle": -1,
+                        },
+                        "tag": 3,
+                        "treeBaseDuration": 0,
+                        "type": null,
+                        "updateQueue": Object {
+                          "baseState": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={
+                                Object {
+                                  "children": <AuthenticatedRoute
+                                    authenticated={true}
+                                    component={[Function]}
+                                    path="/dashboard"
+                                  />,
+                                }
+                              }
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "firstCapturedEffect": null,
+                          "firstCapturedUpdate": null,
+                          "firstEffect": null,
+                          "firstUpdate": null,
+                          "lastCapturedEffect": null,
+                          "lastCapturedUpdate": null,
+                          "lastEffect": null,
+                          "lastUpdate": null,
+                        },
+                      },
+                      "pendingProps": Object {
+                        "Component": [Function],
+                        "context": null,
+                        "props": Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        },
+                        "wrappingComponentProps": null,
+                      },
+                      "ref": null,
+                      "return": FiberNode {
+                        "_debugHookTypes": null,
+                        "_debugID": 60,
+                        "_debugIsCurrentlyTiming": false,
+                        "_debugOwner": null,
+                        "_debugSource": null,
+                        "actualDuration": 0,
+                        "actualStartTime": -1,
+                        "alternate": FiberNode {
+                          "_debugHookTypes": null,
+                          "_debugID": 60,
+                          "_debugIsCurrentlyTiming": false,
+                          "_debugOwner": null,
+                          "_debugSource": null,
+                          "actualDuration": 0,
+                          "actualStartTime": -1,
+                          "alternate": [Circular],
+                          "child": null,
+                          "childExpirationTime": 0,
+                          "contextDependencies": null,
+                          "effectTag": 0,
+                          "elementType": null,
+                          "expirationTime": 1073741823,
+                          "firstEffect": null,
+                          "index": 0,
+                          "key": null,
+                          "lastEffect": null,
+                          "memoizedProps": null,
+                          "memoizedState": null,
+                          "mode": 0,
+                          "nextEffect": null,
+                          "pendingProps": null,
+                          "ref": null,
+                          "return": null,
+                          "selfBaseDuration": 0,
+                          "sibling": null,
+                          "stateNode": Object {
+                            "containerInfo": <div />,
+                            "context": Object {},
+                            "current": [Circular],
+                            "didError": false,
+                            "earliestPendingTime": 0,
+                            "earliestSuspendedTime": 0,
+                            "expirationTime": 0,
+                            "finishedWork": null,
+                            "firstBatch": null,
+                            "hydrate": false,
+                            "interactionThreadID": 15,
+                            "latestPendingTime": 0,
+                            "latestPingedTime": 0,
+                            "latestSuspendedTime": 0,
+                            "memoizedInteractions": Set {},
+                            "nextExpirationTimeToWorkOn": 0,
+                            "nextScheduledRoot": null,
+                            "pendingChildren": null,
+                            "pendingCommitExpirationTime": 0,
+                            "pendingContext": null,
+                            "pendingInteractionMap": Map {},
+                            "pingCache": null,
+                            "timeoutHandle": -1,
+                          },
+                          "tag": 3,
+                          "treeBaseDuration": 0,
+                          "type": null,
+                          "updateQueue": Object {
+                            "baseState": null,
+                            "firstCapturedEffect": null,
+                            "firstCapturedUpdate": null,
+                            "firstEffect": null,
+                            "firstUpdate": Object {
+                              "callback": null,
+                              "expirationTime": 1073741823,
+                              "next": null,
+                              "nextEffect": null,
+                              "payload": Object {
+                                "element": <WrapperComponent
+                                  Component={[Function]}
+                                  context={null}
+                                  props={
+                                    Object {
+                                      "children": <AuthenticatedRoute
+                                        authenticated={true}
+                                        component={[Function]}
+                                        path="/dashboard"
+                                      />,
+                                    }
+                                  }
+                                  wrappingComponentProps={null}
+                                />,
+                              },
+                              "tag": 0,
+                            },
+                            "lastCapturedEffect": null,
+                            "lastCapturedUpdate": null,
+                            "lastEffect": null,
+                            "lastUpdate": Object {
+                              "callback": null,
+                              "expirationTime": 1073741823,
+                              "next": null,
+                              "nextEffect": null,
+                              "payload": Object {
+                                "element": <WrapperComponent
+                                  Component={[Function]}
+                                  context={null}
+                                  props={
+                                    Object {
+                                      "children": <AuthenticatedRoute
+                                        authenticated={true}
+                                        component={[Function]}
+                                        path="/dashboard"
+                                      />,
+                                    }
+                                  }
+                                  wrappingComponentProps={null}
+                                />,
+                              },
+                              "tag": 0,
+                            },
+                          },
+                        },
+                        "child": [Circular],
+                        "childExpirationTime": 0,
+                        "contextDependencies": null,
+                        "effectTag": 32,
+                        "elementType": null,
+                        "expirationTime": 0,
+                        "firstEffect": [Circular],
+                        "index": 0,
+                        "key": null,
+                        "lastEffect": [Circular],
+                        "memoizedProps": null,
+                        "memoizedState": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={
+                              Object {
+                                "children": <AuthenticatedRoute
+                                  authenticated={true}
+                                  component={[Function]}
+                                  path="/dashboard"
+                                />,
+                              }
+                            }
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "mode": 0,
+                        "nextEffect": null,
+                        "pendingProps": null,
+                        "ref": null,
+                        "return": null,
+                        "selfBaseDuration": 0,
+                        "sibling": null,
+                        "stateNode": Object {
+                          "containerInfo": <div />,
+                          "context": Object {},
+                          "current": [Circular],
+                          "didError": false,
+                          "earliestPendingTime": 0,
+                          "earliestSuspendedTime": 0,
+                          "expirationTime": 0,
+                          "finishedWork": null,
+                          "firstBatch": null,
+                          "hydrate": false,
+                          "interactionThreadID": 15,
+                          "latestPendingTime": 0,
+                          "latestPingedTime": 0,
+                          "latestSuspendedTime": 0,
+                          "memoizedInteractions": Set {},
+                          "nextExpirationTimeToWorkOn": 0,
+                          "nextScheduledRoot": null,
+                          "pendingChildren": null,
+                          "pendingCommitExpirationTime": 0,
+                          "pendingContext": null,
+                          "pendingInteractionMap": Map {},
+                          "pingCache": null,
+                          "timeoutHandle": -1,
+                        },
+                        "tag": 3,
+                        "treeBaseDuration": 0,
+                        "type": null,
+                        "updateQueue": Object {
+                          "baseState": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={
+                                Object {
+                                  "children": <AuthenticatedRoute
+                                    authenticated={true}
+                                    component={[Function]}
+                                    path="/dashboard"
+                                  />,
+                                }
+                              }
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "firstCapturedEffect": null,
+                          "firstCapturedUpdate": null,
+                          "firstEffect": null,
+                          "firstUpdate": null,
+                          "lastCapturedEffect": null,
+                          "lastCapturedUpdate": null,
+                          "lastEffect": null,
+                          "lastUpdate": null,
+                        },
+                      },
+                      "selfBaseDuration": 0,
+                      "sibling": null,
+                      "stateNode": WrapperComponent {
+                        "_reactInternalFiber": [Circular],
+                        "_reactInternalInstance": Object {},
+                        "context": Object {},
+                        "props": Object {
+                          "Component": [Function],
+                          "context": null,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "refs": Object {},
+                        "rootFinderInstance": null,
+                        "state": Object {
+                          "context": null,
+                          "mount": true,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "updater": Object {
+                          "enqueueForceUpdate": [Function],
+                          "enqueueReplaceState": [Function],
+                          "enqueueSetState": [Function],
+                          "isMounted": [Function],
+                        },
+                      },
+                      "tag": 1,
+                      "treeBaseDuration": 0,
+                      "type": [Function],
+                      "updateQueue": null,
+                    },
+                    "_debugSource": null,
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": null,
+                    "child": [Circular],
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 1,
+                    "elementType": [Function],
+                    "expirationTime": 0,
+                    "firstEffect": null,
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": null,
+                    "memoizedProps": Object {
+                      "children": <AuthenticatedRoute
+                        authenticated={true}
+                        component={[Function]}
+                        path="/dashboard"
+                      />,
+                    },
+                    "memoizedState": null,
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": Object {
+                      "children": <AuthenticatedRoute
+                        authenticated={true}
+                        component={[Function]}
+                        path="/dashboard"
+                      />,
+                    },
+                    "ref": null,
+                    "return": FiberNode {
+                      "_debugHookTypes": null,
+                      "_debugID": 62,
+                      "_debugIsCurrentlyTiming": false,
+                      "_debugOwner": null,
+                      "_debugSource": null,
+                      "actualDuration": 0,
+                      "actualStartTime": -1,
+                      "alternate": null,
+                      "child": [Circular],
+                      "childExpirationTime": 0,
+                      "contextDependencies": null,
+                      "effectTag": 1,
+                      "elementType": [Function],
+                      "expirationTime": 0,
+                      "firstEffect": null,
+                      "index": 0,
+                      "key": null,
+                      "lastEffect": null,
+                      "memoizedProps": Object {
+                        "Component": [Function],
+                        "context": null,
+                        "props": Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        },
+                        "wrappingComponentProps": null,
+                      },
+                      "memoizedState": Object {
+                        "context": null,
+                        "mount": true,
+                        "props": Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        },
+                        "wrappingComponentProps": null,
+                      },
+                      "mode": 0,
+                      "nextEffect": FiberNode {
+                        "_debugHookTypes": null,
+                        "_debugID": 60,
+                        "_debugIsCurrentlyTiming": false,
+                        "_debugOwner": null,
+                        "_debugSource": null,
+                        "actualDuration": 0,
+                        "actualStartTime": -1,
+                        "alternate": FiberNode {
+                          "_debugHookTypes": null,
+                          "_debugID": 60,
+                          "_debugIsCurrentlyTiming": false,
+                          "_debugOwner": null,
+                          "_debugSource": null,
+                          "actualDuration": 0,
+                          "actualStartTime": -1,
+                          "alternate": [Circular],
+                          "child": null,
+                          "childExpirationTime": 0,
+                          "contextDependencies": null,
+                          "effectTag": 0,
+                          "elementType": null,
+                          "expirationTime": 1073741823,
+                          "firstEffect": null,
+                          "index": 0,
+                          "key": null,
+                          "lastEffect": null,
+                          "memoizedProps": null,
+                          "memoizedState": null,
+                          "mode": 0,
+                          "nextEffect": null,
+                          "pendingProps": null,
+                          "ref": null,
+                          "return": null,
+                          "selfBaseDuration": 0,
+                          "sibling": null,
+                          "stateNode": Object {
+                            "containerInfo": <div />,
+                            "context": Object {},
+                            "current": [Circular],
+                            "didError": false,
+                            "earliestPendingTime": 0,
+                            "earliestSuspendedTime": 0,
+                            "expirationTime": 0,
+                            "finishedWork": null,
+                            "firstBatch": null,
+                            "hydrate": false,
+                            "interactionThreadID": 15,
+                            "latestPendingTime": 0,
+                            "latestPingedTime": 0,
+                            "latestSuspendedTime": 0,
+                            "memoizedInteractions": Set {},
+                            "nextExpirationTimeToWorkOn": 0,
+                            "nextScheduledRoot": null,
+                            "pendingChildren": null,
+                            "pendingCommitExpirationTime": 0,
+                            "pendingContext": null,
+                            "pendingInteractionMap": Map {},
+                            "pingCache": null,
+                            "timeoutHandle": -1,
+                          },
+                          "tag": 3,
+                          "treeBaseDuration": 0,
+                          "type": null,
+                          "updateQueue": Object {
+                            "baseState": null,
+                            "firstCapturedEffect": null,
+                            "firstCapturedUpdate": null,
+                            "firstEffect": null,
+                            "firstUpdate": Object {
+                              "callback": null,
+                              "expirationTime": 1073741823,
+                              "next": null,
+                              "nextEffect": null,
+                              "payload": Object {
+                                "element": <WrapperComponent
+                                  Component={[Function]}
+                                  context={null}
+                                  props={
+                                    Object {
+                                      "children": <AuthenticatedRoute
+                                        authenticated={true}
+                                        component={[Function]}
+                                        path="/dashboard"
+                                      />,
+                                    }
+                                  }
+                                  wrappingComponentProps={null}
+                                />,
+                              },
+                              "tag": 0,
+                            },
+                            "lastCapturedEffect": null,
+                            "lastCapturedUpdate": null,
+                            "lastEffect": null,
+                            "lastUpdate": Object {
+                              "callback": null,
+                              "expirationTime": 1073741823,
+                              "next": null,
+                              "nextEffect": null,
+                              "payload": Object {
+                                "element": <WrapperComponent
+                                  Component={[Function]}
+                                  context={null}
+                                  props={
+                                    Object {
+                                      "children": <AuthenticatedRoute
+                                        authenticated={true}
+                                        component={[Function]}
+                                        path="/dashboard"
+                                      />,
+                                    }
+                                  }
+                                  wrappingComponentProps={null}
+                                />,
+                              },
+                              "tag": 0,
+                            },
+                          },
+                        },
+                        "child": [Circular],
+                        "childExpirationTime": 0,
+                        "contextDependencies": null,
+                        "effectTag": 32,
+                        "elementType": null,
+                        "expirationTime": 0,
+                        "firstEffect": [Circular],
+                        "index": 0,
+                        "key": null,
+                        "lastEffect": [Circular],
+                        "memoizedProps": null,
+                        "memoizedState": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={
+                              Object {
+                                "children": <AuthenticatedRoute
+                                  authenticated={true}
+                                  component={[Function]}
+                                  path="/dashboard"
+                                />,
+                              }
+                            }
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "mode": 0,
+                        "nextEffect": null,
+                        "pendingProps": null,
+                        "ref": null,
+                        "return": null,
+                        "selfBaseDuration": 0,
+                        "sibling": null,
+                        "stateNode": Object {
+                          "containerInfo": <div />,
+                          "context": Object {},
+                          "current": [Circular],
+                          "didError": false,
+                          "earliestPendingTime": 0,
+                          "earliestSuspendedTime": 0,
+                          "expirationTime": 0,
+                          "finishedWork": null,
+                          "firstBatch": null,
+                          "hydrate": false,
+                          "interactionThreadID": 15,
+                          "latestPendingTime": 0,
+                          "latestPingedTime": 0,
+                          "latestSuspendedTime": 0,
+                          "memoizedInteractions": Set {},
+                          "nextExpirationTimeToWorkOn": 0,
+                          "nextScheduledRoot": null,
+                          "pendingChildren": null,
+                          "pendingCommitExpirationTime": 0,
+                          "pendingContext": null,
+                          "pendingInteractionMap": Map {},
+                          "pingCache": null,
+                          "timeoutHandle": -1,
+                        },
+                        "tag": 3,
+                        "treeBaseDuration": 0,
+                        "type": null,
+                        "updateQueue": Object {
+                          "baseState": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={
+                                Object {
+                                  "children": <AuthenticatedRoute
+                                    authenticated={true}
+                                    component={[Function]}
+                                    path="/dashboard"
+                                  />,
+                                }
+                              }
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "firstCapturedEffect": null,
+                          "firstCapturedUpdate": null,
+                          "firstEffect": null,
+                          "firstUpdate": null,
+                          "lastCapturedEffect": null,
+                          "lastCapturedUpdate": null,
+                          "lastEffect": null,
+                          "lastUpdate": null,
+                        },
+                      },
+                      "pendingProps": Object {
+                        "Component": [Function],
+                        "context": null,
+                        "props": Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        },
+                        "wrappingComponentProps": null,
+                      },
+                      "ref": null,
+                      "return": FiberNode {
+                        "_debugHookTypes": null,
+                        "_debugID": 60,
+                        "_debugIsCurrentlyTiming": false,
+                        "_debugOwner": null,
+                        "_debugSource": null,
+                        "actualDuration": 0,
+                        "actualStartTime": -1,
+                        "alternate": FiberNode {
+                          "_debugHookTypes": null,
+                          "_debugID": 60,
+                          "_debugIsCurrentlyTiming": false,
+                          "_debugOwner": null,
+                          "_debugSource": null,
+                          "actualDuration": 0,
+                          "actualStartTime": -1,
+                          "alternate": [Circular],
+                          "child": null,
+                          "childExpirationTime": 0,
+                          "contextDependencies": null,
+                          "effectTag": 0,
+                          "elementType": null,
+                          "expirationTime": 1073741823,
+                          "firstEffect": null,
+                          "index": 0,
+                          "key": null,
+                          "lastEffect": null,
+                          "memoizedProps": null,
+                          "memoizedState": null,
+                          "mode": 0,
+                          "nextEffect": null,
+                          "pendingProps": null,
+                          "ref": null,
+                          "return": null,
+                          "selfBaseDuration": 0,
+                          "sibling": null,
+                          "stateNode": Object {
+                            "containerInfo": <div />,
+                            "context": Object {},
+                            "current": [Circular],
+                            "didError": false,
+                            "earliestPendingTime": 0,
+                            "earliestSuspendedTime": 0,
+                            "expirationTime": 0,
+                            "finishedWork": null,
+                            "firstBatch": null,
+                            "hydrate": false,
+                            "interactionThreadID": 15,
+                            "latestPendingTime": 0,
+                            "latestPingedTime": 0,
+                            "latestSuspendedTime": 0,
+                            "memoizedInteractions": Set {},
+                            "nextExpirationTimeToWorkOn": 0,
+                            "nextScheduledRoot": null,
+                            "pendingChildren": null,
+                            "pendingCommitExpirationTime": 0,
+                            "pendingContext": null,
+                            "pendingInteractionMap": Map {},
+                            "pingCache": null,
+                            "timeoutHandle": -1,
+                          },
+                          "tag": 3,
+                          "treeBaseDuration": 0,
+                          "type": null,
+                          "updateQueue": Object {
+                            "baseState": null,
+                            "firstCapturedEffect": null,
+                            "firstCapturedUpdate": null,
+                            "firstEffect": null,
+                            "firstUpdate": Object {
+                              "callback": null,
+                              "expirationTime": 1073741823,
+                              "next": null,
+                              "nextEffect": null,
+                              "payload": Object {
+                                "element": <WrapperComponent
+                                  Component={[Function]}
+                                  context={null}
+                                  props={
+                                    Object {
+                                      "children": <AuthenticatedRoute
+                                        authenticated={true}
+                                        component={[Function]}
+                                        path="/dashboard"
+                                      />,
+                                    }
+                                  }
+                                  wrappingComponentProps={null}
+                                />,
+                              },
+                              "tag": 0,
+                            },
+                            "lastCapturedEffect": null,
+                            "lastCapturedUpdate": null,
+                            "lastEffect": null,
+                            "lastUpdate": Object {
+                              "callback": null,
+                              "expirationTime": 1073741823,
+                              "next": null,
+                              "nextEffect": null,
+                              "payload": Object {
+                                "element": <WrapperComponent
+                                  Component={[Function]}
+                                  context={null}
+                                  props={
+                                    Object {
+                                      "children": <AuthenticatedRoute
+                                        authenticated={true}
+                                        component={[Function]}
+                                        path="/dashboard"
+                                      />,
+                                    }
+                                  }
+                                  wrappingComponentProps={null}
+                                />,
+                              },
+                              "tag": 0,
+                            },
+                          },
+                        },
+                        "child": [Circular],
+                        "childExpirationTime": 0,
+                        "contextDependencies": null,
+                        "effectTag": 32,
+                        "elementType": null,
+                        "expirationTime": 0,
+                        "firstEffect": [Circular],
+                        "index": 0,
+                        "key": null,
+                        "lastEffect": [Circular],
+                        "memoizedProps": null,
+                        "memoizedState": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={
+                              Object {
+                                "children": <AuthenticatedRoute
+                                  authenticated={true}
+                                  component={[Function]}
+                                  path="/dashboard"
+                                />,
+                              }
+                            }
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "mode": 0,
+                        "nextEffect": null,
+                        "pendingProps": null,
+                        "ref": null,
+                        "return": null,
+                        "selfBaseDuration": 0,
+                        "sibling": null,
+                        "stateNode": Object {
+                          "containerInfo": <div />,
+                          "context": Object {},
+                          "current": [Circular],
+                          "didError": false,
+                          "earliestPendingTime": 0,
+                          "earliestSuspendedTime": 0,
+                          "expirationTime": 0,
+                          "finishedWork": null,
+                          "firstBatch": null,
+                          "hydrate": false,
+                          "interactionThreadID": 15,
+                          "latestPendingTime": 0,
+                          "latestPingedTime": 0,
+                          "latestSuspendedTime": 0,
+                          "memoizedInteractions": Set {},
+                          "nextExpirationTimeToWorkOn": 0,
+                          "nextScheduledRoot": null,
+                          "pendingChildren": null,
+                          "pendingCommitExpirationTime": 0,
+                          "pendingContext": null,
+                          "pendingInteractionMap": Map {},
+                          "pingCache": null,
+                          "timeoutHandle": -1,
+                        },
+                        "tag": 3,
+                        "treeBaseDuration": 0,
+                        "type": null,
+                        "updateQueue": Object {
+                          "baseState": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={
+                                Object {
+                                  "children": <AuthenticatedRoute
+                                    authenticated={true}
+                                    component={[Function]}
+                                    path="/dashboard"
+                                  />,
+                                }
+                              }
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "firstCapturedEffect": null,
+                          "firstCapturedUpdate": null,
+                          "firstEffect": null,
+                          "firstUpdate": null,
+                          "lastCapturedEffect": null,
+                          "lastCapturedUpdate": null,
+                          "lastEffect": null,
+                          "lastUpdate": null,
+                        },
+                      },
+                      "selfBaseDuration": 0,
+                      "sibling": null,
+                      "stateNode": WrapperComponent {
+                        "_reactInternalFiber": [Circular],
+                        "_reactInternalInstance": Object {},
+                        "context": Object {},
+                        "props": Object {
+                          "Component": [Function],
+                          "context": null,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "refs": Object {},
+                        "rootFinderInstance": null,
+                        "state": Object {
+                          "context": null,
+                          "mount": true,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "updater": Object {
+                          "enqueueForceUpdate": [Function],
+                          "enqueueReplaceState": [Function],
+                          "enqueueSetState": [Function],
+                          "isMounted": [Function],
+                        },
+                      },
+                      "tag": 1,
+                      "treeBaseDuration": 0,
+                      "type": [Function],
+                      "updateQueue": null,
+                    },
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": BrowserRouter {
+                      "_reactInternalFiber": [Circular],
+                      "_reactInternalInstance": Object {},
+                      "context": Object {},
+                      "history": Object {
+                        "action": "POP",
+                        "block": [Function],
+                        "createHref": [Function],
+                        "go": [Function],
+                        "goBack": [Function],
+                        "goForward": [Function],
+                        "length": 1,
+                        "listen": [Function],
+                        "location": Object {
+                          "hash": "",
+                          "pathname": "/",
+                          "search": "",
+                          "state": undefined,
+                        },
+                        "push": [Function],
+                        "replace": [Function],
+                      },
+                      "props": Object {
+                        "children": <AuthenticatedRoute
+                          authenticated={true}
+                          component={[Function]}
+                          path="/dashboard"
+                        />,
+                      },
+                      "refs": Object {},
+                      "state": null,
+                      "updater": Object {
+                        "enqueueForceUpdate": [Function],
+                        "enqueueReplaceState": [Function],
+                        "enqueueSetState": [Function],
+                        "isMounted": [Function],
+                      },
+                    },
+                    "tag": 1,
+                    "treeBaseDuration": 0,
+                    "type": [Function],
+                    "updateQueue": null,
+                  },
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": Router {
+                    "__reactInternalMemoizedMaskedChildContext": Object {
+                      "router": undefined,
+                    },
+                    "__reactInternalMemoizedMergedChildContext": Object {
+                      "router": Object {
+                        "history": Object {
+                          "action": "POP",
+                          "block": [Function],
+                          "createHref": [Function],
+                          "go": [Function],
+                          "goBack": [Function],
+                          "goForward": [Function],
+                          "length": 1,
+                          "listen": [Function],
+                          "location": Object {
+                            "hash": "",
+                            "pathname": "/",
+                            "search": "",
+                            "state": undefined,
+                          },
+                          "push": [Function],
+                          "replace": [Function],
+                        },
+                        "route": Object {
+                          "location": Object {
+                            "hash": "",
+                            "pathname": "/",
+                            "search": "",
+                            "state": undefined,
+                          },
+                          "match": Object {
+                            "isExact": true,
+                            "params": Object {},
+                            "path": "/",
+                            "url": "/",
+                          },
+                        },
+                      },
+                    },
+                    "__reactInternalMemoizedUnmaskedChildContext": Object {},
+                    "_reactInternalFiber": [Circular],
+                    "_reactInternalInstance": Object {},
+                    "context": Object {
+                      "router": undefined,
+                    },
+                    "props": Object {
+                      "children": <AuthenticatedRoute
+                        authenticated={true}
+                        component={[Function]}
+                        path="/dashboard"
+                      />,
+                      "history": Object {
+                        "action": "POP",
+                        "block": [Function],
+                        "createHref": [Function],
+                        "go": [Function],
+                        "goBack": [Function],
+                        "goForward": [Function],
+                        "length": 1,
+                        "listen": [Function],
+                        "location": Object {
+                          "hash": "",
+                          "pathname": "/",
+                          "search": "",
+                          "state": undefined,
+                        },
+                        "push": [Function],
+                        "replace": [Function],
+                      },
+                    },
+                    "refs": Object {},
+                    "state": Object {
+                      "match": Object {
+                        "isExact": true,
+                        "params": Object {},
+                        "path": "/",
+                        "url": "/",
+                      },
+                    },
+                    "unlisten": [Function],
+                    "updater": Object {
+                      "enqueueForceUpdate": [Function],
+                      "enqueueReplaceState": [Function],
+                      "enqueueSetState": [Function],
+                      "isMounted": [Function],
+                    },
+                  },
+                  "tag": 1,
+                  "treeBaseDuration": 0,
+                  "type": [Function],
+                  "updateQueue": null,
+                },
+                "selfBaseDuration": 0,
+                "sibling": null,
+                "stateNode": null,
+                "tag": 0,
+                "treeBaseDuration": 0,
+                "type": [Function],
+                "updateQueue": null,
+              },
+              "_debugSource": Object {
+                "fileName": "/Users/chucky/Code/Bench/bp-esa-frontend/src/App.jsx",
+                "lineNumber": 15,
+              },
+              "actualDuration": 0,
+              "actualStartTime": -1,
+              "alternate": null,
+              "child": null,
+              "childExpirationTime": 0,
+              "contextDependencies": null,
+              "effectTag": 1,
+              "elementType": [Function],
+              "expirationTime": 0,
+              "firstEffect": null,
+              "index": 0,
+              "key": null,
+              "lastEffect": null,
+              "memoizedProps": Object {
+                "path": "/dashboard",
+                "render": [Function],
+              },
+              "memoizedState": Object {
+                "match": null,
+              },
+              "mode": 0,
+              "nextEffect": null,
+              "pendingProps": Object {
+                "path": "/dashboard",
+                "render": [Function],
+              },
+              "ref": null,
+              "return": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 65,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": null,
+                "_debugSource": Object {
+                  "fileName": "/Users/chucky/Code/Bench/bp-esa-frontend/src/App.test.jsx",
+                  "lineNumber": 123,
+                },
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": null,
+                "child": [Circular],
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 1,
+                "elementType": [Function],
+                "expirationTime": 0,
+                "firstEffect": null,
+                "index": 0,
+                "key": null,
+                "lastEffect": null,
+                "memoizedProps": Object {
+                  "authenticated": true,
+                  "component": [Function],
+                  "path": "/dashboard",
+                },
+                "memoizedState": null,
+                "mode": 0,
+                "nextEffect": null,
+                "pendingProps": Object {
+                  "authenticated": true,
+                  "component": [Function],
+                  "path": "/dashboard",
+                },
+                "ref": null,
+                "return": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 64,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 63,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": FiberNode {
+                      "_debugHookTypes": null,
+                      "_debugID": 62,
+                      "_debugIsCurrentlyTiming": false,
+                      "_debugOwner": null,
+                      "_debugSource": null,
+                      "actualDuration": 0,
+                      "actualStartTime": -1,
+                      "alternate": null,
+                      "child": [Circular],
+                      "childExpirationTime": 0,
+                      "contextDependencies": null,
+                      "effectTag": 1,
+                      "elementType": [Function],
+                      "expirationTime": 0,
+                      "firstEffect": null,
+                      "index": 0,
+                      "key": null,
+                      "lastEffect": null,
+                      "memoizedProps": Object {
+                        "Component": [Function],
+                        "context": null,
+                        "props": Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        },
+                        "wrappingComponentProps": null,
+                      },
+                      "memoizedState": Object {
+                        "context": null,
+                        "mount": true,
+                        "props": Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        },
+                        "wrappingComponentProps": null,
+                      },
+                      "mode": 0,
+                      "nextEffect": FiberNode {
+                        "_debugHookTypes": null,
+                        "_debugID": 60,
+                        "_debugIsCurrentlyTiming": false,
+                        "_debugOwner": null,
+                        "_debugSource": null,
+                        "actualDuration": 0,
+                        "actualStartTime": -1,
+                        "alternate": FiberNode {
+                          "_debugHookTypes": null,
+                          "_debugID": 60,
+                          "_debugIsCurrentlyTiming": false,
+                          "_debugOwner": null,
+                          "_debugSource": null,
+                          "actualDuration": 0,
+                          "actualStartTime": -1,
+                          "alternate": [Circular],
+                          "child": null,
+                          "childExpirationTime": 0,
+                          "contextDependencies": null,
+                          "effectTag": 0,
+                          "elementType": null,
+                          "expirationTime": 1073741823,
+                          "firstEffect": null,
+                          "index": 0,
+                          "key": null,
+                          "lastEffect": null,
+                          "memoizedProps": null,
+                          "memoizedState": null,
+                          "mode": 0,
+                          "nextEffect": null,
+                          "pendingProps": null,
+                          "ref": null,
+                          "return": null,
+                          "selfBaseDuration": 0,
+                          "sibling": null,
+                          "stateNode": Object {
+                            "containerInfo": <div />,
+                            "context": Object {},
+                            "current": [Circular],
+                            "didError": false,
+                            "earliestPendingTime": 0,
+                            "earliestSuspendedTime": 0,
+                            "expirationTime": 0,
+                            "finishedWork": null,
+                            "firstBatch": null,
+                            "hydrate": false,
+                            "interactionThreadID": 15,
+                            "latestPendingTime": 0,
+                            "latestPingedTime": 0,
+                            "latestSuspendedTime": 0,
+                            "memoizedInteractions": Set {},
+                            "nextExpirationTimeToWorkOn": 0,
+                            "nextScheduledRoot": null,
+                            "pendingChildren": null,
+                            "pendingCommitExpirationTime": 0,
+                            "pendingContext": null,
+                            "pendingInteractionMap": Map {},
+                            "pingCache": null,
+                            "timeoutHandle": -1,
+                          },
+                          "tag": 3,
+                          "treeBaseDuration": 0,
+                          "type": null,
+                          "updateQueue": Object {
+                            "baseState": null,
+                            "firstCapturedEffect": null,
+                            "firstCapturedUpdate": null,
+                            "firstEffect": null,
+                            "firstUpdate": Object {
+                              "callback": null,
+                              "expirationTime": 1073741823,
+                              "next": null,
+                              "nextEffect": null,
+                              "payload": Object {
+                                "element": <WrapperComponent
+                                  Component={[Function]}
+                                  context={null}
+                                  props={
+                                    Object {
+                                      "children": <AuthenticatedRoute
+                                        authenticated={true}
+                                        component={[Function]}
+                                        path="/dashboard"
+                                      />,
+                                    }
+                                  }
+                                  wrappingComponentProps={null}
+                                />,
+                              },
+                              "tag": 0,
+                            },
+                            "lastCapturedEffect": null,
+                            "lastCapturedUpdate": null,
+                            "lastEffect": null,
+                            "lastUpdate": Object {
+                              "callback": null,
+                              "expirationTime": 1073741823,
+                              "next": null,
+                              "nextEffect": null,
+                              "payload": Object {
+                                "element": <WrapperComponent
+                                  Component={[Function]}
+                                  context={null}
+                                  props={
+                                    Object {
+                                      "children": <AuthenticatedRoute
+                                        authenticated={true}
+                                        component={[Function]}
+                                        path="/dashboard"
+                                      />,
+                                    }
+                                  }
+                                  wrappingComponentProps={null}
+                                />,
+                              },
+                              "tag": 0,
+                            },
+                          },
+                        },
+                        "child": [Circular],
+                        "childExpirationTime": 0,
+                        "contextDependencies": null,
+                        "effectTag": 32,
+                        "elementType": null,
+                        "expirationTime": 0,
+                        "firstEffect": [Circular],
+                        "index": 0,
+                        "key": null,
+                        "lastEffect": [Circular],
+                        "memoizedProps": null,
+                        "memoizedState": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={
+                              Object {
+                                "children": <AuthenticatedRoute
+                                  authenticated={true}
+                                  component={[Function]}
+                                  path="/dashboard"
+                                />,
+                              }
+                            }
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "mode": 0,
+                        "nextEffect": null,
+                        "pendingProps": null,
+                        "ref": null,
+                        "return": null,
+                        "selfBaseDuration": 0,
+                        "sibling": null,
+                        "stateNode": Object {
+                          "containerInfo": <div />,
+                          "context": Object {},
+                          "current": [Circular],
+                          "didError": false,
+                          "earliestPendingTime": 0,
+                          "earliestSuspendedTime": 0,
+                          "expirationTime": 0,
+                          "finishedWork": null,
+                          "firstBatch": null,
+                          "hydrate": false,
+                          "interactionThreadID": 15,
+                          "latestPendingTime": 0,
+                          "latestPingedTime": 0,
+                          "latestSuspendedTime": 0,
+                          "memoizedInteractions": Set {},
+                          "nextExpirationTimeToWorkOn": 0,
+                          "nextScheduledRoot": null,
+                          "pendingChildren": null,
+                          "pendingCommitExpirationTime": 0,
+                          "pendingContext": null,
+                          "pendingInteractionMap": Map {},
+                          "pingCache": null,
+                          "timeoutHandle": -1,
+                        },
+                        "tag": 3,
+                        "treeBaseDuration": 0,
+                        "type": null,
+                        "updateQueue": Object {
+                          "baseState": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={
+                                Object {
+                                  "children": <AuthenticatedRoute
+                                    authenticated={true}
+                                    component={[Function]}
+                                    path="/dashboard"
+                                  />,
+                                }
+                              }
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "firstCapturedEffect": null,
+                          "firstCapturedUpdate": null,
+                          "firstEffect": null,
+                          "firstUpdate": null,
+                          "lastCapturedEffect": null,
+                          "lastCapturedUpdate": null,
+                          "lastEffect": null,
+                          "lastUpdate": null,
+                        },
+                      },
+                      "pendingProps": Object {
+                        "Component": [Function],
+                        "context": null,
+                        "props": Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        },
+                        "wrappingComponentProps": null,
+                      },
+                      "ref": null,
+                      "return": FiberNode {
+                        "_debugHookTypes": null,
+                        "_debugID": 60,
+                        "_debugIsCurrentlyTiming": false,
+                        "_debugOwner": null,
+                        "_debugSource": null,
+                        "actualDuration": 0,
+                        "actualStartTime": -1,
+                        "alternate": FiberNode {
+                          "_debugHookTypes": null,
+                          "_debugID": 60,
+                          "_debugIsCurrentlyTiming": false,
+                          "_debugOwner": null,
+                          "_debugSource": null,
+                          "actualDuration": 0,
+                          "actualStartTime": -1,
+                          "alternate": [Circular],
+                          "child": null,
+                          "childExpirationTime": 0,
+                          "contextDependencies": null,
+                          "effectTag": 0,
+                          "elementType": null,
+                          "expirationTime": 1073741823,
+                          "firstEffect": null,
+                          "index": 0,
+                          "key": null,
+                          "lastEffect": null,
+                          "memoizedProps": null,
+                          "memoizedState": null,
+                          "mode": 0,
+                          "nextEffect": null,
+                          "pendingProps": null,
+                          "ref": null,
+                          "return": null,
+                          "selfBaseDuration": 0,
+                          "sibling": null,
+                          "stateNode": Object {
+                            "containerInfo": <div />,
+                            "context": Object {},
+                            "current": [Circular],
+                            "didError": false,
+                            "earliestPendingTime": 0,
+                            "earliestSuspendedTime": 0,
+                            "expirationTime": 0,
+                            "finishedWork": null,
+                            "firstBatch": null,
+                            "hydrate": false,
+                            "interactionThreadID": 15,
+                            "latestPendingTime": 0,
+                            "latestPingedTime": 0,
+                            "latestSuspendedTime": 0,
+                            "memoizedInteractions": Set {},
+                            "nextExpirationTimeToWorkOn": 0,
+                            "nextScheduledRoot": null,
+                            "pendingChildren": null,
+                            "pendingCommitExpirationTime": 0,
+                            "pendingContext": null,
+                            "pendingInteractionMap": Map {},
+                            "pingCache": null,
+                            "timeoutHandle": -1,
+                          },
+                          "tag": 3,
+                          "treeBaseDuration": 0,
+                          "type": null,
+                          "updateQueue": Object {
+                            "baseState": null,
+                            "firstCapturedEffect": null,
+                            "firstCapturedUpdate": null,
+                            "firstEffect": null,
+                            "firstUpdate": Object {
+                              "callback": null,
+                              "expirationTime": 1073741823,
+                              "next": null,
+                              "nextEffect": null,
+                              "payload": Object {
+                                "element": <WrapperComponent
+                                  Component={[Function]}
+                                  context={null}
+                                  props={
+                                    Object {
+                                      "children": <AuthenticatedRoute
+                                        authenticated={true}
+                                        component={[Function]}
+                                        path="/dashboard"
+                                      />,
+                                    }
+                                  }
+                                  wrappingComponentProps={null}
+                                />,
+                              },
+                              "tag": 0,
+                            },
+                            "lastCapturedEffect": null,
+                            "lastCapturedUpdate": null,
+                            "lastEffect": null,
+                            "lastUpdate": Object {
+                              "callback": null,
+                              "expirationTime": 1073741823,
+                              "next": null,
+                              "nextEffect": null,
+                              "payload": Object {
+                                "element": <WrapperComponent
+                                  Component={[Function]}
+                                  context={null}
+                                  props={
+                                    Object {
+                                      "children": <AuthenticatedRoute
+                                        authenticated={true}
+                                        component={[Function]}
+                                        path="/dashboard"
+                                      />,
+                                    }
+                                  }
+                                  wrappingComponentProps={null}
+                                />,
+                              },
+                              "tag": 0,
+                            },
+                          },
+                        },
+                        "child": [Circular],
+                        "childExpirationTime": 0,
+                        "contextDependencies": null,
+                        "effectTag": 32,
+                        "elementType": null,
+                        "expirationTime": 0,
+                        "firstEffect": [Circular],
+                        "index": 0,
+                        "key": null,
+                        "lastEffect": [Circular],
+                        "memoizedProps": null,
+                        "memoizedState": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={
+                              Object {
+                                "children": <AuthenticatedRoute
+                                  authenticated={true}
+                                  component={[Function]}
+                                  path="/dashboard"
+                                />,
+                              }
+                            }
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "mode": 0,
+                        "nextEffect": null,
+                        "pendingProps": null,
+                        "ref": null,
+                        "return": null,
+                        "selfBaseDuration": 0,
+                        "sibling": null,
+                        "stateNode": Object {
+                          "containerInfo": <div />,
+                          "context": Object {},
+                          "current": [Circular],
+                          "didError": false,
+                          "earliestPendingTime": 0,
+                          "earliestSuspendedTime": 0,
+                          "expirationTime": 0,
+                          "finishedWork": null,
+                          "firstBatch": null,
+                          "hydrate": false,
+                          "interactionThreadID": 15,
+                          "latestPendingTime": 0,
+                          "latestPingedTime": 0,
+                          "latestSuspendedTime": 0,
+                          "memoizedInteractions": Set {},
+                          "nextExpirationTimeToWorkOn": 0,
+                          "nextScheduledRoot": null,
+                          "pendingChildren": null,
+                          "pendingCommitExpirationTime": 0,
+                          "pendingContext": null,
+                          "pendingInteractionMap": Map {},
+                          "pingCache": null,
+                          "timeoutHandle": -1,
+                        },
+                        "tag": 3,
+                        "treeBaseDuration": 0,
+                        "type": null,
+                        "updateQueue": Object {
+                          "baseState": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={
+                                Object {
+                                  "children": <AuthenticatedRoute
+                                    authenticated={true}
+                                    component={[Function]}
+                                    path="/dashboard"
+                                  />,
+                                }
+                              }
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "firstCapturedEffect": null,
+                          "firstCapturedUpdate": null,
+                          "firstEffect": null,
+                          "firstUpdate": null,
+                          "lastCapturedEffect": null,
+                          "lastCapturedUpdate": null,
+                          "lastEffect": null,
+                          "lastUpdate": null,
+                        },
+                      },
+                      "selfBaseDuration": 0,
+                      "sibling": null,
+                      "stateNode": WrapperComponent {
+                        "_reactInternalFiber": [Circular],
+                        "_reactInternalInstance": Object {},
+                        "context": Object {},
+                        "props": Object {
+                          "Component": [Function],
+                          "context": null,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "refs": Object {},
+                        "rootFinderInstance": null,
+                        "state": Object {
+                          "context": null,
+                          "mount": true,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "updater": Object {
+                          "enqueueForceUpdate": [Function],
+                          "enqueueReplaceState": [Function],
+                          "enqueueSetState": [Function],
+                          "isMounted": [Function],
+                        },
+                      },
+                      "tag": 1,
+                      "treeBaseDuration": 0,
+                      "type": [Function],
+                      "updateQueue": null,
+                    },
+                    "_debugSource": null,
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": null,
+                    "child": [Circular],
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 1,
+                    "elementType": [Function],
+                    "expirationTime": 0,
+                    "firstEffect": null,
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": null,
+                    "memoizedProps": Object {
+                      "children": <AuthenticatedRoute
+                        authenticated={true}
+                        component={[Function]}
+                        path="/dashboard"
+                      />,
+                    },
+                    "memoizedState": null,
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": Object {
+                      "children": <AuthenticatedRoute
+                        authenticated={true}
+                        component={[Function]}
+                        path="/dashboard"
+                      />,
+                    },
+                    "ref": null,
+                    "return": FiberNode {
+                      "_debugHookTypes": null,
+                      "_debugID": 62,
+                      "_debugIsCurrentlyTiming": false,
+                      "_debugOwner": null,
+                      "_debugSource": null,
+                      "actualDuration": 0,
+                      "actualStartTime": -1,
+                      "alternate": null,
+                      "child": [Circular],
+                      "childExpirationTime": 0,
+                      "contextDependencies": null,
+                      "effectTag": 1,
+                      "elementType": [Function],
+                      "expirationTime": 0,
+                      "firstEffect": null,
+                      "index": 0,
+                      "key": null,
+                      "lastEffect": null,
+                      "memoizedProps": Object {
+                        "Component": [Function],
+                        "context": null,
+                        "props": Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        },
+                        "wrappingComponentProps": null,
+                      },
+                      "memoizedState": Object {
+                        "context": null,
+                        "mount": true,
+                        "props": Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        },
+                        "wrappingComponentProps": null,
+                      },
+                      "mode": 0,
+                      "nextEffect": FiberNode {
+                        "_debugHookTypes": null,
+                        "_debugID": 60,
+                        "_debugIsCurrentlyTiming": false,
+                        "_debugOwner": null,
+                        "_debugSource": null,
+                        "actualDuration": 0,
+                        "actualStartTime": -1,
+                        "alternate": FiberNode {
+                          "_debugHookTypes": null,
+                          "_debugID": 60,
+                          "_debugIsCurrentlyTiming": false,
+                          "_debugOwner": null,
+                          "_debugSource": null,
+                          "actualDuration": 0,
+                          "actualStartTime": -1,
+                          "alternate": [Circular],
+                          "child": null,
+                          "childExpirationTime": 0,
+                          "contextDependencies": null,
+                          "effectTag": 0,
+                          "elementType": null,
+                          "expirationTime": 1073741823,
+                          "firstEffect": null,
+                          "index": 0,
+                          "key": null,
+                          "lastEffect": null,
+                          "memoizedProps": null,
+                          "memoizedState": null,
+                          "mode": 0,
+                          "nextEffect": null,
+                          "pendingProps": null,
+                          "ref": null,
+                          "return": null,
+                          "selfBaseDuration": 0,
+                          "sibling": null,
+                          "stateNode": Object {
+                            "containerInfo": <div />,
+                            "context": Object {},
+                            "current": [Circular],
+                            "didError": false,
+                            "earliestPendingTime": 0,
+                            "earliestSuspendedTime": 0,
+                            "expirationTime": 0,
+                            "finishedWork": null,
+                            "firstBatch": null,
+                            "hydrate": false,
+                            "interactionThreadID": 15,
+                            "latestPendingTime": 0,
+                            "latestPingedTime": 0,
+                            "latestSuspendedTime": 0,
+                            "memoizedInteractions": Set {},
+                            "nextExpirationTimeToWorkOn": 0,
+                            "nextScheduledRoot": null,
+                            "pendingChildren": null,
+                            "pendingCommitExpirationTime": 0,
+                            "pendingContext": null,
+                            "pendingInteractionMap": Map {},
+                            "pingCache": null,
+                            "timeoutHandle": -1,
+                          },
+                          "tag": 3,
+                          "treeBaseDuration": 0,
+                          "type": null,
+                          "updateQueue": Object {
+                            "baseState": null,
+                            "firstCapturedEffect": null,
+                            "firstCapturedUpdate": null,
+                            "firstEffect": null,
+                            "firstUpdate": Object {
+                              "callback": null,
+                              "expirationTime": 1073741823,
+                              "next": null,
+                              "nextEffect": null,
+                              "payload": Object {
+                                "element": <WrapperComponent
+                                  Component={[Function]}
+                                  context={null}
+                                  props={
+                                    Object {
+                                      "children": <AuthenticatedRoute
+                                        authenticated={true}
+                                        component={[Function]}
+                                        path="/dashboard"
+                                      />,
+                                    }
+                                  }
+                                  wrappingComponentProps={null}
+                                />,
+                              },
+                              "tag": 0,
+                            },
+                            "lastCapturedEffect": null,
+                            "lastCapturedUpdate": null,
+                            "lastEffect": null,
+                            "lastUpdate": Object {
+                              "callback": null,
+                              "expirationTime": 1073741823,
+                              "next": null,
+                              "nextEffect": null,
+                              "payload": Object {
+                                "element": <WrapperComponent
+                                  Component={[Function]}
+                                  context={null}
+                                  props={
+                                    Object {
+                                      "children": <AuthenticatedRoute
+                                        authenticated={true}
+                                        component={[Function]}
+                                        path="/dashboard"
+                                      />,
+                                    }
+                                  }
+                                  wrappingComponentProps={null}
+                                />,
+                              },
+                              "tag": 0,
+                            },
+                          },
+                        },
+                        "child": [Circular],
+                        "childExpirationTime": 0,
+                        "contextDependencies": null,
+                        "effectTag": 32,
+                        "elementType": null,
+                        "expirationTime": 0,
+                        "firstEffect": [Circular],
+                        "index": 0,
+                        "key": null,
+                        "lastEffect": [Circular],
+                        "memoizedProps": null,
+                        "memoizedState": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={
+                              Object {
+                                "children": <AuthenticatedRoute
+                                  authenticated={true}
+                                  component={[Function]}
+                                  path="/dashboard"
+                                />,
+                              }
+                            }
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "mode": 0,
+                        "nextEffect": null,
+                        "pendingProps": null,
+                        "ref": null,
+                        "return": null,
+                        "selfBaseDuration": 0,
+                        "sibling": null,
+                        "stateNode": Object {
+                          "containerInfo": <div />,
+                          "context": Object {},
+                          "current": [Circular],
+                          "didError": false,
+                          "earliestPendingTime": 0,
+                          "earliestSuspendedTime": 0,
+                          "expirationTime": 0,
+                          "finishedWork": null,
+                          "firstBatch": null,
+                          "hydrate": false,
+                          "interactionThreadID": 15,
+                          "latestPendingTime": 0,
+                          "latestPingedTime": 0,
+                          "latestSuspendedTime": 0,
+                          "memoizedInteractions": Set {},
+                          "nextExpirationTimeToWorkOn": 0,
+                          "nextScheduledRoot": null,
+                          "pendingChildren": null,
+                          "pendingCommitExpirationTime": 0,
+                          "pendingContext": null,
+                          "pendingInteractionMap": Map {},
+                          "pingCache": null,
+                          "timeoutHandle": -1,
+                        },
+                        "tag": 3,
+                        "treeBaseDuration": 0,
+                        "type": null,
+                        "updateQueue": Object {
+                          "baseState": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={
+                                Object {
+                                  "children": <AuthenticatedRoute
+                                    authenticated={true}
+                                    component={[Function]}
+                                    path="/dashboard"
+                                  />,
+                                }
+                              }
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "firstCapturedEffect": null,
+                          "firstCapturedUpdate": null,
+                          "firstEffect": null,
+                          "firstUpdate": null,
+                          "lastCapturedEffect": null,
+                          "lastCapturedUpdate": null,
+                          "lastEffect": null,
+                          "lastUpdate": null,
+                        },
+                      },
+                      "pendingProps": Object {
+                        "Component": [Function],
+                        "context": null,
+                        "props": Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        },
+                        "wrappingComponentProps": null,
+                      },
+                      "ref": null,
+                      "return": FiberNode {
+                        "_debugHookTypes": null,
+                        "_debugID": 60,
+                        "_debugIsCurrentlyTiming": false,
+                        "_debugOwner": null,
+                        "_debugSource": null,
+                        "actualDuration": 0,
+                        "actualStartTime": -1,
+                        "alternate": FiberNode {
+                          "_debugHookTypes": null,
+                          "_debugID": 60,
+                          "_debugIsCurrentlyTiming": false,
+                          "_debugOwner": null,
+                          "_debugSource": null,
+                          "actualDuration": 0,
+                          "actualStartTime": -1,
+                          "alternate": [Circular],
+                          "child": null,
+                          "childExpirationTime": 0,
+                          "contextDependencies": null,
+                          "effectTag": 0,
+                          "elementType": null,
+                          "expirationTime": 1073741823,
+                          "firstEffect": null,
+                          "index": 0,
+                          "key": null,
+                          "lastEffect": null,
+                          "memoizedProps": null,
+                          "memoizedState": null,
+                          "mode": 0,
+                          "nextEffect": null,
+                          "pendingProps": null,
+                          "ref": null,
+                          "return": null,
+                          "selfBaseDuration": 0,
+                          "sibling": null,
+                          "stateNode": Object {
+                            "containerInfo": <div />,
+                            "context": Object {},
+                            "current": [Circular],
+                            "didError": false,
+                            "earliestPendingTime": 0,
+                            "earliestSuspendedTime": 0,
+                            "expirationTime": 0,
+                            "finishedWork": null,
+                            "firstBatch": null,
+                            "hydrate": false,
+                            "interactionThreadID": 15,
+                            "latestPendingTime": 0,
+                            "latestPingedTime": 0,
+                            "latestSuspendedTime": 0,
+                            "memoizedInteractions": Set {},
+                            "nextExpirationTimeToWorkOn": 0,
+                            "nextScheduledRoot": null,
+                            "pendingChildren": null,
+                            "pendingCommitExpirationTime": 0,
+                            "pendingContext": null,
+                            "pendingInteractionMap": Map {},
+                            "pingCache": null,
+                            "timeoutHandle": -1,
+                          },
+                          "tag": 3,
+                          "treeBaseDuration": 0,
+                          "type": null,
+                          "updateQueue": Object {
+                            "baseState": null,
+                            "firstCapturedEffect": null,
+                            "firstCapturedUpdate": null,
+                            "firstEffect": null,
+                            "firstUpdate": Object {
+                              "callback": null,
+                              "expirationTime": 1073741823,
+                              "next": null,
+                              "nextEffect": null,
+                              "payload": Object {
+                                "element": <WrapperComponent
+                                  Component={[Function]}
+                                  context={null}
+                                  props={
+                                    Object {
+                                      "children": <AuthenticatedRoute
+                                        authenticated={true}
+                                        component={[Function]}
+                                        path="/dashboard"
+                                      />,
+                                    }
+                                  }
+                                  wrappingComponentProps={null}
+                                />,
+                              },
+                              "tag": 0,
+                            },
+                            "lastCapturedEffect": null,
+                            "lastCapturedUpdate": null,
+                            "lastEffect": null,
+                            "lastUpdate": Object {
+                              "callback": null,
+                              "expirationTime": 1073741823,
+                              "next": null,
+                              "nextEffect": null,
+                              "payload": Object {
+                                "element": <WrapperComponent
+                                  Component={[Function]}
+                                  context={null}
+                                  props={
+                                    Object {
+                                      "children": <AuthenticatedRoute
+                                        authenticated={true}
+                                        component={[Function]}
+                                        path="/dashboard"
+                                      />,
+                                    }
+                                  }
+                                  wrappingComponentProps={null}
+                                />,
+                              },
+                              "tag": 0,
+                            },
+                          },
+                        },
+                        "child": [Circular],
+                        "childExpirationTime": 0,
+                        "contextDependencies": null,
+                        "effectTag": 32,
+                        "elementType": null,
+                        "expirationTime": 0,
+                        "firstEffect": [Circular],
+                        "index": 0,
+                        "key": null,
+                        "lastEffect": [Circular],
+                        "memoizedProps": null,
+                        "memoizedState": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={
+                              Object {
+                                "children": <AuthenticatedRoute
+                                  authenticated={true}
+                                  component={[Function]}
+                                  path="/dashboard"
+                                />,
+                              }
+                            }
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "mode": 0,
+                        "nextEffect": null,
+                        "pendingProps": null,
+                        "ref": null,
+                        "return": null,
+                        "selfBaseDuration": 0,
+                        "sibling": null,
+                        "stateNode": Object {
+                          "containerInfo": <div />,
+                          "context": Object {},
+                          "current": [Circular],
+                          "didError": false,
+                          "earliestPendingTime": 0,
+                          "earliestSuspendedTime": 0,
+                          "expirationTime": 0,
+                          "finishedWork": null,
+                          "firstBatch": null,
+                          "hydrate": false,
+                          "interactionThreadID": 15,
+                          "latestPendingTime": 0,
+                          "latestPingedTime": 0,
+                          "latestSuspendedTime": 0,
+                          "memoizedInteractions": Set {},
+                          "nextExpirationTimeToWorkOn": 0,
+                          "nextScheduledRoot": null,
+                          "pendingChildren": null,
+                          "pendingCommitExpirationTime": 0,
+                          "pendingContext": null,
+                          "pendingInteractionMap": Map {},
+                          "pingCache": null,
+                          "timeoutHandle": -1,
+                        },
+                        "tag": 3,
+                        "treeBaseDuration": 0,
+                        "type": null,
+                        "updateQueue": Object {
+                          "baseState": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={
+                                Object {
+                                  "children": <AuthenticatedRoute
+                                    authenticated={true}
+                                    component={[Function]}
+                                    path="/dashboard"
+                                  />,
+                                }
+                              }
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "firstCapturedEffect": null,
+                          "firstCapturedUpdate": null,
+                          "firstEffect": null,
+                          "firstUpdate": null,
+                          "lastCapturedEffect": null,
+                          "lastCapturedUpdate": null,
+                          "lastEffect": null,
+                          "lastUpdate": null,
+                        },
+                      },
+                      "selfBaseDuration": 0,
+                      "sibling": null,
+                      "stateNode": WrapperComponent {
+                        "_reactInternalFiber": [Circular],
+                        "_reactInternalInstance": Object {},
+                        "context": Object {},
+                        "props": Object {
+                          "Component": [Function],
+                          "context": null,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "refs": Object {},
+                        "rootFinderInstance": null,
+                        "state": Object {
+                          "context": null,
+                          "mount": true,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "updater": Object {
+                          "enqueueForceUpdate": [Function],
+                          "enqueueReplaceState": [Function],
+                          "enqueueSetState": [Function],
+                          "isMounted": [Function],
+                        },
+                      },
+                      "tag": 1,
+                      "treeBaseDuration": 0,
+                      "type": [Function],
+                      "updateQueue": null,
+                    },
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": BrowserRouter {
+                      "_reactInternalFiber": [Circular],
+                      "_reactInternalInstance": Object {},
+                      "context": Object {},
+                      "history": Object {
+                        "action": "POP",
+                        "block": [Function],
+                        "createHref": [Function],
+                        "go": [Function],
+                        "goBack": [Function],
+                        "goForward": [Function],
+                        "length": 1,
+                        "listen": [Function],
+                        "location": Object {
+                          "hash": "",
+                          "pathname": "/",
+                          "search": "",
+                          "state": undefined,
+                        },
+                        "push": [Function],
+                        "replace": [Function],
+                      },
+                      "props": Object {
+                        "children": <AuthenticatedRoute
+                          authenticated={true}
+                          component={[Function]}
+                          path="/dashboard"
+                        />,
+                      },
+                      "refs": Object {},
+                      "state": null,
+                      "updater": Object {
+                        "enqueueForceUpdate": [Function],
+                        "enqueueReplaceState": [Function],
+                        "enqueueSetState": [Function],
+                        "isMounted": [Function],
+                      },
+                    },
+                    "tag": 1,
+                    "treeBaseDuration": 0,
+                    "type": [Function],
+                    "updateQueue": null,
+                  },
+                  "_debugSource": null,
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": null,
+                  "child": [Circular],
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 1,
+                  "elementType": [Function],
+                  "expirationTime": 0,
+                  "firstEffect": null,
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": null,
+                  "memoizedProps": Object {
+                    "children": <AuthenticatedRoute
+                      authenticated={true}
+                      component={[Function]}
+                      path="/dashboard"
+                    />,
+                    "history": Object {
+                      "action": "POP",
+                      "block": [Function],
+                      "createHref": [Function],
+                      "go": [Function],
+                      "goBack": [Function],
+                      "goForward": [Function],
+                      "length": 1,
+                      "listen": [Function],
+                      "location": Object {
+                        "hash": "",
+                        "pathname": "/",
+                        "search": "",
+                        "state": undefined,
+                      },
+                      "push": [Function],
+                      "replace": [Function],
+                    },
+                  },
+                  "memoizedState": Object {
+                    "match": Object {
+                      "isExact": true,
+                      "params": Object {},
+                      "path": "/",
+                      "url": "/",
+                    },
+                  },
+                  "mode": 0,
+                  "nextEffect": null,
+                  "pendingProps": Object {
+                    "children": <AuthenticatedRoute
+                      authenticated={true}
+                      component={[Function]}
+                      path="/dashboard"
+                    />,
+                    "history": Object {
+                      "action": "POP",
+                      "block": [Function],
+                      "createHref": [Function],
+                      "go": [Function],
+                      "goBack": [Function],
+                      "goForward": [Function],
+                      "length": 1,
+                      "listen": [Function],
+                      "location": Object {
+                        "hash": "",
+                        "pathname": "/",
+                        "search": "",
+                        "state": undefined,
+                      },
+                      "push": [Function],
+                      "replace": [Function],
+                    },
+                  },
+                  "ref": null,
+                  "return": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 63,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": FiberNode {
+                      "_debugHookTypes": null,
+                      "_debugID": 62,
+                      "_debugIsCurrentlyTiming": false,
+                      "_debugOwner": null,
+                      "_debugSource": null,
+                      "actualDuration": 0,
+                      "actualStartTime": -1,
+                      "alternate": null,
+                      "child": [Circular],
+                      "childExpirationTime": 0,
+                      "contextDependencies": null,
+                      "effectTag": 1,
+                      "elementType": [Function],
+                      "expirationTime": 0,
+                      "firstEffect": null,
+                      "index": 0,
+                      "key": null,
+                      "lastEffect": null,
+                      "memoizedProps": Object {
+                        "Component": [Function],
+                        "context": null,
+                        "props": Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        },
+                        "wrappingComponentProps": null,
+                      },
+                      "memoizedState": Object {
+                        "context": null,
+                        "mount": true,
+                        "props": Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        },
+                        "wrappingComponentProps": null,
+                      },
+                      "mode": 0,
+                      "nextEffect": FiberNode {
+                        "_debugHookTypes": null,
+                        "_debugID": 60,
+                        "_debugIsCurrentlyTiming": false,
+                        "_debugOwner": null,
+                        "_debugSource": null,
+                        "actualDuration": 0,
+                        "actualStartTime": -1,
+                        "alternate": FiberNode {
+                          "_debugHookTypes": null,
+                          "_debugID": 60,
+                          "_debugIsCurrentlyTiming": false,
+                          "_debugOwner": null,
+                          "_debugSource": null,
+                          "actualDuration": 0,
+                          "actualStartTime": -1,
+                          "alternate": [Circular],
+                          "child": null,
+                          "childExpirationTime": 0,
+                          "contextDependencies": null,
+                          "effectTag": 0,
+                          "elementType": null,
+                          "expirationTime": 1073741823,
+                          "firstEffect": null,
+                          "index": 0,
+                          "key": null,
+                          "lastEffect": null,
+                          "memoizedProps": null,
+                          "memoizedState": null,
+                          "mode": 0,
+                          "nextEffect": null,
+                          "pendingProps": null,
+                          "ref": null,
+                          "return": null,
+                          "selfBaseDuration": 0,
+                          "sibling": null,
+                          "stateNode": Object {
+                            "containerInfo": <div />,
+                            "context": Object {},
+                            "current": [Circular],
+                            "didError": false,
+                            "earliestPendingTime": 0,
+                            "earliestSuspendedTime": 0,
+                            "expirationTime": 0,
+                            "finishedWork": null,
+                            "firstBatch": null,
+                            "hydrate": false,
+                            "interactionThreadID": 15,
+                            "latestPendingTime": 0,
+                            "latestPingedTime": 0,
+                            "latestSuspendedTime": 0,
+                            "memoizedInteractions": Set {},
+                            "nextExpirationTimeToWorkOn": 0,
+                            "nextScheduledRoot": null,
+                            "pendingChildren": null,
+                            "pendingCommitExpirationTime": 0,
+                            "pendingContext": null,
+                            "pendingInteractionMap": Map {},
+                            "pingCache": null,
+                            "timeoutHandle": -1,
+                          },
+                          "tag": 3,
+                          "treeBaseDuration": 0,
+                          "type": null,
+                          "updateQueue": Object {
+                            "baseState": null,
+                            "firstCapturedEffect": null,
+                            "firstCapturedUpdate": null,
+                            "firstEffect": null,
+                            "firstUpdate": Object {
+                              "callback": null,
+                              "expirationTime": 1073741823,
+                              "next": null,
+                              "nextEffect": null,
+                              "payload": Object {
+                                "element": <WrapperComponent
+                                  Component={[Function]}
+                                  context={null}
+                                  props={
+                                    Object {
+                                      "children": <AuthenticatedRoute
+                                        authenticated={true}
+                                        component={[Function]}
+                                        path="/dashboard"
+                                      />,
+                                    }
+                                  }
+                                  wrappingComponentProps={null}
+                                />,
+                              },
+                              "tag": 0,
+                            },
+                            "lastCapturedEffect": null,
+                            "lastCapturedUpdate": null,
+                            "lastEffect": null,
+                            "lastUpdate": Object {
+                              "callback": null,
+                              "expirationTime": 1073741823,
+                              "next": null,
+                              "nextEffect": null,
+                              "payload": Object {
+                                "element": <WrapperComponent
+                                  Component={[Function]}
+                                  context={null}
+                                  props={
+                                    Object {
+                                      "children": <AuthenticatedRoute
+                                        authenticated={true}
+                                        component={[Function]}
+                                        path="/dashboard"
+                                      />,
+                                    }
+                                  }
+                                  wrappingComponentProps={null}
+                                />,
+                              },
+                              "tag": 0,
+                            },
+                          },
+                        },
+                        "child": [Circular],
+                        "childExpirationTime": 0,
+                        "contextDependencies": null,
+                        "effectTag": 32,
+                        "elementType": null,
+                        "expirationTime": 0,
+                        "firstEffect": [Circular],
+                        "index": 0,
+                        "key": null,
+                        "lastEffect": [Circular],
+                        "memoizedProps": null,
+                        "memoizedState": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={
+                              Object {
+                                "children": <AuthenticatedRoute
+                                  authenticated={true}
+                                  component={[Function]}
+                                  path="/dashboard"
+                                />,
+                              }
+                            }
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "mode": 0,
+                        "nextEffect": null,
+                        "pendingProps": null,
+                        "ref": null,
+                        "return": null,
+                        "selfBaseDuration": 0,
+                        "sibling": null,
+                        "stateNode": Object {
+                          "containerInfo": <div />,
+                          "context": Object {},
+                          "current": [Circular],
+                          "didError": false,
+                          "earliestPendingTime": 0,
+                          "earliestSuspendedTime": 0,
+                          "expirationTime": 0,
+                          "finishedWork": null,
+                          "firstBatch": null,
+                          "hydrate": false,
+                          "interactionThreadID": 15,
+                          "latestPendingTime": 0,
+                          "latestPingedTime": 0,
+                          "latestSuspendedTime": 0,
+                          "memoizedInteractions": Set {},
+                          "nextExpirationTimeToWorkOn": 0,
+                          "nextScheduledRoot": null,
+                          "pendingChildren": null,
+                          "pendingCommitExpirationTime": 0,
+                          "pendingContext": null,
+                          "pendingInteractionMap": Map {},
+                          "pingCache": null,
+                          "timeoutHandle": -1,
+                        },
+                        "tag": 3,
+                        "treeBaseDuration": 0,
+                        "type": null,
+                        "updateQueue": Object {
+                          "baseState": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={
+                                Object {
+                                  "children": <AuthenticatedRoute
+                                    authenticated={true}
+                                    component={[Function]}
+                                    path="/dashboard"
+                                  />,
+                                }
+                              }
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "firstCapturedEffect": null,
+                          "firstCapturedUpdate": null,
+                          "firstEffect": null,
+                          "firstUpdate": null,
+                          "lastCapturedEffect": null,
+                          "lastCapturedUpdate": null,
+                          "lastEffect": null,
+                          "lastUpdate": null,
+                        },
+                      },
+                      "pendingProps": Object {
+                        "Component": [Function],
+                        "context": null,
+                        "props": Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        },
+                        "wrappingComponentProps": null,
+                      },
+                      "ref": null,
+                      "return": FiberNode {
+                        "_debugHookTypes": null,
+                        "_debugID": 60,
+                        "_debugIsCurrentlyTiming": false,
+                        "_debugOwner": null,
+                        "_debugSource": null,
+                        "actualDuration": 0,
+                        "actualStartTime": -1,
+                        "alternate": FiberNode {
+                          "_debugHookTypes": null,
+                          "_debugID": 60,
+                          "_debugIsCurrentlyTiming": false,
+                          "_debugOwner": null,
+                          "_debugSource": null,
+                          "actualDuration": 0,
+                          "actualStartTime": -1,
+                          "alternate": [Circular],
+                          "child": null,
+                          "childExpirationTime": 0,
+                          "contextDependencies": null,
+                          "effectTag": 0,
+                          "elementType": null,
+                          "expirationTime": 1073741823,
+                          "firstEffect": null,
+                          "index": 0,
+                          "key": null,
+                          "lastEffect": null,
+                          "memoizedProps": null,
+                          "memoizedState": null,
+                          "mode": 0,
+                          "nextEffect": null,
+                          "pendingProps": null,
+                          "ref": null,
+                          "return": null,
+                          "selfBaseDuration": 0,
+                          "sibling": null,
+                          "stateNode": Object {
+                            "containerInfo": <div />,
+                            "context": Object {},
+                            "current": [Circular],
+                            "didError": false,
+                            "earliestPendingTime": 0,
+                            "earliestSuspendedTime": 0,
+                            "expirationTime": 0,
+                            "finishedWork": null,
+                            "firstBatch": null,
+                            "hydrate": false,
+                            "interactionThreadID": 15,
+                            "latestPendingTime": 0,
+                            "latestPingedTime": 0,
+                            "latestSuspendedTime": 0,
+                            "memoizedInteractions": Set {},
+                            "nextExpirationTimeToWorkOn": 0,
+                            "nextScheduledRoot": null,
+                            "pendingChildren": null,
+                            "pendingCommitExpirationTime": 0,
+                            "pendingContext": null,
+                            "pendingInteractionMap": Map {},
+                            "pingCache": null,
+                            "timeoutHandle": -1,
+                          },
+                          "tag": 3,
+                          "treeBaseDuration": 0,
+                          "type": null,
+                          "updateQueue": Object {
+                            "baseState": null,
+                            "firstCapturedEffect": null,
+                            "firstCapturedUpdate": null,
+                            "firstEffect": null,
+                            "firstUpdate": Object {
+                              "callback": null,
+                              "expirationTime": 1073741823,
+                              "next": null,
+                              "nextEffect": null,
+                              "payload": Object {
+                                "element": <WrapperComponent
+                                  Component={[Function]}
+                                  context={null}
+                                  props={
+                                    Object {
+                                      "children": <AuthenticatedRoute
+                                        authenticated={true}
+                                        component={[Function]}
+                                        path="/dashboard"
+                                      />,
+                                    }
+                                  }
+                                  wrappingComponentProps={null}
+                                />,
+                              },
+                              "tag": 0,
+                            },
+                            "lastCapturedEffect": null,
+                            "lastCapturedUpdate": null,
+                            "lastEffect": null,
+                            "lastUpdate": Object {
+                              "callback": null,
+                              "expirationTime": 1073741823,
+                              "next": null,
+                              "nextEffect": null,
+                              "payload": Object {
+                                "element": <WrapperComponent
+                                  Component={[Function]}
+                                  context={null}
+                                  props={
+                                    Object {
+                                      "children": <AuthenticatedRoute
+                                        authenticated={true}
+                                        component={[Function]}
+                                        path="/dashboard"
+                                      />,
+                                    }
+                                  }
+                                  wrappingComponentProps={null}
+                                />,
+                              },
+                              "tag": 0,
+                            },
+                          },
+                        },
+                        "child": [Circular],
+                        "childExpirationTime": 0,
+                        "contextDependencies": null,
+                        "effectTag": 32,
+                        "elementType": null,
+                        "expirationTime": 0,
+                        "firstEffect": [Circular],
+                        "index": 0,
+                        "key": null,
+                        "lastEffect": [Circular],
+                        "memoizedProps": null,
+                        "memoizedState": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={
+                              Object {
+                                "children": <AuthenticatedRoute
+                                  authenticated={true}
+                                  component={[Function]}
+                                  path="/dashboard"
+                                />,
+                              }
+                            }
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "mode": 0,
+                        "nextEffect": null,
+                        "pendingProps": null,
+                        "ref": null,
+                        "return": null,
+                        "selfBaseDuration": 0,
+                        "sibling": null,
+                        "stateNode": Object {
+                          "containerInfo": <div />,
+                          "context": Object {},
+                          "current": [Circular],
+                          "didError": false,
+                          "earliestPendingTime": 0,
+                          "earliestSuspendedTime": 0,
+                          "expirationTime": 0,
+                          "finishedWork": null,
+                          "firstBatch": null,
+                          "hydrate": false,
+                          "interactionThreadID": 15,
+                          "latestPendingTime": 0,
+                          "latestPingedTime": 0,
+                          "latestSuspendedTime": 0,
+                          "memoizedInteractions": Set {},
+                          "nextExpirationTimeToWorkOn": 0,
+                          "nextScheduledRoot": null,
+                          "pendingChildren": null,
+                          "pendingCommitExpirationTime": 0,
+                          "pendingContext": null,
+                          "pendingInteractionMap": Map {},
+                          "pingCache": null,
+                          "timeoutHandle": -1,
+                        },
+                        "tag": 3,
+                        "treeBaseDuration": 0,
+                        "type": null,
+                        "updateQueue": Object {
+                          "baseState": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={
+                                Object {
+                                  "children": <AuthenticatedRoute
+                                    authenticated={true}
+                                    component={[Function]}
+                                    path="/dashboard"
+                                  />,
+                                }
+                              }
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "firstCapturedEffect": null,
+                          "firstCapturedUpdate": null,
+                          "firstEffect": null,
+                          "firstUpdate": null,
+                          "lastCapturedEffect": null,
+                          "lastCapturedUpdate": null,
+                          "lastEffect": null,
+                          "lastUpdate": null,
+                        },
+                      },
+                      "selfBaseDuration": 0,
+                      "sibling": null,
+                      "stateNode": WrapperComponent {
+                        "_reactInternalFiber": [Circular],
+                        "_reactInternalInstance": Object {},
+                        "context": Object {},
+                        "props": Object {
+                          "Component": [Function],
+                          "context": null,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "refs": Object {},
+                        "rootFinderInstance": null,
+                        "state": Object {
+                          "context": null,
+                          "mount": true,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "updater": Object {
+                          "enqueueForceUpdate": [Function],
+                          "enqueueReplaceState": [Function],
+                          "enqueueSetState": [Function],
+                          "isMounted": [Function],
+                        },
+                      },
+                      "tag": 1,
+                      "treeBaseDuration": 0,
+                      "type": [Function],
+                      "updateQueue": null,
+                    },
+                    "_debugSource": null,
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": null,
+                    "child": [Circular],
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 1,
+                    "elementType": [Function],
+                    "expirationTime": 0,
+                    "firstEffect": null,
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": null,
+                    "memoizedProps": Object {
+                      "children": <AuthenticatedRoute
+                        authenticated={true}
+                        component={[Function]}
+                        path="/dashboard"
+                      />,
+                    },
+                    "memoizedState": null,
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": Object {
+                      "children": <AuthenticatedRoute
+                        authenticated={true}
+                        component={[Function]}
+                        path="/dashboard"
+                      />,
+                    },
+                    "ref": null,
+                    "return": FiberNode {
+                      "_debugHookTypes": null,
+                      "_debugID": 62,
+                      "_debugIsCurrentlyTiming": false,
+                      "_debugOwner": null,
+                      "_debugSource": null,
+                      "actualDuration": 0,
+                      "actualStartTime": -1,
+                      "alternate": null,
+                      "child": [Circular],
+                      "childExpirationTime": 0,
+                      "contextDependencies": null,
+                      "effectTag": 1,
+                      "elementType": [Function],
+                      "expirationTime": 0,
+                      "firstEffect": null,
+                      "index": 0,
+                      "key": null,
+                      "lastEffect": null,
+                      "memoizedProps": Object {
+                        "Component": [Function],
+                        "context": null,
+                        "props": Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        },
+                        "wrappingComponentProps": null,
+                      },
+                      "memoizedState": Object {
+                        "context": null,
+                        "mount": true,
+                        "props": Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        },
+                        "wrappingComponentProps": null,
+                      },
+                      "mode": 0,
+                      "nextEffect": FiberNode {
+                        "_debugHookTypes": null,
+                        "_debugID": 60,
+                        "_debugIsCurrentlyTiming": false,
+                        "_debugOwner": null,
+                        "_debugSource": null,
+                        "actualDuration": 0,
+                        "actualStartTime": -1,
+                        "alternate": FiberNode {
+                          "_debugHookTypes": null,
+                          "_debugID": 60,
+                          "_debugIsCurrentlyTiming": false,
+                          "_debugOwner": null,
+                          "_debugSource": null,
+                          "actualDuration": 0,
+                          "actualStartTime": -1,
+                          "alternate": [Circular],
+                          "child": null,
+                          "childExpirationTime": 0,
+                          "contextDependencies": null,
+                          "effectTag": 0,
+                          "elementType": null,
+                          "expirationTime": 1073741823,
+                          "firstEffect": null,
+                          "index": 0,
+                          "key": null,
+                          "lastEffect": null,
+                          "memoizedProps": null,
+                          "memoizedState": null,
+                          "mode": 0,
+                          "nextEffect": null,
+                          "pendingProps": null,
+                          "ref": null,
+                          "return": null,
+                          "selfBaseDuration": 0,
+                          "sibling": null,
+                          "stateNode": Object {
+                            "containerInfo": <div />,
+                            "context": Object {},
+                            "current": [Circular],
+                            "didError": false,
+                            "earliestPendingTime": 0,
+                            "earliestSuspendedTime": 0,
+                            "expirationTime": 0,
+                            "finishedWork": null,
+                            "firstBatch": null,
+                            "hydrate": false,
+                            "interactionThreadID": 15,
+                            "latestPendingTime": 0,
+                            "latestPingedTime": 0,
+                            "latestSuspendedTime": 0,
+                            "memoizedInteractions": Set {},
+                            "nextExpirationTimeToWorkOn": 0,
+                            "nextScheduledRoot": null,
+                            "pendingChildren": null,
+                            "pendingCommitExpirationTime": 0,
+                            "pendingContext": null,
+                            "pendingInteractionMap": Map {},
+                            "pingCache": null,
+                            "timeoutHandle": -1,
+                          },
+                          "tag": 3,
+                          "treeBaseDuration": 0,
+                          "type": null,
+                          "updateQueue": Object {
+                            "baseState": null,
+                            "firstCapturedEffect": null,
+                            "firstCapturedUpdate": null,
+                            "firstEffect": null,
+                            "firstUpdate": Object {
+                              "callback": null,
+                              "expirationTime": 1073741823,
+                              "next": null,
+                              "nextEffect": null,
+                              "payload": Object {
+                                "element": <WrapperComponent
+                                  Component={[Function]}
+                                  context={null}
+                                  props={
+                                    Object {
+                                      "children": <AuthenticatedRoute
+                                        authenticated={true}
+                                        component={[Function]}
+                                        path="/dashboard"
+                                      />,
+                                    }
+                                  }
+                                  wrappingComponentProps={null}
+                                />,
+                              },
+                              "tag": 0,
+                            },
+                            "lastCapturedEffect": null,
+                            "lastCapturedUpdate": null,
+                            "lastEffect": null,
+                            "lastUpdate": Object {
+                              "callback": null,
+                              "expirationTime": 1073741823,
+                              "next": null,
+                              "nextEffect": null,
+                              "payload": Object {
+                                "element": <WrapperComponent
+                                  Component={[Function]}
+                                  context={null}
+                                  props={
+                                    Object {
+                                      "children": <AuthenticatedRoute
+                                        authenticated={true}
+                                        component={[Function]}
+                                        path="/dashboard"
+                                      />,
+                                    }
+                                  }
+                                  wrappingComponentProps={null}
+                                />,
+                              },
+                              "tag": 0,
+                            },
+                          },
+                        },
+                        "child": [Circular],
+                        "childExpirationTime": 0,
+                        "contextDependencies": null,
+                        "effectTag": 32,
+                        "elementType": null,
+                        "expirationTime": 0,
+                        "firstEffect": [Circular],
+                        "index": 0,
+                        "key": null,
+                        "lastEffect": [Circular],
+                        "memoizedProps": null,
+                        "memoizedState": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={
+                              Object {
+                                "children": <AuthenticatedRoute
+                                  authenticated={true}
+                                  component={[Function]}
+                                  path="/dashboard"
+                                />,
+                              }
+                            }
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "mode": 0,
+                        "nextEffect": null,
+                        "pendingProps": null,
+                        "ref": null,
+                        "return": null,
+                        "selfBaseDuration": 0,
+                        "sibling": null,
+                        "stateNode": Object {
+                          "containerInfo": <div />,
+                          "context": Object {},
+                          "current": [Circular],
+                          "didError": false,
+                          "earliestPendingTime": 0,
+                          "earliestSuspendedTime": 0,
+                          "expirationTime": 0,
+                          "finishedWork": null,
+                          "firstBatch": null,
+                          "hydrate": false,
+                          "interactionThreadID": 15,
+                          "latestPendingTime": 0,
+                          "latestPingedTime": 0,
+                          "latestSuspendedTime": 0,
+                          "memoizedInteractions": Set {},
+                          "nextExpirationTimeToWorkOn": 0,
+                          "nextScheduledRoot": null,
+                          "pendingChildren": null,
+                          "pendingCommitExpirationTime": 0,
+                          "pendingContext": null,
+                          "pendingInteractionMap": Map {},
+                          "pingCache": null,
+                          "timeoutHandle": -1,
+                        },
+                        "tag": 3,
+                        "treeBaseDuration": 0,
+                        "type": null,
+                        "updateQueue": Object {
+                          "baseState": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={
+                                Object {
+                                  "children": <AuthenticatedRoute
+                                    authenticated={true}
+                                    component={[Function]}
+                                    path="/dashboard"
+                                  />,
+                                }
+                              }
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "firstCapturedEffect": null,
+                          "firstCapturedUpdate": null,
+                          "firstEffect": null,
+                          "firstUpdate": null,
+                          "lastCapturedEffect": null,
+                          "lastCapturedUpdate": null,
+                          "lastEffect": null,
+                          "lastUpdate": null,
+                        },
+                      },
+                      "pendingProps": Object {
+                        "Component": [Function],
+                        "context": null,
+                        "props": Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        },
+                        "wrappingComponentProps": null,
+                      },
+                      "ref": null,
+                      "return": FiberNode {
+                        "_debugHookTypes": null,
+                        "_debugID": 60,
+                        "_debugIsCurrentlyTiming": false,
+                        "_debugOwner": null,
+                        "_debugSource": null,
+                        "actualDuration": 0,
+                        "actualStartTime": -1,
+                        "alternate": FiberNode {
+                          "_debugHookTypes": null,
+                          "_debugID": 60,
+                          "_debugIsCurrentlyTiming": false,
+                          "_debugOwner": null,
+                          "_debugSource": null,
+                          "actualDuration": 0,
+                          "actualStartTime": -1,
+                          "alternate": [Circular],
+                          "child": null,
+                          "childExpirationTime": 0,
+                          "contextDependencies": null,
+                          "effectTag": 0,
+                          "elementType": null,
+                          "expirationTime": 1073741823,
+                          "firstEffect": null,
+                          "index": 0,
+                          "key": null,
+                          "lastEffect": null,
+                          "memoizedProps": null,
+                          "memoizedState": null,
+                          "mode": 0,
+                          "nextEffect": null,
+                          "pendingProps": null,
+                          "ref": null,
+                          "return": null,
+                          "selfBaseDuration": 0,
+                          "sibling": null,
+                          "stateNode": Object {
+                            "containerInfo": <div />,
+                            "context": Object {},
+                            "current": [Circular],
+                            "didError": false,
+                            "earliestPendingTime": 0,
+                            "earliestSuspendedTime": 0,
+                            "expirationTime": 0,
+                            "finishedWork": null,
+                            "firstBatch": null,
+                            "hydrate": false,
+                            "interactionThreadID": 15,
+                            "latestPendingTime": 0,
+                            "latestPingedTime": 0,
+                            "latestSuspendedTime": 0,
+                            "memoizedInteractions": Set {},
+                            "nextExpirationTimeToWorkOn": 0,
+                            "nextScheduledRoot": null,
+                            "pendingChildren": null,
+                            "pendingCommitExpirationTime": 0,
+                            "pendingContext": null,
+                            "pendingInteractionMap": Map {},
+                            "pingCache": null,
+                            "timeoutHandle": -1,
+                          },
+                          "tag": 3,
+                          "treeBaseDuration": 0,
+                          "type": null,
+                          "updateQueue": Object {
+                            "baseState": null,
+                            "firstCapturedEffect": null,
+                            "firstCapturedUpdate": null,
+                            "firstEffect": null,
+                            "firstUpdate": Object {
+                              "callback": null,
+                              "expirationTime": 1073741823,
+                              "next": null,
+                              "nextEffect": null,
+                              "payload": Object {
+                                "element": <WrapperComponent
+                                  Component={[Function]}
+                                  context={null}
+                                  props={
+                                    Object {
+                                      "children": <AuthenticatedRoute
+                                        authenticated={true}
+                                        component={[Function]}
+                                        path="/dashboard"
+                                      />,
+                                    }
+                                  }
+                                  wrappingComponentProps={null}
+                                />,
+                              },
+                              "tag": 0,
+                            },
+                            "lastCapturedEffect": null,
+                            "lastCapturedUpdate": null,
+                            "lastEffect": null,
+                            "lastUpdate": Object {
+                              "callback": null,
+                              "expirationTime": 1073741823,
+                              "next": null,
+                              "nextEffect": null,
+                              "payload": Object {
+                                "element": <WrapperComponent
+                                  Component={[Function]}
+                                  context={null}
+                                  props={
+                                    Object {
+                                      "children": <AuthenticatedRoute
+                                        authenticated={true}
+                                        component={[Function]}
+                                        path="/dashboard"
+                                      />,
+                                    }
+                                  }
+                                  wrappingComponentProps={null}
+                                />,
+                              },
+                              "tag": 0,
+                            },
+                          },
+                        },
+                        "child": [Circular],
+                        "childExpirationTime": 0,
+                        "contextDependencies": null,
+                        "effectTag": 32,
+                        "elementType": null,
+                        "expirationTime": 0,
+                        "firstEffect": [Circular],
+                        "index": 0,
+                        "key": null,
+                        "lastEffect": [Circular],
+                        "memoizedProps": null,
+                        "memoizedState": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={
+                              Object {
+                                "children": <AuthenticatedRoute
+                                  authenticated={true}
+                                  component={[Function]}
+                                  path="/dashboard"
+                                />,
+                              }
+                            }
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "mode": 0,
+                        "nextEffect": null,
+                        "pendingProps": null,
+                        "ref": null,
+                        "return": null,
+                        "selfBaseDuration": 0,
+                        "sibling": null,
+                        "stateNode": Object {
+                          "containerInfo": <div />,
+                          "context": Object {},
+                          "current": [Circular],
+                          "didError": false,
+                          "earliestPendingTime": 0,
+                          "earliestSuspendedTime": 0,
+                          "expirationTime": 0,
+                          "finishedWork": null,
+                          "firstBatch": null,
+                          "hydrate": false,
+                          "interactionThreadID": 15,
+                          "latestPendingTime": 0,
+                          "latestPingedTime": 0,
+                          "latestSuspendedTime": 0,
+                          "memoizedInteractions": Set {},
+                          "nextExpirationTimeToWorkOn": 0,
+                          "nextScheduledRoot": null,
+                          "pendingChildren": null,
+                          "pendingCommitExpirationTime": 0,
+                          "pendingContext": null,
+                          "pendingInteractionMap": Map {},
+                          "pingCache": null,
+                          "timeoutHandle": -1,
+                        },
+                        "tag": 3,
+                        "treeBaseDuration": 0,
+                        "type": null,
+                        "updateQueue": Object {
+                          "baseState": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={
+                                Object {
+                                  "children": <AuthenticatedRoute
+                                    authenticated={true}
+                                    component={[Function]}
+                                    path="/dashboard"
+                                  />,
+                                }
+                              }
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "firstCapturedEffect": null,
+                          "firstCapturedUpdate": null,
+                          "firstEffect": null,
+                          "firstUpdate": null,
+                          "lastCapturedEffect": null,
+                          "lastCapturedUpdate": null,
+                          "lastEffect": null,
+                          "lastUpdate": null,
+                        },
+                      },
+                      "selfBaseDuration": 0,
+                      "sibling": null,
+                      "stateNode": WrapperComponent {
+                        "_reactInternalFiber": [Circular],
+                        "_reactInternalInstance": Object {},
+                        "context": Object {},
+                        "props": Object {
+                          "Component": [Function],
+                          "context": null,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "refs": Object {},
+                        "rootFinderInstance": null,
+                        "state": Object {
+                          "context": null,
+                          "mount": true,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "updater": Object {
+                          "enqueueForceUpdate": [Function],
+                          "enqueueReplaceState": [Function],
+                          "enqueueSetState": [Function],
+                          "isMounted": [Function],
+                        },
+                      },
+                      "tag": 1,
+                      "treeBaseDuration": 0,
+                      "type": [Function],
+                      "updateQueue": null,
+                    },
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": BrowserRouter {
+                      "_reactInternalFiber": [Circular],
+                      "_reactInternalInstance": Object {},
+                      "context": Object {},
+                      "history": Object {
+                        "action": "POP",
+                        "block": [Function],
+                        "createHref": [Function],
+                        "go": [Function],
+                        "goBack": [Function],
+                        "goForward": [Function],
+                        "length": 1,
+                        "listen": [Function],
+                        "location": Object {
+                          "hash": "",
+                          "pathname": "/",
+                          "search": "",
+                          "state": undefined,
+                        },
+                        "push": [Function],
+                        "replace": [Function],
+                      },
+                      "props": Object {
+                        "children": <AuthenticatedRoute
+                          authenticated={true}
+                          component={[Function]}
+                          path="/dashboard"
+                        />,
+                      },
+                      "refs": Object {},
+                      "state": null,
+                      "updater": Object {
+                        "enqueueForceUpdate": [Function],
+                        "enqueueReplaceState": [Function],
+                        "enqueueSetState": [Function],
+                        "isMounted": [Function],
+                      },
+                    },
+                    "tag": 1,
+                    "treeBaseDuration": 0,
+                    "type": [Function],
+                    "updateQueue": null,
+                  },
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": Router {
+                    "__reactInternalMemoizedMaskedChildContext": Object {
+                      "router": undefined,
+                    },
+                    "__reactInternalMemoizedMergedChildContext": Object {
+                      "router": Object {
+                        "history": Object {
+                          "action": "POP",
+                          "block": [Function],
+                          "createHref": [Function],
+                          "go": [Function],
+                          "goBack": [Function],
+                          "goForward": [Function],
+                          "length": 1,
+                          "listen": [Function],
+                          "location": Object {
+                            "hash": "",
+                            "pathname": "/",
+                            "search": "",
+                            "state": undefined,
+                          },
+                          "push": [Function],
+                          "replace": [Function],
+                        },
+                        "route": Object {
+                          "location": Object {
+                            "hash": "",
+                            "pathname": "/",
+                            "search": "",
+                            "state": undefined,
+                          },
+                          "match": Object {
+                            "isExact": true,
+                            "params": Object {},
+                            "path": "/",
+                            "url": "/",
+                          },
+                        },
+                      },
+                    },
+                    "__reactInternalMemoizedUnmaskedChildContext": Object {},
+                    "_reactInternalFiber": [Circular],
+                    "_reactInternalInstance": Object {},
+                    "context": Object {
+                      "router": undefined,
+                    },
+                    "props": Object {
+                      "children": <AuthenticatedRoute
+                        authenticated={true}
+                        component={[Function]}
+                        path="/dashboard"
+                      />,
+                      "history": Object {
+                        "action": "POP",
+                        "block": [Function],
+                        "createHref": [Function],
+                        "go": [Function],
+                        "goBack": [Function],
+                        "goForward": [Function],
+                        "length": 1,
+                        "listen": [Function],
+                        "location": Object {
+                          "hash": "",
+                          "pathname": "/",
+                          "search": "",
+                          "state": undefined,
+                        },
+                        "push": [Function],
+                        "replace": [Function],
+                      },
+                    },
+                    "refs": Object {},
+                    "state": Object {
+                      "match": Object {
+                        "isExact": true,
+                        "params": Object {},
+                        "path": "/",
+                        "url": "/",
+                      },
+                    },
+                    "unlisten": [Function],
+                    "updater": Object {
+                      "enqueueForceUpdate": [Function],
+                      "enqueueReplaceState": [Function],
+                      "enqueueSetState": [Function],
+                      "isMounted": [Function],
+                    },
+                  },
+                  "tag": 1,
+                  "treeBaseDuration": 0,
+                  "type": [Function],
+                  "updateQueue": null,
+                },
+                "selfBaseDuration": 0,
+                "sibling": null,
+                "stateNode": null,
+                "tag": 0,
+                "treeBaseDuration": 0,
+                "type": [Function],
+                "updateQueue": null,
+              },
+              "selfBaseDuration": 0,
+              "sibling": null,
+              "stateNode": [Circular],
+              "tag": 1,
+              "treeBaseDuration": 0,
+              "type": [Function],
+              "updateQueue": null,
+            },
+            "_reactInternalInstance": Object {},
+            "context": Object {
+              "router": Object {
+                "history": Object {
+                  "action": "POP",
+                  "block": [Function],
+                  "createHref": [Function],
+                  "go": [Function],
+                  "goBack": [Function],
+                  "goForward": [Function],
+                  "length": 1,
+                  "listen": [Function],
+                  "location": Object {
+                    "hash": "",
+                    "pathname": "/",
+                    "search": "",
+                    "state": undefined,
+                  },
+                  "push": [Function],
+                  "replace": [Function],
+                },
+                "route": Object {
+                  "location": Object {
+                    "hash": "",
+                    "pathname": "/",
+                    "search": "",
+                    "state": undefined,
+                  },
+                  "match": Object {
+                    "isExact": true,
+                    "params": Object {},
+                    "path": "/",
+                    "url": "/",
+                  },
+                },
+              },
+            },
+            "props": Object {
+              "path": "/dashboard",
+              "render": [Function],
+            },
+            "refs": Object {},
+            "state": Object {
+              "match": null,
+            },
+            "updater": Object {
+              "enqueueForceUpdate": [Function],
+              "enqueueReplaceState": [Function],
+              "enqueueSetState": [Function],
+              "isMounted": [Function],
+            },
+          },
+          "key": undefined,
+          "nodeType": "class",
+          "props": Object {
+            "path": "/dashboard",
+            "render": [Function],
+          },
+          "ref": null,
+          "rendered": null,
+          "type": [Function],
+        },
+        "type": [Function],
+      },
+      "type": [Function],
+    },
+    "type": [Function],
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": BrowserRouter {
+        "_reactInternalFiber": FiberNode {
+          "_debugHookTypes": null,
+          "_debugID": 63,
+          "_debugIsCurrentlyTiming": false,
+          "_debugOwner": FiberNode {
+            "_debugHookTypes": null,
+            "_debugID": 62,
+            "_debugIsCurrentlyTiming": false,
+            "_debugOwner": null,
+            "_debugSource": null,
+            "actualDuration": 0,
+            "actualStartTime": -1,
+            "alternate": null,
+            "child": [Circular],
+            "childExpirationTime": 0,
+            "contextDependencies": null,
+            "effectTag": 1,
+            "elementType": [Function],
+            "expirationTime": 0,
+            "firstEffect": null,
+            "index": 0,
+            "key": null,
+            "lastEffect": null,
+            "memoizedProps": Object {
+              "Component": [Function],
+              "context": null,
+              "props": Object {
+                "children": <AuthenticatedRoute
+                  authenticated={true}
+                  component={[Function]}
+                  path="/dashboard"
+                />,
+              },
+              "wrappingComponentProps": null,
+            },
+            "memoizedState": Object {
+              "context": null,
+              "mount": true,
+              "props": Object {
+                "children": <AuthenticatedRoute
+                  authenticated={true}
+                  component={[Function]}
+                  path="/dashboard"
+                />,
+              },
+              "wrappingComponentProps": null,
+            },
+            "mode": 0,
+            "nextEffect": FiberNode {
+              "_debugHookTypes": null,
+              "_debugID": 60,
+              "_debugIsCurrentlyTiming": false,
+              "_debugOwner": null,
+              "_debugSource": null,
+              "actualDuration": 0,
+              "actualStartTime": -1,
+              "alternate": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 60,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": null,
+                "_debugSource": null,
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": [Circular],
+                "child": null,
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 0,
+                "elementType": null,
+                "expirationTime": 1073741823,
+                "firstEffect": null,
+                "index": 0,
+                "key": null,
+                "lastEffect": null,
+                "memoizedProps": null,
+                "memoizedState": null,
+                "mode": 0,
+                "nextEffect": null,
+                "pendingProps": null,
+                "ref": null,
+                "return": null,
+                "selfBaseDuration": 0,
+                "sibling": null,
+                "stateNode": Object {
+                  "containerInfo": <div />,
+                  "context": Object {},
+                  "current": [Circular],
+                  "didError": false,
+                  "earliestPendingTime": 0,
+                  "earliestSuspendedTime": 0,
+                  "expirationTime": 0,
+                  "finishedWork": null,
+                  "firstBatch": null,
+                  "hydrate": false,
+                  "interactionThreadID": 15,
+                  "latestPendingTime": 0,
+                  "latestPingedTime": 0,
+                  "latestSuspendedTime": 0,
+                  "memoizedInteractions": Set {},
+                  "nextExpirationTimeToWorkOn": 0,
+                  "nextScheduledRoot": null,
+                  "pendingChildren": null,
+                  "pendingCommitExpirationTime": 0,
+                  "pendingContext": null,
+                  "pendingInteractionMap": Map {},
+                  "pingCache": null,
+                  "timeoutHandle": -1,
+                },
+                "tag": 3,
+                "treeBaseDuration": 0,
+                "type": null,
+                "updateQueue": Object {
+                  "baseState": null,
+                  "firstCapturedEffect": null,
+                  "firstCapturedUpdate": null,
+                  "firstEffect": null,
+                  "firstUpdate": Object {
+                    "callback": null,
+                    "expirationTime": 1073741823,
+                    "next": null,
+                    "nextEffect": null,
+                    "payload": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={
+                          Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          }
+                        }
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "tag": 0,
+                  },
+                  "lastCapturedEffect": null,
+                  "lastCapturedUpdate": null,
+                  "lastEffect": null,
+                  "lastUpdate": Object {
+                    "callback": null,
+                    "expirationTime": 1073741823,
+                    "next": null,
+                    "nextEffect": null,
+                    "payload": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={
+                          Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          }
+                        }
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "tag": 0,
+                  },
+                },
+              },
+              "child": [Circular],
+              "childExpirationTime": 0,
+              "contextDependencies": null,
+              "effectTag": 32,
+              "elementType": null,
+              "expirationTime": 0,
+              "firstEffect": [Circular],
+              "index": 0,
+              "key": null,
+              "lastEffect": [Circular],
+              "memoizedProps": null,
+              "memoizedState": Object {
+                "element": <WrapperComponent
+                  Component={[Function]}
+                  context={null}
+                  props={
+                    Object {
+                      "children": <AuthenticatedRoute
+                        authenticated={true}
+                        component={[Function]}
+                        path="/dashboard"
+                      />,
+                    }
+                  }
+                  wrappingComponentProps={null}
+                />,
+              },
+              "mode": 0,
+              "nextEffect": null,
+              "pendingProps": null,
+              "ref": null,
+              "return": null,
+              "selfBaseDuration": 0,
+              "sibling": null,
+              "stateNode": Object {
+                "containerInfo": <div />,
+                "context": Object {},
+                "current": [Circular],
+                "didError": false,
+                "earliestPendingTime": 0,
+                "earliestSuspendedTime": 0,
+                "expirationTime": 0,
+                "finishedWork": null,
+                "firstBatch": null,
+                "hydrate": false,
+                "interactionThreadID": 15,
+                "latestPendingTime": 0,
+                "latestPingedTime": 0,
+                "latestSuspendedTime": 0,
+                "memoizedInteractions": Set {},
+                "nextExpirationTimeToWorkOn": 0,
+                "nextScheduledRoot": null,
+                "pendingChildren": null,
+                "pendingCommitExpirationTime": 0,
+                "pendingContext": null,
+                "pendingInteractionMap": Map {},
+                "pingCache": null,
+                "timeoutHandle": -1,
+              },
+              "tag": 3,
+              "treeBaseDuration": 0,
+              "type": null,
+              "updateQueue": Object {
+                "baseState": Object {
+                  "element": <WrapperComponent
+                    Component={[Function]}
+                    context={null}
+                    props={
+                      Object {
+                        "children": <AuthenticatedRoute
+                          authenticated={true}
+                          component={[Function]}
+                          path="/dashboard"
+                        />,
+                      }
+                    }
+                    wrappingComponentProps={null}
+                  />,
+                },
+                "firstCapturedEffect": null,
+                "firstCapturedUpdate": null,
+                "firstEffect": null,
+                "firstUpdate": null,
+                "lastCapturedEffect": null,
+                "lastCapturedUpdate": null,
+                "lastEffect": null,
+                "lastUpdate": null,
+              },
+            },
+            "pendingProps": Object {
+              "Component": [Function],
+              "context": null,
+              "props": Object {
+                "children": <AuthenticatedRoute
+                  authenticated={true}
+                  component={[Function]}
+                  path="/dashboard"
+                />,
+              },
+              "wrappingComponentProps": null,
+            },
+            "ref": null,
+            "return": FiberNode {
+              "_debugHookTypes": null,
+              "_debugID": 60,
+              "_debugIsCurrentlyTiming": false,
+              "_debugOwner": null,
+              "_debugSource": null,
+              "actualDuration": 0,
+              "actualStartTime": -1,
+              "alternate": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 60,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": null,
+                "_debugSource": null,
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": [Circular],
+                "child": null,
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 0,
+                "elementType": null,
+                "expirationTime": 1073741823,
+                "firstEffect": null,
+                "index": 0,
+                "key": null,
+                "lastEffect": null,
+                "memoizedProps": null,
+                "memoizedState": null,
+                "mode": 0,
+                "nextEffect": null,
+                "pendingProps": null,
+                "ref": null,
+                "return": null,
+                "selfBaseDuration": 0,
+                "sibling": null,
+                "stateNode": Object {
+                  "containerInfo": <div />,
+                  "context": Object {},
+                  "current": [Circular],
+                  "didError": false,
+                  "earliestPendingTime": 0,
+                  "earliestSuspendedTime": 0,
+                  "expirationTime": 0,
+                  "finishedWork": null,
+                  "firstBatch": null,
+                  "hydrate": false,
+                  "interactionThreadID": 15,
+                  "latestPendingTime": 0,
+                  "latestPingedTime": 0,
+                  "latestSuspendedTime": 0,
+                  "memoizedInteractions": Set {},
+                  "nextExpirationTimeToWorkOn": 0,
+                  "nextScheduledRoot": null,
+                  "pendingChildren": null,
+                  "pendingCommitExpirationTime": 0,
+                  "pendingContext": null,
+                  "pendingInteractionMap": Map {},
+                  "pingCache": null,
+                  "timeoutHandle": -1,
+                },
+                "tag": 3,
+                "treeBaseDuration": 0,
+                "type": null,
+                "updateQueue": Object {
+                  "baseState": null,
+                  "firstCapturedEffect": null,
+                  "firstCapturedUpdate": null,
+                  "firstEffect": null,
+                  "firstUpdate": Object {
+                    "callback": null,
+                    "expirationTime": 1073741823,
+                    "next": null,
+                    "nextEffect": null,
+                    "payload": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={
+                          Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          }
+                        }
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "tag": 0,
+                  },
+                  "lastCapturedEffect": null,
+                  "lastCapturedUpdate": null,
+                  "lastEffect": null,
+                  "lastUpdate": Object {
+                    "callback": null,
+                    "expirationTime": 1073741823,
+                    "next": null,
+                    "nextEffect": null,
+                    "payload": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={
+                          Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          }
+                        }
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "tag": 0,
+                  },
+                },
+              },
+              "child": [Circular],
+              "childExpirationTime": 0,
+              "contextDependencies": null,
+              "effectTag": 32,
+              "elementType": null,
+              "expirationTime": 0,
+              "firstEffect": [Circular],
+              "index": 0,
+              "key": null,
+              "lastEffect": [Circular],
+              "memoizedProps": null,
+              "memoizedState": Object {
+                "element": <WrapperComponent
+                  Component={[Function]}
+                  context={null}
+                  props={
+                    Object {
+                      "children": <AuthenticatedRoute
+                        authenticated={true}
+                        component={[Function]}
+                        path="/dashboard"
+                      />,
+                    }
+                  }
+                  wrappingComponentProps={null}
+                />,
+              },
+              "mode": 0,
+              "nextEffect": null,
+              "pendingProps": null,
+              "ref": null,
+              "return": null,
+              "selfBaseDuration": 0,
+              "sibling": null,
+              "stateNode": Object {
+                "containerInfo": <div />,
+                "context": Object {},
+                "current": [Circular],
+                "didError": false,
+                "earliestPendingTime": 0,
+                "earliestSuspendedTime": 0,
+                "expirationTime": 0,
+                "finishedWork": null,
+                "firstBatch": null,
+                "hydrate": false,
+                "interactionThreadID": 15,
+                "latestPendingTime": 0,
+                "latestPingedTime": 0,
+                "latestSuspendedTime": 0,
+                "memoizedInteractions": Set {},
+                "nextExpirationTimeToWorkOn": 0,
+                "nextScheduledRoot": null,
+                "pendingChildren": null,
+                "pendingCommitExpirationTime": 0,
+                "pendingContext": null,
+                "pendingInteractionMap": Map {},
+                "pingCache": null,
+                "timeoutHandle": -1,
+              },
+              "tag": 3,
+              "treeBaseDuration": 0,
+              "type": null,
+              "updateQueue": Object {
+                "baseState": Object {
+                  "element": <WrapperComponent
+                    Component={[Function]}
+                    context={null}
+                    props={
+                      Object {
+                        "children": <AuthenticatedRoute
+                          authenticated={true}
+                          component={[Function]}
+                          path="/dashboard"
+                        />,
+                      }
+                    }
+                    wrappingComponentProps={null}
+                  />,
+                },
+                "firstCapturedEffect": null,
+                "firstCapturedUpdate": null,
+                "firstEffect": null,
+                "firstUpdate": null,
+                "lastCapturedEffect": null,
+                "lastCapturedUpdate": null,
+                "lastEffect": null,
+                "lastUpdate": null,
+              },
+            },
+            "selfBaseDuration": 0,
+            "sibling": null,
+            "stateNode": WrapperComponent {
+              "_reactInternalFiber": [Circular],
+              "_reactInternalInstance": Object {},
+              "context": Object {},
+              "props": Object {
+                "Component": [Function],
+                "context": null,
+                "props": Object {
+                  "children": <AuthenticatedRoute
+                    authenticated={true}
+                    component={[Function]}
+                    path="/dashboard"
+                  />,
+                },
+                "wrappingComponentProps": null,
+              },
+              "refs": Object {},
+              "rootFinderInstance": null,
+              "state": Object {
+                "context": null,
+                "mount": true,
+                "props": Object {
+                  "children": <AuthenticatedRoute
+                    authenticated={true}
+                    component={[Function]}
+                    path="/dashboard"
+                  />,
+                },
+                "wrappingComponentProps": null,
+              },
+              "updater": Object {
+                "enqueueForceUpdate": [Function],
+                "enqueueReplaceState": [Function],
+                "enqueueSetState": [Function],
+                "isMounted": [Function],
+              },
+            },
+            "tag": 1,
+            "treeBaseDuration": 0,
+            "type": [Function],
+            "updateQueue": null,
+          },
+          "_debugSource": null,
+          "actualDuration": 0,
+          "actualStartTime": -1,
+          "alternate": null,
+          "child": FiberNode {
+            "_debugHookTypes": null,
+            "_debugID": 64,
+            "_debugIsCurrentlyTiming": false,
+            "_debugOwner": [Circular],
+            "_debugSource": null,
+            "actualDuration": 0,
+            "actualStartTime": -1,
+            "alternate": null,
+            "child": FiberNode {
+              "_debugHookTypes": null,
+              "_debugID": 65,
+              "_debugIsCurrentlyTiming": false,
+              "_debugOwner": null,
+              "_debugSource": Object {
+                "fileName": "/Users/chucky/Code/Bench/bp-esa-frontend/src/App.test.jsx",
+                "lineNumber": 123,
+              },
+              "actualDuration": 0,
+              "actualStartTime": -1,
+              "alternate": null,
+              "child": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 66,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": [Circular],
+                "_debugSource": Object {
+                  "fileName": "/Users/chucky/Code/Bench/bp-esa-frontend/src/App.jsx",
+                  "lineNumber": 15,
+                },
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": null,
+                "child": null,
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 1,
+                "elementType": [Function],
+                "expirationTime": 0,
+                "firstEffect": null,
+                "index": 0,
+                "key": null,
+                "lastEffect": null,
+                "memoizedProps": Object {
+                  "path": "/dashboard",
+                  "render": [Function],
+                },
+                "memoizedState": Object {
+                  "match": null,
+                },
+                "mode": 0,
+                "nextEffect": null,
+                "pendingProps": Object {
+                  "path": "/dashboard",
+                  "render": [Function],
+                },
+                "ref": null,
+                "return": [Circular],
+                "selfBaseDuration": 0,
+                "sibling": null,
+                "stateNode": Route {
+                  "__reactInternalMemoizedMaskedChildContext": Object {
+                    "router": Object {
+                      "history": Object {
+                        "action": "POP",
+                        "block": [Function],
+                        "createHref": [Function],
+                        "go": [Function],
+                        "goBack": [Function],
+                        "goForward": [Function],
+                        "length": 1,
+                        "listen": [Function],
+                        "location": Object {
+                          "hash": "",
+                          "pathname": "/",
+                          "search": "",
+                          "state": undefined,
+                        },
+                        "push": [Function],
+                        "replace": [Function],
+                      },
+                      "route": Object {
+                        "location": Object {
+                          "hash": "",
+                          "pathname": "/",
+                          "search": "",
+                          "state": undefined,
+                        },
+                        "match": Object {
+                          "isExact": true,
+                          "params": Object {},
+                          "path": "/",
+                          "url": "/",
+                        },
+                      },
+                    },
+                  },
+                  "__reactInternalMemoizedMergedChildContext": Object {
+                    "router": Object {
+                      "history": Object {
+                        "action": "POP",
+                        "block": [Function],
+                        "createHref": [Function],
+                        "go": [Function],
+                        "goBack": [Function],
+                        "goForward": [Function],
+                        "length": 1,
+                        "listen": [Function],
+                        "location": Object {
+                          "hash": "",
+                          "pathname": "/",
+                          "search": "",
+                          "state": undefined,
+                        },
+                        "push": [Function],
+                        "replace": [Function],
+                      },
+                      "route": Object {
+                        "location": Object {
+                          "hash": "",
+                          "pathname": "/",
+                          "search": "",
+                          "state": undefined,
+                        },
+                        "match": null,
+                      },
+                    },
+                  },
+                  "__reactInternalMemoizedUnmaskedChildContext": Object {
+                    "router": Object {
+                      "history": Object {
+                        "action": "POP",
+                        "block": [Function],
+                        "createHref": [Function],
+                        "go": [Function],
+                        "goBack": [Function],
+                        "goForward": [Function],
+                        "length": 1,
+                        "listen": [Function],
+                        "location": Object {
+                          "hash": "",
+                          "pathname": "/",
+                          "search": "",
+                          "state": undefined,
+                        },
+                        "push": [Function],
+                        "replace": [Function],
+                      },
+                      "route": Object {
+                        "location": Object {
+                          "hash": "",
+                          "pathname": "/",
+                          "search": "",
+                          "state": undefined,
+                        },
+                        "match": Object {
+                          "isExact": true,
+                          "params": Object {},
+                          "path": "/",
+                          "url": "/",
+                        },
+                      },
+                    },
+                  },
+                  "_reactInternalFiber": [Circular],
+                  "_reactInternalInstance": Object {},
+                  "context": Object {
+                    "router": Object {
+                      "history": Object {
+                        "action": "POP",
+                        "block": [Function],
+                        "createHref": [Function],
+                        "go": [Function],
+                        "goBack": [Function],
+                        "goForward": [Function],
+                        "length": 1,
+                        "listen": [Function],
+                        "location": Object {
+                          "hash": "",
+                          "pathname": "/",
+                          "search": "",
+                          "state": undefined,
+                        },
+                        "push": [Function],
+                        "replace": [Function],
+                      },
+                      "route": Object {
+                        "location": Object {
+                          "hash": "",
+                          "pathname": "/",
+                          "search": "",
+                          "state": undefined,
+                        },
+                        "match": Object {
+                          "isExact": true,
+                          "params": Object {},
+                          "path": "/",
+                          "url": "/",
+                        },
+                      },
+                    },
+                  },
+                  "props": Object {
+                    "path": "/dashboard",
+                    "render": [Function],
+                  },
+                  "refs": Object {},
+                  "state": Object {
+                    "match": null,
+                  },
+                  "updater": Object {
+                    "enqueueForceUpdate": [Function],
+                    "enqueueReplaceState": [Function],
+                    "enqueueSetState": [Function],
+                    "isMounted": [Function],
+                  },
+                },
+                "tag": 1,
+                "treeBaseDuration": 0,
+                "type": [Function],
+                "updateQueue": null,
+              },
+              "childExpirationTime": 0,
+              "contextDependencies": null,
+              "effectTag": 1,
+              "elementType": [Function],
+              "expirationTime": 0,
+              "firstEffect": null,
+              "index": 0,
+              "key": null,
+              "lastEffect": null,
+              "memoizedProps": Object {
+                "authenticated": true,
+                "component": [Function],
+                "path": "/dashboard",
+              },
+              "memoizedState": null,
+              "mode": 0,
+              "nextEffect": null,
+              "pendingProps": Object {
+                "authenticated": true,
+                "component": [Function],
+                "path": "/dashboard",
+              },
+              "ref": null,
+              "return": [Circular],
+              "selfBaseDuration": 0,
+              "sibling": null,
+              "stateNode": null,
+              "tag": 0,
+              "treeBaseDuration": 0,
+              "type": [Function],
+              "updateQueue": null,
+            },
+            "childExpirationTime": 0,
+            "contextDependencies": null,
+            "effectTag": 1,
+            "elementType": [Function],
+            "expirationTime": 0,
+            "firstEffect": null,
+            "index": 0,
+            "key": null,
+            "lastEffect": null,
+            "memoizedProps": Object {
+              "children": <AuthenticatedRoute
+                authenticated={true}
+                component={[Function]}
+                path="/dashboard"
+              />,
+              "history": Object {
+                "action": "POP",
+                "block": [Function],
+                "createHref": [Function],
+                "go": [Function],
+                "goBack": [Function],
+                "goForward": [Function],
+                "length": 1,
+                "listen": [Function],
+                "location": Object {
+                  "hash": "",
+                  "pathname": "/",
+                  "search": "",
+                  "state": undefined,
+                },
+                "push": [Function],
+                "replace": [Function],
+              },
+            },
+            "memoizedState": Object {
+              "match": Object {
+                "isExact": true,
+                "params": Object {},
+                "path": "/",
+                "url": "/",
+              },
+            },
+            "mode": 0,
+            "nextEffect": null,
+            "pendingProps": Object {
+              "children": <AuthenticatedRoute
+                authenticated={true}
+                component={[Function]}
+                path="/dashboard"
+              />,
+              "history": Object {
+                "action": "POP",
+                "block": [Function],
+                "createHref": [Function],
+                "go": [Function],
+                "goBack": [Function],
+                "goForward": [Function],
+                "length": 1,
+                "listen": [Function],
+                "location": Object {
+                  "hash": "",
+                  "pathname": "/",
+                  "search": "",
+                  "state": undefined,
+                },
+                "push": [Function],
+                "replace": [Function],
+              },
+            },
+            "ref": null,
+            "return": [Circular],
+            "selfBaseDuration": 0,
+            "sibling": null,
+            "stateNode": Router {
+              "__reactInternalMemoizedMaskedChildContext": Object {
+                "router": undefined,
+              },
+              "__reactInternalMemoizedMergedChildContext": Object {
+                "router": Object {
+                  "history": Object {
+                    "action": "POP",
+                    "block": [Function],
+                    "createHref": [Function],
+                    "go": [Function],
+                    "goBack": [Function],
+                    "goForward": [Function],
+                    "length": 1,
+                    "listen": [Function],
+                    "location": Object {
+                      "hash": "",
+                      "pathname": "/",
+                      "search": "",
+                      "state": undefined,
+                    },
+                    "push": [Function],
+                    "replace": [Function],
+                  },
+                  "route": Object {
+                    "location": Object {
+                      "hash": "",
+                      "pathname": "/",
+                      "search": "",
+                      "state": undefined,
+                    },
+                    "match": Object {
+                      "isExact": true,
+                      "params": Object {},
+                      "path": "/",
+                      "url": "/",
+                    },
+                  },
+                },
+              },
+              "__reactInternalMemoizedUnmaskedChildContext": Object {},
+              "_reactInternalFiber": [Circular],
+              "_reactInternalInstance": Object {},
+              "context": Object {
+                "router": undefined,
+              },
+              "props": Object {
+                "children": <AuthenticatedRoute
+                  authenticated={true}
+                  component={[Function]}
+                  path="/dashboard"
+                />,
+                "history": Object {
+                  "action": "POP",
+                  "block": [Function],
+                  "createHref": [Function],
+                  "go": [Function],
+                  "goBack": [Function],
+                  "goForward": [Function],
+                  "length": 1,
+                  "listen": [Function],
+                  "location": Object {
+                    "hash": "",
+                    "pathname": "/",
+                    "search": "",
+                    "state": undefined,
+                  },
+                  "push": [Function],
+                  "replace": [Function],
+                },
+              },
+              "refs": Object {},
+              "state": Object {
+                "match": Object {
+                  "isExact": true,
+                  "params": Object {},
+                  "path": "/",
+                  "url": "/",
+                },
+              },
+              "unlisten": [Function],
+              "updater": Object {
+                "enqueueForceUpdate": [Function],
+                "enqueueReplaceState": [Function],
+                "enqueueSetState": [Function],
+                "isMounted": [Function],
+              },
+            },
+            "tag": 1,
+            "treeBaseDuration": 0,
+            "type": [Function],
+            "updateQueue": null,
+          },
+          "childExpirationTime": 0,
+          "contextDependencies": null,
+          "effectTag": 1,
+          "elementType": [Function],
+          "expirationTime": 0,
+          "firstEffect": null,
+          "index": 0,
+          "key": null,
+          "lastEffect": null,
+          "memoizedProps": Object {
+            "children": <AuthenticatedRoute
+              authenticated={true}
+              component={[Function]}
+              path="/dashboard"
+            />,
+          },
+          "memoizedState": null,
+          "mode": 0,
+          "nextEffect": null,
+          "pendingProps": Object {
+            "children": <AuthenticatedRoute
+              authenticated={true}
+              component={[Function]}
+              path="/dashboard"
+            />,
+          },
+          "ref": null,
+          "return": FiberNode {
+            "_debugHookTypes": null,
+            "_debugID": 62,
+            "_debugIsCurrentlyTiming": false,
+            "_debugOwner": null,
+            "_debugSource": null,
+            "actualDuration": 0,
+            "actualStartTime": -1,
+            "alternate": null,
+            "child": [Circular],
+            "childExpirationTime": 0,
+            "contextDependencies": null,
+            "effectTag": 1,
+            "elementType": [Function],
+            "expirationTime": 0,
+            "firstEffect": null,
+            "index": 0,
+            "key": null,
+            "lastEffect": null,
+            "memoizedProps": Object {
+              "Component": [Function],
+              "context": null,
+              "props": Object {
+                "children": <AuthenticatedRoute
+                  authenticated={true}
+                  component={[Function]}
+                  path="/dashboard"
+                />,
+              },
+              "wrappingComponentProps": null,
+            },
+            "memoizedState": Object {
+              "context": null,
+              "mount": true,
+              "props": Object {
+                "children": <AuthenticatedRoute
+                  authenticated={true}
+                  component={[Function]}
+                  path="/dashboard"
+                />,
+              },
+              "wrappingComponentProps": null,
+            },
+            "mode": 0,
+            "nextEffect": FiberNode {
+              "_debugHookTypes": null,
+              "_debugID": 60,
+              "_debugIsCurrentlyTiming": false,
+              "_debugOwner": null,
+              "_debugSource": null,
+              "actualDuration": 0,
+              "actualStartTime": -1,
+              "alternate": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 60,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": null,
+                "_debugSource": null,
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": [Circular],
+                "child": null,
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 0,
+                "elementType": null,
+                "expirationTime": 1073741823,
+                "firstEffect": null,
+                "index": 0,
+                "key": null,
+                "lastEffect": null,
+                "memoizedProps": null,
+                "memoizedState": null,
+                "mode": 0,
+                "nextEffect": null,
+                "pendingProps": null,
+                "ref": null,
+                "return": null,
+                "selfBaseDuration": 0,
+                "sibling": null,
+                "stateNode": Object {
+                  "containerInfo": <div />,
+                  "context": Object {},
+                  "current": [Circular],
+                  "didError": false,
+                  "earliestPendingTime": 0,
+                  "earliestSuspendedTime": 0,
+                  "expirationTime": 0,
+                  "finishedWork": null,
+                  "firstBatch": null,
+                  "hydrate": false,
+                  "interactionThreadID": 15,
+                  "latestPendingTime": 0,
+                  "latestPingedTime": 0,
+                  "latestSuspendedTime": 0,
+                  "memoizedInteractions": Set {},
+                  "nextExpirationTimeToWorkOn": 0,
+                  "nextScheduledRoot": null,
+                  "pendingChildren": null,
+                  "pendingCommitExpirationTime": 0,
+                  "pendingContext": null,
+                  "pendingInteractionMap": Map {},
+                  "pingCache": null,
+                  "timeoutHandle": -1,
+                },
+                "tag": 3,
+                "treeBaseDuration": 0,
+                "type": null,
+                "updateQueue": Object {
+                  "baseState": null,
+                  "firstCapturedEffect": null,
+                  "firstCapturedUpdate": null,
+                  "firstEffect": null,
+                  "firstUpdate": Object {
+                    "callback": null,
+                    "expirationTime": 1073741823,
+                    "next": null,
+                    "nextEffect": null,
+                    "payload": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={
+                          Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          }
+                        }
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "tag": 0,
+                  },
+                  "lastCapturedEffect": null,
+                  "lastCapturedUpdate": null,
+                  "lastEffect": null,
+                  "lastUpdate": Object {
+                    "callback": null,
+                    "expirationTime": 1073741823,
+                    "next": null,
+                    "nextEffect": null,
+                    "payload": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={
+                          Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          }
+                        }
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "tag": 0,
+                  },
+                },
+              },
+              "child": [Circular],
+              "childExpirationTime": 0,
+              "contextDependencies": null,
+              "effectTag": 32,
+              "elementType": null,
+              "expirationTime": 0,
+              "firstEffect": [Circular],
+              "index": 0,
+              "key": null,
+              "lastEffect": [Circular],
+              "memoizedProps": null,
+              "memoizedState": Object {
+                "element": <WrapperComponent
+                  Component={[Function]}
+                  context={null}
+                  props={
+                    Object {
+                      "children": <AuthenticatedRoute
+                        authenticated={true}
+                        component={[Function]}
+                        path="/dashboard"
+                      />,
+                    }
+                  }
+                  wrappingComponentProps={null}
+                />,
+              },
+              "mode": 0,
+              "nextEffect": null,
+              "pendingProps": null,
+              "ref": null,
+              "return": null,
+              "selfBaseDuration": 0,
+              "sibling": null,
+              "stateNode": Object {
+                "containerInfo": <div />,
+                "context": Object {},
+                "current": [Circular],
+                "didError": false,
+                "earliestPendingTime": 0,
+                "earliestSuspendedTime": 0,
+                "expirationTime": 0,
+                "finishedWork": null,
+                "firstBatch": null,
+                "hydrate": false,
+                "interactionThreadID": 15,
+                "latestPendingTime": 0,
+                "latestPingedTime": 0,
+                "latestSuspendedTime": 0,
+                "memoizedInteractions": Set {},
+                "nextExpirationTimeToWorkOn": 0,
+                "nextScheduledRoot": null,
+                "pendingChildren": null,
+                "pendingCommitExpirationTime": 0,
+                "pendingContext": null,
+                "pendingInteractionMap": Map {},
+                "pingCache": null,
+                "timeoutHandle": -1,
+              },
+              "tag": 3,
+              "treeBaseDuration": 0,
+              "type": null,
+              "updateQueue": Object {
+                "baseState": Object {
+                  "element": <WrapperComponent
+                    Component={[Function]}
+                    context={null}
+                    props={
+                      Object {
+                        "children": <AuthenticatedRoute
+                          authenticated={true}
+                          component={[Function]}
+                          path="/dashboard"
+                        />,
+                      }
+                    }
+                    wrappingComponentProps={null}
+                  />,
+                },
+                "firstCapturedEffect": null,
+                "firstCapturedUpdate": null,
+                "firstEffect": null,
+                "firstUpdate": null,
+                "lastCapturedEffect": null,
+                "lastCapturedUpdate": null,
+                "lastEffect": null,
+                "lastUpdate": null,
+              },
+            },
+            "pendingProps": Object {
+              "Component": [Function],
+              "context": null,
+              "props": Object {
+                "children": <AuthenticatedRoute
+                  authenticated={true}
+                  component={[Function]}
+                  path="/dashboard"
+                />,
+              },
+              "wrappingComponentProps": null,
+            },
+            "ref": null,
+            "return": FiberNode {
+              "_debugHookTypes": null,
+              "_debugID": 60,
+              "_debugIsCurrentlyTiming": false,
+              "_debugOwner": null,
+              "_debugSource": null,
+              "actualDuration": 0,
+              "actualStartTime": -1,
+              "alternate": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 60,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": null,
+                "_debugSource": null,
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": [Circular],
+                "child": null,
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 0,
+                "elementType": null,
+                "expirationTime": 1073741823,
+                "firstEffect": null,
+                "index": 0,
+                "key": null,
+                "lastEffect": null,
+                "memoizedProps": null,
+                "memoizedState": null,
+                "mode": 0,
+                "nextEffect": null,
+                "pendingProps": null,
+                "ref": null,
+                "return": null,
+                "selfBaseDuration": 0,
+                "sibling": null,
+                "stateNode": Object {
+                  "containerInfo": <div />,
+                  "context": Object {},
+                  "current": [Circular],
+                  "didError": false,
+                  "earliestPendingTime": 0,
+                  "earliestSuspendedTime": 0,
+                  "expirationTime": 0,
+                  "finishedWork": null,
+                  "firstBatch": null,
+                  "hydrate": false,
+                  "interactionThreadID": 15,
+                  "latestPendingTime": 0,
+                  "latestPingedTime": 0,
+                  "latestSuspendedTime": 0,
+                  "memoizedInteractions": Set {},
+                  "nextExpirationTimeToWorkOn": 0,
+                  "nextScheduledRoot": null,
+                  "pendingChildren": null,
+                  "pendingCommitExpirationTime": 0,
+                  "pendingContext": null,
+                  "pendingInteractionMap": Map {},
+                  "pingCache": null,
+                  "timeoutHandle": -1,
+                },
+                "tag": 3,
+                "treeBaseDuration": 0,
+                "type": null,
+                "updateQueue": Object {
+                  "baseState": null,
+                  "firstCapturedEffect": null,
+                  "firstCapturedUpdate": null,
+                  "firstEffect": null,
+                  "firstUpdate": Object {
+                    "callback": null,
+                    "expirationTime": 1073741823,
+                    "next": null,
+                    "nextEffect": null,
+                    "payload": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={
+                          Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          }
+                        }
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "tag": 0,
+                  },
+                  "lastCapturedEffect": null,
+                  "lastCapturedUpdate": null,
+                  "lastEffect": null,
+                  "lastUpdate": Object {
+                    "callback": null,
+                    "expirationTime": 1073741823,
+                    "next": null,
+                    "nextEffect": null,
+                    "payload": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={
+                          Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          }
+                        }
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "tag": 0,
+                  },
+                },
+              },
+              "child": [Circular],
+              "childExpirationTime": 0,
+              "contextDependencies": null,
+              "effectTag": 32,
+              "elementType": null,
+              "expirationTime": 0,
+              "firstEffect": [Circular],
+              "index": 0,
+              "key": null,
+              "lastEffect": [Circular],
+              "memoizedProps": null,
+              "memoizedState": Object {
+                "element": <WrapperComponent
+                  Component={[Function]}
+                  context={null}
+                  props={
+                    Object {
+                      "children": <AuthenticatedRoute
+                        authenticated={true}
+                        component={[Function]}
+                        path="/dashboard"
+                      />,
+                    }
+                  }
+                  wrappingComponentProps={null}
+                />,
+              },
+              "mode": 0,
+              "nextEffect": null,
+              "pendingProps": null,
+              "ref": null,
+              "return": null,
+              "selfBaseDuration": 0,
+              "sibling": null,
+              "stateNode": Object {
+                "containerInfo": <div />,
+                "context": Object {},
+                "current": [Circular],
+                "didError": false,
+                "earliestPendingTime": 0,
+                "earliestSuspendedTime": 0,
+                "expirationTime": 0,
+                "finishedWork": null,
+                "firstBatch": null,
+                "hydrate": false,
+                "interactionThreadID": 15,
+                "latestPendingTime": 0,
+                "latestPingedTime": 0,
+                "latestSuspendedTime": 0,
+                "memoizedInteractions": Set {},
+                "nextExpirationTimeToWorkOn": 0,
+                "nextScheduledRoot": null,
+                "pendingChildren": null,
+                "pendingCommitExpirationTime": 0,
+                "pendingContext": null,
+                "pendingInteractionMap": Map {},
+                "pingCache": null,
+                "timeoutHandle": -1,
+              },
+              "tag": 3,
+              "treeBaseDuration": 0,
+              "type": null,
+              "updateQueue": Object {
+                "baseState": Object {
+                  "element": <WrapperComponent
+                    Component={[Function]}
+                    context={null}
+                    props={
+                      Object {
+                        "children": <AuthenticatedRoute
+                          authenticated={true}
+                          component={[Function]}
+                          path="/dashboard"
+                        />,
+                      }
+                    }
+                    wrappingComponentProps={null}
+                  />,
+                },
+                "firstCapturedEffect": null,
+                "firstCapturedUpdate": null,
+                "firstEffect": null,
+                "firstUpdate": null,
+                "lastCapturedEffect": null,
+                "lastCapturedUpdate": null,
+                "lastEffect": null,
+                "lastUpdate": null,
+              },
+            },
+            "selfBaseDuration": 0,
+            "sibling": null,
+            "stateNode": WrapperComponent {
+              "_reactInternalFiber": [Circular],
+              "_reactInternalInstance": Object {},
+              "context": Object {},
+              "props": Object {
+                "Component": [Function],
+                "context": null,
+                "props": Object {
+                  "children": <AuthenticatedRoute
+                    authenticated={true}
+                    component={[Function]}
+                    path="/dashboard"
+                  />,
+                },
+                "wrappingComponentProps": null,
+              },
+              "refs": Object {},
+              "rootFinderInstance": null,
+              "state": Object {
+                "context": null,
+                "mount": true,
+                "props": Object {
+                  "children": <AuthenticatedRoute
+                    authenticated={true}
+                    component={[Function]}
+                    path="/dashboard"
+                  />,
+                },
+                "wrappingComponentProps": null,
+              },
+              "updater": Object {
+                "enqueueForceUpdate": [Function],
+                "enqueueReplaceState": [Function],
+                "enqueueSetState": [Function],
+                "isMounted": [Function],
+              },
+            },
+            "tag": 1,
+            "treeBaseDuration": 0,
+            "type": [Function],
+            "updateQueue": null,
+          },
+          "selfBaseDuration": 0,
+          "sibling": null,
+          "stateNode": [Circular],
+          "tag": 1,
+          "treeBaseDuration": 0,
+          "type": [Function],
+          "updateQueue": null,
+        },
+        "_reactInternalInstance": Object {},
+        "context": Object {},
+        "history": Object {
+          "action": "POP",
+          "block": [Function],
+          "createHref": [Function],
+          "go": [Function],
+          "goBack": [Function],
+          "goForward": [Function],
+          "length": 1,
+          "listen": [Function],
+          "location": Object {
+            "hash": "",
+            "pathname": "/",
+            "search": "",
+            "state": undefined,
+          },
+          "push": [Function],
+          "replace": [Function],
+        },
+        "props": Object {
+          "children": <AuthenticatedRoute
+            authenticated={true}
+            component={[Function]}
+            path="/dashboard"
+          />,
+        },
+        "refs": Object {},
+        "state": null,
+        "updater": Object {
+          "enqueueForceUpdate": [Function],
+          "enqueueReplaceState": [Function],
+          "enqueueSetState": [Function],
+          "isMounted": [Function],
+        },
+      },
+      "key": undefined,
+      "nodeType": "class",
+      "props": Object {
+        "children": <AuthenticatedRoute
+          authenticated={true}
+          component={[Function]}
+          path="/dashboard"
+        />,
+      },
+      "ref": null,
+      "rendered": Object {
+        "instance": Router {
+          "__reactInternalMemoizedMaskedChildContext": Object {
+            "router": undefined,
+          },
+          "__reactInternalMemoizedMergedChildContext": Object {
+            "router": Object {
+              "history": Object {
+                "action": "POP",
+                "block": [Function],
+                "createHref": [Function],
+                "go": [Function],
+                "goBack": [Function],
+                "goForward": [Function],
+                "length": 1,
+                "listen": [Function],
+                "location": Object {
+                  "hash": "",
+                  "pathname": "/",
+                  "search": "",
+                  "state": undefined,
+                },
+                "push": [Function],
+                "replace": [Function],
+              },
+              "route": Object {
+                "location": Object {
+                  "hash": "",
+                  "pathname": "/",
+                  "search": "",
+                  "state": undefined,
+                },
+                "match": Object {
+                  "isExact": true,
+                  "params": Object {},
+                  "path": "/",
+                  "url": "/",
+                },
+              },
+            },
+          },
+          "__reactInternalMemoizedUnmaskedChildContext": Object {},
+          "_reactInternalFiber": FiberNode {
+            "_debugHookTypes": null,
+            "_debugID": 64,
+            "_debugIsCurrentlyTiming": false,
+            "_debugOwner": FiberNode {
+              "_debugHookTypes": null,
+              "_debugID": 63,
+              "_debugIsCurrentlyTiming": false,
+              "_debugOwner": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 62,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": null,
+                "_debugSource": null,
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": null,
+                "child": [Circular],
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 1,
+                "elementType": [Function],
+                "expirationTime": 0,
+                "firstEffect": null,
+                "index": 0,
+                "key": null,
+                "lastEffect": null,
+                "memoizedProps": Object {
+                  "Component": [Function],
+                  "context": null,
+                  "props": Object {
+                    "children": <AuthenticatedRoute
+                      authenticated={true}
+                      component={[Function]}
+                      path="/dashboard"
+                    />,
+                  },
+                  "wrappingComponentProps": null,
+                },
+                "memoizedState": Object {
+                  "context": null,
+                  "mount": true,
+                  "props": Object {
+                    "children": <AuthenticatedRoute
+                      authenticated={true}
+                      component={[Function]}
+                      path="/dashboard"
+                    />,
+                  },
+                  "wrappingComponentProps": null,
+                },
+                "mode": 0,
+                "nextEffect": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 60,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": null,
+                  "_debugSource": null,
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 60,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": null,
+                    "_debugSource": null,
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": [Circular],
+                    "child": null,
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 0,
+                    "elementType": null,
+                    "expirationTime": 1073741823,
+                    "firstEffect": null,
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": null,
+                    "memoizedProps": null,
+                    "memoizedState": null,
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": null,
+                    "ref": null,
+                    "return": null,
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": Object {
+                      "containerInfo": <div />,
+                      "context": Object {},
+                      "current": [Circular],
+                      "didError": false,
+                      "earliestPendingTime": 0,
+                      "earliestSuspendedTime": 0,
+                      "expirationTime": 0,
+                      "finishedWork": null,
+                      "firstBatch": null,
+                      "hydrate": false,
+                      "interactionThreadID": 15,
+                      "latestPendingTime": 0,
+                      "latestPingedTime": 0,
+                      "latestSuspendedTime": 0,
+                      "memoizedInteractions": Set {},
+                      "nextExpirationTimeToWorkOn": 0,
+                      "nextScheduledRoot": null,
+                      "pendingChildren": null,
+                      "pendingCommitExpirationTime": 0,
+                      "pendingContext": null,
+                      "pendingInteractionMap": Map {},
+                      "pingCache": null,
+                      "timeoutHandle": -1,
+                    },
+                    "tag": 3,
+                    "treeBaseDuration": 0,
+                    "type": null,
+                    "updateQueue": Object {
+                      "baseState": null,
+                      "firstCapturedEffect": null,
+                      "firstCapturedUpdate": null,
+                      "firstEffect": null,
+                      "firstUpdate": Object {
+                        "callback": null,
+                        "expirationTime": 1073741823,
+                        "next": null,
+                        "nextEffect": null,
+                        "payload": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={
+                              Object {
+                                "children": <AuthenticatedRoute
+                                  authenticated={true}
+                                  component={[Function]}
+                                  path="/dashboard"
+                                />,
+                              }
+                            }
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "tag": 0,
+                      },
+                      "lastCapturedEffect": null,
+                      "lastCapturedUpdate": null,
+                      "lastEffect": null,
+                      "lastUpdate": Object {
+                        "callback": null,
+                        "expirationTime": 1073741823,
+                        "next": null,
+                        "nextEffect": null,
+                        "payload": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={
+                              Object {
+                                "children": <AuthenticatedRoute
+                                  authenticated={true}
+                                  component={[Function]}
+                                  path="/dashboard"
+                                />,
+                              }
+                            }
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "tag": 0,
+                      },
+                    },
+                  },
+                  "child": [Circular],
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 32,
+                  "elementType": null,
+                  "expirationTime": 0,
+                  "firstEffect": [Circular],
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": [Circular],
+                  "memoizedProps": null,
+                  "memoizedState": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={
+                        Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        }
+                      }
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "mode": 0,
+                  "nextEffect": null,
+                  "pendingProps": null,
+                  "ref": null,
+                  "return": null,
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": Object {
+                    "containerInfo": <div />,
+                    "context": Object {},
+                    "current": [Circular],
+                    "didError": false,
+                    "earliestPendingTime": 0,
+                    "earliestSuspendedTime": 0,
+                    "expirationTime": 0,
+                    "finishedWork": null,
+                    "firstBatch": null,
+                    "hydrate": false,
+                    "interactionThreadID": 15,
+                    "latestPendingTime": 0,
+                    "latestPingedTime": 0,
+                    "latestSuspendedTime": 0,
+                    "memoizedInteractions": Set {},
+                    "nextExpirationTimeToWorkOn": 0,
+                    "nextScheduledRoot": null,
+                    "pendingChildren": null,
+                    "pendingCommitExpirationTime": 0,
+                    "pendingContext": null,
+                    "pendingInteractionMap": Map {},
+                    "pingCache": null,
+                    "timeoutHandle": -1,
+                  },
+                  "tag": 3,
+                  "treeBaseDuration": 0,
+                  "type": null,
+                  "updateQueue": Object {
+                    "baseState": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={
+                          Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          }
+                        }
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "firstCapturedEffect": null,
+                    "firstCapturedUpdate": null,
+                    "firstEffect": null,
+                    "firstUpdate": null,
+                    "lastCapturedEffect": null,
+                    "lastCapturedUpdate": null,
+                    "lastEffect": null,
+                    "lastUpdate": null,
+                  },
+                },
+                "pendingProps": Object {
+                  "Component": [Function],
+                  "context": null,
+                  "props": Object {
+                    "children": <AuthenticatedRoute
+                      authenticated={true}
+                      component={[Function]}
+                      path="/dashboard"
+                    />,
+                  },
+                  "wrappingComponentProps": null,
+                },
+                "ref": null,
+                "return": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 60,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": null,
+                  "_debugSource": null,
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 60,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": null,
+                    "_debugSource": null,
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": [Circular],
+                    "child": null,
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 0,
+                    "elementType": null,
+                    "expirationTime": 1073741823,
+                    "firstEffect": null,
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": null,
+                    "memoizedProps": null,
+                    "memoizedState": null,
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": null,
+                    "ref": null,
+                    "return": null,
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": Object {
+                      "containerInfo": <div />,
+                      "context": Object {},
+                      "current": [Circular],
+                      "didError": false,
+                      "earliestPendingTime": 0,
+                      "earliestSuspendedTime": 0,
+                      "expirationTime": 0,
+                      "finishedWork": null,
+                      "firstBatch": null,
+                      "hydrate": false,
+                      "interactionThreadID": 15,
+                      "latestPendingTime": 0,
+                      "latestPingedTime": 0,
+                      "latestSuspendedTime": 0,
+                      "memoizedInteractions": Set {},
+                      "nextExpirationTimeToWorkOn": 0,
+                      "nextScheduledRoot": null,
+                      "pendingChildren": null,
+                      "pendingCommitExpirationTime": 0,
+                      "pendingContext": null,
+                      "pendingInteractionMap": Map {},
+                      "pingCache": null,
+                      "timeoutHandle": -1,
+                    },
+                    "tag": 3,
+                    "treeBaseDuration": 0,
+                    "type": null,
+                    "updateQueue": Object {
+                      "baseState": null,
+                      "firstCapturedEffect": null,
+                      "firstCapturedUpdate": null,
+                      "firstEffect": null,
+                      "firstUpdate": Object {
+                        "callback": null,
+                        "expirationTime": 1073741823,
+                        "next": null,
+                        "nextEffect": null,
+                        "payload": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={
+                              Object {
+                                "children": <AuthenticatedRoute
+                                  authenticated={true}
+                                  component={[Function]}
+                                  path="/dashboard"
+                                />,
+                              }
+                            }
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "tag": 0,
+                      },
+                      "lastCapturedEffect": null,
+                      "lastCapturedUpdate": null,
+                      "lastEffect": null,
+                      "lastUpdate": Object {
+                        "callback": null,
+                        "expirationTime": 1073741823,
+                        "next": null,
+                        "nextEffect": null,
+                        "payload": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={
+                              Object {
+                                "children": <AuthenticatedRoute
+                                  authenticated={true}
+                                  component={[Function]}
+                                  path="/dashboard"
+                                />,
+                              }
+                            }
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "tag": 0,
+                      },
+                    },
+                  },
+                  "child": [Circular],
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 32,
+                  "elementType": null,
+                  "expirationTime": 0,
+                  "firstEffect": [Circular],
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": [Circular],
+                  "memoizedProps": null,
+                  "memoizedState": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={
+                        Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        }
+                      }
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "mode": 0,
+                  "nextEffect": null,
+                  "pendingProps": null,
+                  "ref": null,
+                  "return": null,
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": Object {
+                    "containerInfo": <div />,
+                    "context": Object {},
+                    "current": [Circular],
+                    "didError": false,
+                    "earliestPendingTime": 0,
+                    "earliestSuspendedTime": 0,
+                    "expirationTime": 0,
+                    "finishedWork": null,
+                    "firstBatch": null,
+                    "hydrate": false,
+                    "interactionThreadID": 15,
+                    "latestPendingTime": 0,
+                    "latestPingedTime": 0,
+                    "latestSuspendedTime": 0,
+                    "memoizedInteractions": Set {},
+                    "nextExpirationTimeToWorkOn": 0,
+                    "nextScheduledRoot": null,
+                    "pendingChildren": null,
+                    "pendingCommitExpirationTime": 0,
+                    "pendingContext": null,
+                    "pendingInteractionMap": Map {},
+                    "pingCache": null,
+                    "timeoutHandle": -1,
+                  },
+                  "tag": 3,
+                  "treeBaseDuration": 0,
+                  "type": null,
+                  "updateQueue": Object {
+                    "baseState": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={
+                          Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          }
+                        }
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "firstCapturedEffect": null,
+                    "firstCapturedUpdate": null,
+                    "firstEffect": null,
+                    "firstUpdate": null,
+                    "lastCapturedEffect": null,
+                    "lastCapturedUpdate": null,
+                    "lastEffect": null,
+                    "lastUpdate": null,
+                  },
+                },
+                "selfBaseDuration": 0,
+                "sibling": null,
+                "stateNode": WrapperComponent {
+                  "_reactInternalFiber": [Circular],
+                  "_reactInternalInstance": Object {},
+                  "context": Object {},
+                  "props": Object {
+                    "Component": [Function],
+                    "context": null,
+                    "props": Object {
+                      "children": <AuthenticatedRoute
+                        authenticated={true}
+                        component={[Function]}
+                        path="/dashboard"
+                      />,
+                    },
+                    "wrappingComponentProps": null,
+                  },
+                  "refs": Object {},
+                  "rootFinderInstance": null,
+                  "state": Object {
+                    "context": null,
+                    "mount": true,
+                    "props": Object {
+                      "children": <AuthenticatedRoute
+                        authenticated={true}
+                        component={[Function]}
+                        path="/dashboard"
+                      />,
+                    },
+                    "wrappingComponentProps": null,
+                  },
+                  "updater": Object {
+                    "enqueueForceUpdate": [Function],
+                    "enqueueReplaceState": [Function],
+                    "enqueueSetState": [Function],
+                    "isMounted": [Function],
+                  },
+                },
+                "tag": 1,
+                "treeBaseDuration": 0,
+                "type": [Function],
+                "updateQueue": null,
+              },
+              "_debugSource": null,
+              "actualDuration": 0,
+              "actualStartTime": -1,
+              "alternate": null,
+              "child": [Circular],
+              "childExpirationTime": 0,
+              "contextDependencies": null,
+              "effectTag": 1,
+              "elementType": [Function],
+              "expirationTime": 0,
+              "firstEffect": null,
+              "index": 0,
+              "key": null,
+              "lastEffect": null,
+              "memoizedProps": Object {
+                "children": <AuthenticatedRoute
+                  authenticated={true}
+                  component={[Function]}
+                  path="/dashboard"
+                />,
+              },
+              "memoizedState": null,
+              "mode": 0,
+              "nextEffect": null,
+              "pendingProps": Object {
+                "children": <AuthenticatedRoute
+                  authenticated={true}
+                  component={[Function]}
+                  path="/dashboard"
+                />,
+              },
+              "ref": null,
+              "return": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 62,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": null,
+                "_debugSource": null,
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": null,
+                "child": [Circular],
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 1,
+                "elementType": [Function],
+                "expirationTime": 0,
+                "firstEffect": null,
+                "index": 0,
+                "key": null,
+                "lastEffect": null,
+                "memoizedProps": Object {
+                  "Component": [Function],
+                  "context": null,
+                  "props": Object {
+                    "children": <AuthenticatedRoute
+                      authenticated={true}
+                      component={[Function]}
+                      path="/dashboard"
+                    />,
+                  },
+                  "wrappingComponentProps": null,
+                },
+                "memoizedState": Object {
+                  "context": null,
+                  "mount": true,
+                  "props": Object {
+                    "children": <AuthenticatedRoute
+                      authenticated={true}
+                      component={[Function]}
+                      path="/dashboard"
+                    />,
+                  },
+                  "wrappingComponentProps": null,
+                },
+                "mode": 0,
+                "nextEffect": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 60,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": null,
+                  "_debugSource": null,
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 60,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": null,
+                    "_debugSource": null,
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": [Circular],
+                    "child": null,
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 0,
+                    "elementType": null,
+                    "expirationTime": 1073741823,
+                    "firstEffect": null,
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": null,
+                    "memoizedProps": null,
+                    "memoizedState": null,
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": null,
+                    "ref": null,
+                    "return": null,
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": Object {
+                      "containerInfo": <div />,
+                      "context": Object {},
+                      "current": [Circular],
+                      "didError": false,
+                      "earliestPendingTime": 0,
+                      "earliestSuspendedTime": 0,
+                      "expirationTime": 0,
+                      "finishedWork": null,
+                      "firstBatch": null,
+                      "hydrate": false,
+                      "interactionThreadID": 15,
+                      "latestPendingTime": 0,
+                      "latestPingedTime": 0,
+                      "latestSuspendedTime": 0,
+                      "memoizedInteractions": Set {},
+                      "nextExpirationTimeToWorkOn": 0,
+                      "nextScheduledRoot": null,
+                      "pendingChildren": null,
+                      "pendingCommitExpirationTime": 0,
+                      "pendingContext": null,
+                      "pendingInteractionMap": Map {},
+                      "pingCache": null,
+                      "timeoutHandle": -1,
+                    },
+                    "tag": 3,
+                    "treeBaseDuration": 0,
+                    "type": null,
+                    "updateQueue": Object {
+                      "baseState": null,
+                      "firstCapturedEffect": null,
+                      "firstCapturedUpdate": null,
+                      "firstEffect": null,
+                      "firstUpdate": Object {
+                        "callback": null,
+                        "expirationTime": 1073741823,
+                        "next": null,
+                        "nextEffect": null,
+                        "payload": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={
+                              Object {
+                                "children": <AuthenticatedRoute
+                                  authenticated={true}
+                                  component={[Function]}
+                                  path="/dashboard"
+                                />,
+                              }
+                            }
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "tag": 0,
+                      },
+                      "lastCapturedEffect": null,
+                      "lastCapturedUpdate": null,
+                      "lastEffect": null,
+                      "lastUpdate": Object {
+                        "callback": null,
+                        "expirationTime": 1073741823,
+                        "next": null,
+                        "nextEffect": null,
+                        "payload": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={
+                              Object {
+                                "children": <AuthenticatedRoute
+                                  authenticated={true}
+                                  component={[Function]}
+                                  path="/dashboard"
+                                />,
+                              }
+                            }
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "tag": 0,
+                      },
+                    },
+                  },
+                  "child": [Circular],
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 32,
+                  "elementType": null,
+                  "expirationTime": 0,
+                  "firstEffect": [Circular],
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": [Circular],
+                  "memoizedProps": null,
+                  "memoizedState": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={
+                        Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        }
+                      }
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "mode": 0,
+                  "nextEffect": null,
+                  "pendingProps": null,
+                  "ref": null,
+                  "return": null,
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": Object {
+                    "containerInfo": <div />,
+                    "context": Object {},
+                    "current": [Circular],
+                    "didError": false,
+                    "earliestPendingTime": 0,
+                    "earliestSuspendedTime": 0,
+                    "expirationTime": 0,
+                    "finishedWork": null,
+                    "firstBatch": null,
+                    "hydrate": false,
+                    "interactionThreadID": 15,
+                    "latestPendingTime": 0,
+                    "latestPingedTime": 0,
+                    "latestSuspendedTime": 0,
+                    "memoizedInteractions": Set {},
+                    "nextExpirationTimeToWorkOn": 0,
+                    "nextScheduledRoot": null,
+                    "pendingChildren": null,
+                    "pendingCommitExpirationTime": 0,
+                    "pendingContext": null,
+                    "pendingInteractionMap": Map {},
+                    "pingCache": null,
+                    "timeoutHandle": -1,
+                  },
+                  "tag": 3,
+                  "treeBaseDuration": 0,
+                  "type": null,
+                  "updateQueue": Object {
+                    "baseState": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={
+                          Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          }
+                        }
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "firstCapturedEffect": null,
+                    "firstCapturedUpdate": null,
+                    "firstEffect": null,
+                    "firstUpdate": null,
+                    "lastCapturedEffect": null,
+                    "lastCapturedUpdate": null,
+                    "lastEffect": null,
+                    "lastUpdate": null,
+                  },
+                },
+                "pendingProps": Object {
+                  "Component": [Function],
+                  "context": null,
+                  "props": Object {
+                    "children": <AuthenticatedRoute
+                      authenticated={true}
+                      component={[Function]}
+                      path="/dashboard"
+                    />,
+                  },
+                  "wrappingComponentProps": null,
+                },
+                "ref": null,
+                "return": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 60,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": null,
+                  "_debugSource": null,
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 60,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": null,
+                    "_debugSource": null,
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": [Circular],
+                    "child": null,
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 0,
+                    "elementType": null,
+                    "expirationTime": 1073741823,
+                    "firstEffect": null,
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": null,
+                    "memoizedProps": null,
+                    "memoizedState": null,
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": null,
+                    "ref": null,
+                    "return": null,
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": Object {
+                      "containerInfo": <div />,
+                      "context": Object {},
+                      "current": [Circular],
+                      "didError": false,
+                      "earliestPendingTime": 0,
+                      "earliestSuspendedTime": 0,
+                      "expirationTime": 0,
+                      "finishedWork": null,
+                      "firstBatch": null,
+                      "hydrate": false,
+                      "interactionThreadID": 15,
+                      "latestPendingTime": 0,
+                      "latestPingedTime": 0,
+                      "latestSuspendedTime": 0,
+                      "memoizedInteractions": Set {},
+                      "nextExpirationTimeToWorkOn": 0,
+                      "nextScheduledRoot": null,
+                      "pendingChildren": null,
+                      "pendingCommitExpirationTime": 0,
+                      "pendingContext": null,
+                      "pendingInteractionMap": Map {},
+                      "pingCache": null,
+                      "timeoutHandle": -1,
+                    },
+                    "tag": 3,
+                    "treeBaseDuration": 0,
+                    "type": null,
+                    "updateQueue": Object {
+                      "baseState": null,
+                      "firstCapturedEffect": null,
+                      "firstCapturedUpdate": null,
+                      "firstEffect": null,
+                      "firstUpdate": Object {
+                        "callback": null,
+                        "expirationTime": 1073741823,
+                        "next": null,
+                        "nextEffect": null,
+                        "payload": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={
+                              Object {
+                                "children": <AuthenticatedRoute
+                                  authenticated={true}
+                                  component={[Function]}
+                                  path="/dashboard"
+                                />,
+                              }
+                            }
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "tag": 0,
+                      },
+                      "lastCapturedEffect": null,
+                      "lastCapturedUpdate": null,
+                      "lastEffect": null,
+                      "lastUpdate": Object {
+                        "callback": null,
+                        "expirationTime": 1073741823,
+                        "next": null,
+                        "nextEffect": null,
+                        "payload": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={
+                              Object {
+                                "children": <AuthenticatedRoute
+                                  authenticated={true}
+                                  component={[Function]}
+                                  path="/dashboard"
+                                />,
+                              }
+                            }
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "tag": 0,
+                      },
+                    },
+                  },
+                  "child": [Circular],
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 32,
+                  "elementType": null,
+                  "expirationTime": 0,
+                  "firstEffect": [Circular],
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": [Circular],
+                  "memoizedProps": null,
+                  "memoizedState": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={
+                        Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        }
+                      }
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "mode": 0,
+                  "nextEffect": null,
+                  "pendingProps": null,
+                  "ref": null,
+                  "return": null,
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": Object {
+                    "containerInfo": <div />,
+                    "context": Object {},
+                    "current": [Circular],
+                    "didError": false,
+                    "earliestPendingTime": 0,
+                    "earliestSuspendedTime": 0,
+                    "expirationTime": 0,
+                    "finishedWork": null,
+                    "firstBatch": null,
+                    "hydrate": false,
+                    "interactionThreadID": 15,
+                    "latestPendingTime": 0,
+                    "latestPingedTime": 0,
+                    "latestSuspendedTime": 0,
+                    "memoizedInteractions": Set {},
+                    "nextExpirationTimeToWorkOn": 0,
+                    "nextScheduledRoot": null,
+                    "pendingChildren": null,
+                    "pendingCommitExpirationTime": 0,
+                    "pendingContext": null,
+                    "pendingInteractionMap": Map {},
+                    "pingCache": null,
+                    "timeoutHandle": -1,
+                  },
+                  "tag": 3,
+                  "treeBaseDuration": 0,
+                  "type": null,
+                  "updateQueue": Object {
+                    "baseState": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={
+                          Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          }
+                        }
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "firstCapturedEffect": null,
+                    "firstCapturedUpdate": null,
+                    "firstEffect": null,
+                    "firstUpdate": null,
+                    "lastCapturedEffect": null,
+                    "lastCapturedUpdate": null,
+                    "lastEffect": null,
+                    "lastUpdate": null,
+                  },
+                },
+                "selfBaseDuration": 0,
+                "sibling": null,
+                "stateNode": WrapperComponent {
+                  "_reactInternalFiber": [Circular],
+                  "_reactInternalInstance": Object {},
+                  "context": Object {},
+                  "props": Object {
+                    "Component": [Function],
+                    "context": null,
+                    "props": Object {
+                      "children": <AuthenticatedRoute
+                        authenticated={true}
+                        component={[Function]}
+                        path="/dashboard"
+                      />,
+                    },
+                    "wrappingComponentProps": null,
+                  },
+                  "refs": Object {},
+                  "rootFinderInstance": null,
+                  "state": Object {
+                    "context": null,
+                    "mount": true,
+                    "props": Object {
+                      "children": <AuthenticatedRoute
+                        authenticated={true}
+                        component={[Function]}
+                        path="/dashboard"
+                      />,
+                    },
+                    "wrappingComponentProps": null,
+                  },
+                  "updater": Object {
+                    "enqueueForceUpdate": [Function],
+                    "enqueueReplaceState": [Function],
+                    "enqueueSetState": [Function],
+                    "isMounted": [Function],
+                  },
+                },
+                "tag": 1,
+                "treeBaseDuration": 0,
+                "type": [Function],
+                "updateQueue": null,
+              },
+              "selfBaseDuration": 0,
+              "sibling": null,
+              "stateNode": BrowserRouter {
+                "_reactInternalFiber": [Circular],
+                "_reactInternalInstance": Object {},
+                "context": Object {},
+                "history": Object {
+                  "action": "POP",
+                  "block": [Function],
+                  "createHref": [Function],
+                  "go": [Function],
+                  "goBack": [Function],
+                  "goForward": [Function],
+                  "length": 1,
+                  "listen": [Function],
+                  "location": Object {
+                    "hash": "",
+                    "pathname": "/",
+                    "search": "",
+                    "state": undefined,
+                  },
+                  "push": [Function],
+                  "replace": [Function],
+                },
+                "props": Object {
+                  "children": <AuthenticatedRoute
+                    authenticated={true}
+                    component={[Function]}
+                    path="/dashboard"
+                  />,
+                },
+                "refs": Object {},
+                "state": null,
+                "updater": Object {
+                  "enqueueForceUpdate": [Function],
+                  "enqueueReplaceState": [Function],
+                  "enqueueSetState": [Function],
+                  "isMounted": [Function],
+                },
+              },
+              "tag": 1,
+              "treeBaseDuration": 0,
+              "type": [Function],
+              "updateQueue": null,
+            },
+            "_debugSource": null,
+            "actualDuration": 0,
+            "actualStartTime": -1,
+            "alternate": null,
+            "child": FiberNode {
+              "_debugHookTypes": null,
+              "_debugID": 65,
+              "_debugIsCurrentlyTiming": false,
+              "_debugOwner": null,
+              "_debugSource": Object {
+                "fileName": "/Users/chucky/Code/Bench/bp-esa-frontend/src/App.test.jsx",
+                "lineNumber": 123,
+              },
+              "actualDuration": 0,
+              "actualStartTime": -1,
+              "alternate": null,
+              "child": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 66,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": [Circular],
+                "_debugSource": Object {
+                  "fileName": "/Users/chucky/Code/Bench/bp-esa-frontend/src/App.jsx",
+                  "lineNumber": 15,
+                },
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": null,
+                "child": null,
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 1,
+                "elementType": [Function],
+                "expirationTime": 0,
+                "firstEffect": null,
+                "index": 0,
+                "key": null,
+                "lastEffect": null,
+                "memoizedProps": Object {
+                  "path": "/dashboard",
+                  "render": [Function],
+                },
+                "memoizedState": Object {
+                  "match": null,
+                },
+                "mode": 0,
+                "nextEffect": null,
+                "pendingProps": Object {
+                  "path": "/dashboard",
+                  "render": [Function],
+                },
+                "ref": null,
+                "return": [Circular],
+                "selfBaseDuration": 0,
+                "sibling": null,
+                "stateNode": Route {
+                  "__reactInternalMemoizedMaskedChildContext": Object {
+                    "router": Object {
+                      "history": Object {
+                        "action": "POP",
+                        "block": [Function],
+                        "createHref": [Function],
+                        "go": [Function],
+                        "goBack": [Function],
+                        "goForward": [Function],
+                        "length": 1,
+                        "listen": [Function],
+                        "location": Object {
+                          "hash": "",
+                          "pathname": "/",
+                          "search": "",
+                          "state": undefined,
+                        },
+                        "push": [Function],
+                        "replace": [Function],
+                      },
+                      "route": Object {
+                        "location": Object {
+                          "hash": "",
+                          "pathname": "/",
+                          "search": "",
+                          "state": undefined,
+                        },
+                        "match": Object {
+                          "isExact": true,
+                          "params": Object {},
+                          "path": "/",
+                          "url": "/",
+                        },
+                      },
+                    },
+                  },
+                  "__reactInternalMemoizedMergedChildContext": Object {
+                    "router": Object {
+                      "history": Object {
+                        "action": "POP",
+                        "block": [Function],
+                        "createHref": [Function],
+                        "go": [Function],
+                        "goBack": [Function],
+                        "goForward": [Function],
+                        "length": 1,
+                        "listen": [Function],
+                        "location": Object {
+                          "hash": "",
+                          "pathname": "/",
+                          "search": "",
+                          "state": undefined,
+                        },
+                        "push": [Function],
+                        "replace": [Function],
+                      },
+                      "route": Object {
+                        "location": Object {
+                          "hash": "",
+                          "pathname": "/",
+                          "search": "",
+                          "state": undefined,
+                        },
+                        "match": null,
+                      },
+                    },
+                  },
+                  "__reactInternalMemoizedUnmaskedChildContext": Object {
+                    "router": Object {
+                      "history": Object {
+                        "action": "POP",
+                        "block": [Function],
+                        "createHref": [Function],
+                        "go": [Function],
+                        "goBack": [Function],
+                        "goForward": [Function],
+                        "length": 1,
+                        "listen": [Function],
+                        "location": Object {
+                          "hash": "",
+                          "pathname": "/",
+                          "search": "",
+                          "state": undefined,
+                        },
+                        "push": [Function],
+                        "replace": [Function],
+                      },
+                      "route": Object {
+                        "location": Object {
+                          "hash": "",
+                          "pathname": "/",
+                          "search": "",
+                          "state": undefined,
+                        },
+                        "match": Object {
+                          "isExact": true,
+                          "params": Object {},
+                          "path": "/",
+                          "url": "/",
+                        },
+                      },
+                    },
+                  },
+                  "_reactInternalFiber": [Circular],
+                  "_reactInternalInstance": Object {},
+                  "context": Object {
+                    "router": Object {
+                      "history": Object {
+                        "action": "POP",
+                        "block": [Function],
+                        "createHref": [Function],
+                        "go": [Function],
+                        "goBack": [Function],
+                        "goForward": [Function],
+                        "length": 1,
+                        "listen": [Function],
+                        "location": Object {
+                          "hash": "",
+                          "pathname": "/",
+                          "search": "",
+                          "state": undefined,
+                        },
+                        "push": [Function],
+                        "replace": [Function],
+                      },
+                      "route": Object {
+                        "location": Object {
+                          "hash": "",
+                          "pathname": "/",
+                          "search": "",
+                          "state": undefined,
+                        },
+                        "match": Object {
+                          "isExact": true,
+                          "params": Object {},
+                          "path": "/",
+                          "url": "/",
+                        },
+                      },
+                    },
+                  },
+                  "props": Object {
+                    "path": "/dashboard",
+                    "render": [Function],
+                  },
+                  "refs": Object {},
+                  "state": Object {
+                    "match": null,
+                  },
+                  "updater": Object {
+                    "enqueueForceUpdate": [Function],
+                    "enqueueReplaceState": [Function],
+                    "enqueueSetState": [Function],
+                    "isMounted": [Function],
+                  },
+                },
+                "tag": 1,
+                "treeBaseDuration": 0,
+                "type": [Function],
+                "updateQueue": null,
+              },
+              "childExpirationTime": 0,
+              "contextDependencies": null,
+              "effectTag": 1,
+              "elementType": [Function],
+              "expirationTime": 0,
+              "firstEffect": null,
+              "index": 0,
+              "key": null,
+              "lastEffect": null,
+              "memoizedProps": Object {
+                "authenticated": true,
+                "component": [Function],
+                "path": "/dashboard",
+              },
+              "memoizedState": null,
+              "mode": 0,
+              "nextEffect": null,
+              "pendingProps": Object {
+                "authenticated": true,
+                "component": [Function],
+                "path": "/dashboard",
+              },
+              "ref": null,
+              "return": [Circular],
+              "selfBaseDuration": 0,
+              "sibling": null,
+              "stateNode": null,
+              "tag": 0,
+              "treeBaseDuration": 0,
+              "type": [Function],
+              "updateQueue": null,
+            },
+            "childExpirationTime": 0,
+            "contextDependencies": null,
+            "effectTag": 1,
+            "elementType": [Function],
+            "expirationTime": 0,
+            "firstEffect": null,
+            "index": 0,
+            "key": null,
+            "lastEffect": null,
+            "memoizedProps": Object {
+              "children": <AuthenticatedRoute
+                authenticated={true}
+                component={[Function]}
+                path="/dashboard"
+              />,
+              "history": Object {
+                "action": "POP",
+                "block": [Function],
+                "createHref": [Function],
+                "go": [Function],
+                "goBack": [Function],
+                "goForward": [Function],
+                "length": 1,
+                "listen": [Function],
+                "location": Object {
+                  "hash": "",
+                  "pathname": "/",
+                  "search": "",
+                  "state": undefined,
+                },
+                "push": [Function],
+                "replace": [Function],
+              },
+            },
+            "memoizedState": Object {
+              "match": Object {
+                "isExact": true,
+                "params": Object {},
+                "path": "/",
+                "url": "/",
+              },
+            },
+            "mode": 0,
+            "nextEffect": null,
+            "pendingProps": Object {
+              "children": <AuthenticatedRoute
+                authenticated={true}
+                component={[Function]}
+                path="/dashboard"
+              />,
+              "history": Object {
+                "action": "POP",
+                "block": [Function],
+                "createHref": [Function],
+                "go": [Function],
+                "goBack": [Function],
+                "goForward": [Function],
+                "length": 1,
+                "listen": [Function],
+                "location": Object {
+                  "hash": "",
+                  "pathname": "/",
+                  "search": "",
+                  "state": undefined,
+                },
+                "push": [Function],
+                "replace": [Function],
+              },
+            },
+            "ref": null,
+            "return": FiberNode {
+              "_debugHookTypes": null,
+              "_debugID": 63,
+              "_debugIsCurrentlyTiming": false,
+              "_debugOwner": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 62,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": null,
+                "_debugSource": null,
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": null,
+                "child": [Circular],
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 1,
+                "elementType": [Function],
+                "expirationTime": 0,
+                "firstEffect": null,
+                "index": 0,
+                "key": null,
+                "lastEffect": null,
+                "memoizedProps": Object {
+                  "Component": [Function],
+                  "context": null,
+                  "props": Object {
+                    "children": <AuthenticatedRoute
+                      authenticated={true}
+                      component={[Function]}
+                      path="/dashboard"
+                    />,
+                  },
+                  "wrappingComponentProps": null,
+                },
+                "memoizedState": Object {
+                  "context": null,
+                  "mount": true,
+                  "props": Object {
+                    "children": <AuthenticatedRoute
+                      authenticated={true}
+                      component={[Function]}
+                      path="/dashboard"
+                    />,
+                  },
+                  "wrappingComponentProps": null,
+                },
+                "mode": 0,
+                "nextEffect": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 60,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": null,
+                  "_debugSource": null,
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 60,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": null,
+                    "_debugSource": null,
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": [Circular],
+                    "child": null,
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 0,
+                    "elementType": null,
+                    "expirationTime": 1073741823,
+                    "firstEffect": null,
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": null,
+                    "memoizedProps": null,
+                    "memoizedState": null,
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": null,
+                    "ref": null,
+                    "return": null,
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": Object {
+                      "containerInfo": <div />,
+                      "context": Object {},
+                      "current": [Circular],
+                      "didError": false,
+                      "earliestPendingTime": 0,
+                      "earliestSuspendedTime": 0,
+                      "expirationTime": 0,
+                      "finishedWork": null,
+                      "firstBatch": null,
+                      "hydrate": false,
+                      "interactionThreadID": 15,
+                      "latestPendingTime": 0,
+                      "latestPingedTime": 0,
+                      "latestSuspendedTime": 0,
+                      "memoizedInteractions": Set {},
+                      "nextExpirationTimeToWorkOn": 0,
+                      "nextScheduledRoot": null,
+                      "pendingChildren": null,
+                      "pendingCommitExpirationTime": 0,
+                      "pendingContext": null,
+                      "pendingInteractionMap": Map {},
+                      "pingCache": null,
+                      "timeoutHandle": -1,
+                    },
+                    "tag": 3,
+                    "treeBaseDuration": 0,
+                    "type": null,
+                    "updateQueue": Object {
+                      "baseState": null,
+                      "firstCapturedEffect": null,
+                      "firstCapturedUpdate": null,
+                      "firstEffect": null,
+                      "firstUpdate": Object {
+                        "callback": null,
+                        "expirationTime": 1073741823,
+                        "next": null,
+                        "nextEffect": null,
+                        "payload": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={
+                              Object {
+                                "children": <AuthenticatedRoute
+                                  authenticated={true}
+                                  component={[Function]}
+                                  path="/dashboard"
+                                />,
+                              }
+                            }
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "tag": 0,
+                      },
+                      "lastCapturedEffect": null,
+                      "lastCapturedUpdate": null,
+                      "lastEffect": null,
+                      "lastUpdate": Object {
+                        "callback": null,
+                        "expirationTime": 1073741823,
+                        "next": null,
+                        "nextEffect": null,
+                        "payload": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={
+                              Object {
+                                "children": <AuthenticatedRoute
+                                  authenticated={true}
+                                  component={[Function]}
+                                  path="/dashboard"
+                                />,
+                              }
+                            }
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "tag": 0,
+                      },
+                    },
+                  },
+                  "child": [Circular],
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 32,
+                  "elementType": null,
+                  "expirationTime": 0,
+                  "firstEffect": [Circular],
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": [Circular],
+                  "memoizedProps": null,
+                  "memoizedState": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={
+                        Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        }
+                      }
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "mode": 0,
+                  "nextEffect": null,
+                  "pendingProps": null,
+                  "ref": null,
+                  "return": null,
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": Object {
+                    "containerInfo": <div />,
+                    "context": Object {},
+                    "current": [Circular],
+                    "didError": false,
+                    "earliestPendingTime": 0,
+                    "earliestSuspendedTime": 0,
+                    "expirationTime": 0,
+                    "finishedWork": null,
+                    "firstBatch": null,
+                    "hydrate": false,
+                    "interactionThreadID": 15,
+                    "latestPendingTime": 0,
+                    "latestPingedTime": 0,
+                    "latestSuspendedTime": 0,
+                    "memoizedInteractions": Set {},
+                    "nextExpirationTimeToWorkOn": 0,
+                    "nextScheduledRoot": null,
+                    "pendingChildren": null,
+                    "pendingCommitExpirationTime": 0,
+                    "pendingContext": null,
+                    "pendingInteractionMap": Map {},
+                    "pingCache": null,
+                    "timeoutHandle": -1,
+                  },
+                  "tag": 3,
+                  "treeBaseDuration": 0,
+                  "type": null,
+                  "updateQueue": Object {
+                    "baseState": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={
+                          Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          }
+                        }
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "firstCapturedEffect": null,
+                    "firstCapturedUpdate": null,
+                    "firstEffect": null,
+                    "firstUpdate": null,
+                    "lastCapturedEffect": null,
+                    "lastCapturedUpdate": null,
+                    "lastEffect": null,
+                    "lastUpdate": null,
+                  },
+                },
+                "pendingProps": Object {
+                  "Component": [Function],
+                  "context": null,
+                  "props": Object {
+                    "children": <AuthenticatedRoute
+                      authenticated={true}
+                      component={[Function]}
+                      path="/dashboard"
+                    />,
+                  },
+                  "wrappingComponentProps": null,
+                },
+                "ref": null,
+                "return": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 60,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": null,
+                  "_debugSource": null,
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 60,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": null,
+                    "_debugSource": null,
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": [Circular],
+                    "child": null,
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 0,
+                    "elementType": null,
+                    "expirationTime": 1073741823,
+                    "firstEffect": null,
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": null,
+                    "memoizedProps": null,
+                    "memoizedState": null,
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": null,
+                    "ref": null,
+                    "return": null,
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": Object {
+                      "containerInfo": <div />,
+                      "context": Object {},
+                      "current": [Circular],
+                      "didError": false,
+                      "earliestPendingTime": 0,
+                      "earliestSuspendedTime": 0,
+                      "expirationTime": 0,
+                      "finishedWork": null,
+                      "firstBatch": null,
+                      "hydrate": false,
+                      "interactionThreadID": 15,
+                      "latestPendingTime": 0,
+                      "latestPingedTime": 0,
+                      "latestSuspendedTime": 0,
+                      "memoizedInteractions": Set {},
+                      "nextExpirationTimeToWorkOn": 0,
+                      "nextScheduledRoot": null,
+                      "pendingChildren": null,
+                      "pendingCommitExpirationTime": 0,
+                      "pendingContext": null,
+                      "pendingInteractionMap": Map {},
+                      "pingCache": null,
+                      "timeoutHandle": -1,
+                    },
+                    "tag": 3,
+                    "treeBaseDuration": 0,
+                    "type": null,
+                    "updateQueue": Object {
+                      "baseState": null,
+                      "firstCapturedEffect": null,
+                      "firstCapturedUpdate": null,
+                      "firstEffect": null,
+                      "firstUpdate": Object {
+                        "callback": null,
+                        "expirationTime": 1073741823,
+                        "next": null,
+                        "nextEffect": null,
+                        "payload": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={
+                              Object {
+                                "children": <AuthenticatedRoute
+                                  authenticated={true}
+                                  component={[Function]}
+                                  path="/dashboard"
+                                />,
+                              }
+                            }
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "tag": 0,
+                      },
+                      "lastCapturedEffect": null,
+                      "lastCapturedUpdate": null,
+                      "lastEffect": null,
+                      "lastUpdate": Object {
+                        "callback": null,
+                        "expirationTime": 1073741823,
+                        "next": null,
+                        "nextEffect": null,
+                        "payload": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={
+                              Object {
+                                "children": <AuthenticatedRoute
+                                  authenticated={true}
+                                  component={[Function]}
+                                  path="/dashboard"
+                                />,
+                              }
+                            }
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "tag": 0,
+                      },
+                    },
+                  },
+                  "child": [Circular],
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 32,
+                  "elementType": null,
+                  "expirationTime": 0,
+                  "firstEffect": [Circular],
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": [Circular],
+                  "memoizedProps": null,
+                  "memoizedState": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={
+                        Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        }
+                      }
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "mode": 0,
+                  "nextEffect": null,
+                  "pendingProps": null,
+                  "ref": null,
+                  "return": null,
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": Object {
+                    "containerInfo": <div />,
+                    "context": Object {},
+                    "current": [Circular],
+                    "didError": false,
+                    "earliestPendingTime": 0,
+                    "earliestSuspendedTime": 0,
+                    "expirationTime": 0,
+                    "finishedWork": null,
+                    "firstBatch": null,
+                    "hydrate": false,
+                    "interactionThreadID": 15,
+                    "latestPendingTime": 0,
+                    "latestPingedTime": 0,
+                    "latestSuspendedTime": 0,
+                    "memoizedInteractions": Set {},
+                    "nextExpirationTimeToWorkOn": 0,
+                    "nextScheduledRoot": null,
+                    "pendingChildren": null,
+                    "pendingCommitExpirationTime": 0,
+                    "pendingContext": null,
+                    "pendingInteractionMap": Map {},
+                    "pingCache": null,
+                    "timeoutHandle": -1,
+                  },
+                  "tag": 3,
+                  "treeBaseDuration": 0,
+                  "type": null,
+                  "updateQueue": Object {
+                    "baseState": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={
+                          Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          }
+                        }
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "firstCapturedEffect": null,
+                    "firstCapturedUpdate": null,
+                    "firstEffect": null,
+                    "firstUpdate": null,
+                    "lastCapturedEffect": null,
+                    "lastCapturedUpdate": null,
+                    "lastEffect": null,
+                    "lastUpdate": null,
+                  },
+                },
+                "selfBaseDuration": 0,
+                "sibling": null,
+                "stateNode": WrapperComponent {
+                  "_reactInternalFiber": [Circular],
+                  "_reactInternalInstance": Object {},
+                  "context": Object {},
+                  "props": Object {
+                    "Component": [Function],
+                    "context": null,
+                    "props": Object {
+                      "children": <AuthenticatedRoute
+                        authenticated={true}
+                        component={[Function]}
+                        path="/dashboard"
+                      />,
+                    },
+                    "wrappingComponentProps": null,
+                  },
+                  "refs": Object {},
+                  "rootFinderInstance": null,
+                  "state": Object {
+                    "context": null,
+                    "mount": true,
+                    "props": Object {
+                      "children": <AuthenticatedRoute
+                        authenticated={true}
+                        component={[Function]}
+                        path="/dashboard"
+                      />,
+                    },
+                    "wrappingComponentProps": null,
+                  },
+                  "updater": Object {
+                    "enqueueForceUpdate": [Function],
+                    "enqueueReplaceState": [Function],
+                    "enqueueSetState": [Function],
+                    "isMounted": [Function],
+                  },
+                },
+                "tag": 1,
+                "treeBaseDuration": 0,
+                "type": [Function],
+                "updateQueue": null,
+              },
+              "_debugSource": null,
+              "actualDuration": 0,
+              "actualStartTime": -1,
+              "alternate": null,
+              "child": [Circular],
+              "childExpirationTime": 0,
+              "contextDependencies": null,
+              "effectTag": 1,
+              "elementType": [Function],
+              "expirationTime": 0,
+              "firstEffect": null,
+              "index": 0,
+              "key": null,
+              "lastEffect": null,
+              "memoizedProps": Object {
+                "children": <AuthenticatedRoute
+                  authenticated={true}
+                  component={[Function]}
+                  path="/dashboard"
+                />,
+              },
+              "memoizedState": null,
+              "mode": 0,
+              "nextEffect": null,
+              "pendingProps": Object {
+                "children": <AuthenticatedRoute
+                  authenticated={true}
+                  component={[Function]}
+                  path="/dashboard"
+                />,
+              },
+              "ref": null,
+              "return": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 62,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": null,
+                "_debugSource": null,
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": null,
+                "child": [Circular],
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 1,
+                "elementType": [Function],
+                "expirationTime": 0,
+                "firstEffect": null,
+                "index": 0,
+                "key": null,
+                "lastEffect": null,
+                "memoizedProps": Object {
+                  "Component": [Function],
+                  "context": null,
+                  "props": Object {
+                    "children": <AuthenticatedRoute
+                      authenticated={true}
+                      component={[Function]}
+                      path="/dashboard"
+                    />,
+                  },
+                  "wrappingComponentProps": null,
+                },
+                "memoizedState": Object {
+                  "context": null,
+                  "mount": true,
+                  "props": Object {
+                    "children": <AuthenticatedRoute
+                      authenticated={true}
+                      component={[Function]}
+                      path="/dashboard"
+                    />,
+                  },
+                  "wrappingComponentProps": null,
+                },
+                "mode": 0,
+                "nextEffect": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 60,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": null,
+                  "_debugSource": null,
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 60,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": null,
+                    "_debugSource": null,
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": [Circular],
+                    "child": null,
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 0,
+                    "elementType": null,
+                    "expirationTime": 1073741823,
+                    "firstEffect": null,
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": null,
+                    "memoizedProps": null,
+                    "memoizedState": null,
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": null,
+                    "ref": null,
+                    "return": null,
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": Object {
+                      "containerInfo": <div />,
+                      "context": Object {},
+                      "current": [Circular],
+                      "didError": false,
+                      "earliestPendingTime": 0,
+                      "earliestSuspendedTime": 0,
+                      "expirationTime": 0,
+                      "finishedWork": null,
+                      "firstBatch": null,
+                      "hydrate": false,
+                      "interactionThreadID": 15,
+                      "latestPendingTime": 0,
+                      "latestPingedTime": 0,
+                      "latestSuspendedTime": 0,
+                      "memoizedInteractions": Set {},
+                      "nextExpirationTimeToWorkOn": 0,
+                      "nextScheduledRoot": null,
+                      "pendingChildren": null,
+                      "pendingCommitExpirationTime": 0,
+                      "pendingContext": null,
+                      "pendingInteractionMap": Map {},
+                      "pingCache": null,
+                      "timeoutHandle": -1,
+                    },
+                    "tag": 3,
+                    "treeBaseDuration": 0,
+                    "type": null,
+                    "updateQueue": Object {
+                      "baseState": null,
+                      "firstCapturedEffect": null,
+                      "firstCapturedUpdate": null,
+                      "firstEffect": null,
+                      "firstUpdate": Object {
+                        "callback": null,
+                        "expirationTime": 1073741823,
+                        "next": null,
+                        "nextEffect": null,
+                        "payload": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={
+                              Object {
+                                "children": <AuthenticatedRoute
+                                  authenticated={true}
+                                  component={[Function]}
+                                  path="/dashboard"
+                                />,
+                              }
+                            }
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "tag": 0,
+                      },
+                      "lastCapturedEffect": null,
+                      "lastCapturedUpdate": null,
+                      "lastEffect": null,
+                      "lastUpdate": Object {
+                        "callback": null,
+                        "expirationTime": 1073741823,
+                        "next": null,
+                        "nextEffect": null,
+                        "payload": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={
+                              Object {
+                                "children": <AuthenticatedRoute
+                                  authenticated={true}
+                                  component={[Function]}
+                                  path="/dashboard"
+                                />,
+                              }
+                            }
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "tag": 0,
+                      },
+                    },
+                  },
+                  "child": [Circular],
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 32,
+                  "elementType": null,
+                  "expirationTime": 0,
+                  "firstEffect": [Circular],
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": [Circular],
+                  "memoizedProps": null,
+                  "memoizedState": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={
+                        Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        }
+                      }
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "mode": 0,
+                  "nextEffect": null,
+                  "pendingProps": null,
+                  "ref": null,
+                  "return": null,
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": Object {
+                    "containerInfo": <div />,
+                    "context": Object {},
+                    "current": [Circular],
+                    "didError": false,
+                    "earliestPendingTime": 0,
+                    "earliestSuspendedTime": 0,
+                    "expirationTime": 0,
+                    "finishedWork": null,
+                    "firstBatch": null,
+                    "hydrate": false,
+                    "interactionThreadID": 15,
+                    "latestPendingTime": 0,
+                    "latestPingedTime": 0,
+                    "latestSuspendedTime": 0,
+                    "memoizedInteractions": Set {},
+                    "nextExpirationTimeToWorkOn": 0,
+                    "nextScheduledRoot": null,
+                    "pendingChildren": null,
+                    "pendingCommitExpirationTime": 0,
+                    "pendingContext": null,
+                    "pendingInteractionMap": Map {},
+                    "pingCache": null,
+                    "timeoutHandle": -1,
+                  },
+                  "tag": 3,
+                  "treeBaseDuration": 0,
+                  "type": null,
+                  "updateQueue": Object {
+                    "baseState": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={
+                          Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          }
+                        }
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "firstCapturedEffect": null,
+                    "firstCapturedUpdate": null,
+                    "firstEffect": null,
+                    "firstUpdate": null,
+                    "lastCapturedEffect": null,
+                    "lastCapturedUpdate": null,
+                    "lastEffect": null,
+                    "lastUpdate": null,
+                  },
+                },
+                "pendingProps": Object {
+                  "Component": [Function],
+                  "context": null,
+                  "props": Object {
+                    "children": <AuthenticatedRoute
+                      authenticated={true}
+                      component={[Function]}
+                      path="/dashboard"
+                    />,
+                  },
+                  "wrappingComponentProps": null,
+                },
+                "ref": null,
+                "return": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 60,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": null,
+                  "_debugSource": null,
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 60,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": null,
+                    "_debugSource": null,
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": [Circular],
+                    "child": null,
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 0,
+                    "elementType": null,
+                    "expirationTime": 1073741823,
+                    "firstEffect": null,
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": null,
+                    "memoizedProps": null,
+                    "memoizedState": null,
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": null,
+                    "ref": null,
+                    "return": null,
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": Object {
+                      "containerInfo": <div />,
+                      "context": Object {},
+                      "current": [Circular],
+                      "didError": false,
+                      "earliestPendingTime": 0,
+                      "earliestSuspendedTime": 0,
+                      "expirationTime": 0,
+                      "finishedWork": null,
+                      "firstBatch": null,
+                      "hydrate": false,
+                      "interactionThreadID": 15,
+                      "latestPendingTime": 0,
+                      "latestPingedTime": 0,
+                      "latestSuspendedTime": 0,
+                      "memoizedInteractions": Set {},
+                      "nextExpirationTimeToWorkOn": 0,
+                      "nextScheduledRoot": null,
+                      "pendingChildren": null,
+                      "pendingCommitExpirationTime": 0,
+                      "pendingContext": null,
+                      "pendingInteractionMap": Map {},
+                      "pingCache": null,
+                      "timeoutHandle": -1,
+                    },
+                    "tag": 3,
+                    "treeBaseDuration": 0,
+                    "type": null,
+                    "updateQueue": Object {
+                      "baseState": null,
+                      "firstCapturedEffect": null,
+                      "firstCapturedUpdate": null,
+                      "firstEffect": null,
+                      "firstUpdate": Object {
+                        "callback": null,
+                        "expirationTime": 1073741823,
+                        "next": null,
+                        "nextEffect": null,
+                        "payload": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={
+                              Object {
+                                "children": <AuthenticatedRoute
+                                  authenticated={true}
+                                  component={[Function]}
+                                  path="/dashboard"
+                                />,
+                              }
+                            }
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "tag": 0,
+                      },
+                      "lastCapturedEffect": null,
+                      "lastCapturedUpdate": null,
+                      "lastEffect": null,
+                      "lastUpdate": Object {
+                        "callback": null,
+                        "expirationTime": 1073741823,
+                        "next": null,
+                        "nextEffect": null,
+                        "payload": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={
+                              Object {
+                                "children": <AuthenticatedRoute
+                                  authenticated={true}
+                                  component={[Function]}
+                                  path="/dashboard"
+                                />,
+                              }
+                            }
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "tag": 0,
+                      },
+                    },
+                  },
+                  "child": [Circular],
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 32,
+                  "elementType": null,
+                  "expirationTime": 0,
+                  "firstEffect": [Circular],
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": [Circular],
+                  "memoizedProps": null,
+                  "memoizedState": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={
+                        Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        }
+                      }
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "mode": 0,
+                  "nextEffect": null,
+                  "pendingProps": null,
+                  "ref": null,
+                  "return": null,
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": Object {
+                    "containerInfo": <div />,
+                    "context": Object {},
+                    "current": [Circular],
+                    "didError": false,
+                    "earliestPendingTime": 0,
+                    "earliestSuspendedTime": 0,
+                    "expirationTime": 0,
+                    "finishedWork": null,
+                    "firstBatch": null,
+                    "hydrate": false,
+                    "interactionThreadID": 15,
+                    "latestPendingTime": 0,
+                    "latestPingedTime": 0,
+                    "latestSuspendedTime": 0,
+                    "memoizedInteractions": Set {},
+                    "nextExpirationTimeToWorkOn": 0,
+                    "nextScheduledRoot": null,
+                    "pendingChildren": null,
+                    "pendingCommitExpirationTime": 0,
+                    "pendingContext": null,
+                    "pendingInteractionMap": Map {},
+                    "pingCache": null,
+                    "timeoutHandle": -1,
+                  },
+                  "tag": 3,
+                  "treeBaseDuration": 0,
+                  "type": null,
+                  "updateQueue": Object {
+                    "baseState": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={
+                          Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          }
+                        }
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "firstCapturedEffect": null,
+                    "firstCapturedUpdate": null,
+                    "firstEffect": null,
+                    "firstUpdate": null,
+                    "lastCapturedEffect": null,
+                    "lastCapturedUpdate": null,
+                    "lastEffect": null,
+                    "lastUpdate": null,
+                  },
+                },
+                "selfBaseDuration": 0,
+                "sibling": null,
+                "stateNode": WrapperComponent {
+                  "_reactInternalFiber": [Circular],
+                  "_reactInternalInstance": Object {},
+                  "context": Object {},
+                  "props": Object {
+                    "Component": [Function],
+                    "context": null,
+                    "props": Object {
+                      "children": <AuthenticatedRoute
+                        authenticated={true}
+                        component={[Function]}
+                        path="/dashboard"
+                      />,
+                    },
+                    "wrappingComponentProps": null,
+                  },
+                  "refs": Object {},
+                  "rootFinderInstance": null,
+                  "state": Object {
+                    "context": null,
+                    "mount": true,
+                    "props": Object {
+                      "children": <AuthenticatedRoute
+                        authenticated={true}
+                        component={[Function]}
+                        path="/dashboard"
+                      />,
+                    },
+                    "wrappingComponentProps": null,
+                  },
+                  "updater": Object {
+                    "enqueueForceUpdate": [Function],
+                    "enqueueReplaceState": [Function],
+                    "enqueueSetState": [Function],
+                    "isMounted": [Function],
+                  },
+                },
+                "tag": 1,
+                "treeBaseDuration": 0,
+                "type": [Function],
+                "updateQueue": null,
+              },
+              "selfBaseDuration": 0,
+              "sibling": null,
+              "stateNode": BrowserRouter {
+                "_reactInternalFiber": [Circular],
+                "_reactInternalInstance": Object {},
+                "context": Object {},
+                "history": Object {
+                  "action": "POP",
+                  "block": [Function],
+                  "createHref": [Function],
+                  "go": [Function],
+                  "goBack": [Function],
+                  "goForward": [Function],
+                  "length": 1,
+                  "listen": [Function],
+                  "location": Object {
+                    "hash": "",
+                    "pathname": "/",
+                    "search": "",
+                    "state": undefined,
+                  },
+                  "push": [Function],
+                  "replace": [Function],
+                },
+                "props": Object {
+                  "children": <AuthenticatedRoute
+                    authenticated={true}
+                    component={[Function]}
+                    path="/dashboard"
+                  />,
+                },
+                "refs": Object {},
+                "state": null,
+                "updater": Object {
+                  "enqueueForceUpdate": [Function],
+                  "enqueueReplaceState": [Function],
+                  "enqueueSetState": [Function],
+                  "isMounted": [Function],
+                },
+              },
+              "tag": 1,
+              "treeBaseDuration": 0,
+              "type": [Function],
+              "updateQueue": null,
+            },
+            "selfBaseDuration": 0,
+            "sibling": null,
+            "stateNode": [Circular],
+            "tag": 1,
+            "treeBaseDuration": 0,
+            "type": [Function],
+            "updateQueue": null,
+          },
+          "_reactInternalInstance": Object {},
+          "context": Object {
+            "router": undefined,
+          },
+          "props": Object {
+            "children": <AuthenticatedRoute
+              authenticated={true}
+              component={[Function]}
+              path="/dashboard"
+            />,
+            "history": Object {
+              "action": "POP",
+              "block": [Function],
+              "createHref": [Function],
+              "go": [Function],
+              "goBack": [Function],
+              "goForward": [Function],
+              "length": 1,
+              "listen": [Function],
+              "location": Object {
+                "hash": "",
+                "pathname": "/",
+                "search": "",
+                "state": undefined,
+              },
+              "push": [Function],
+              "replace": [Function],
+            },
+          },
+          "refs": Object {},
+          "state": Object {
+            "match": Object {
+              "isExact": true,
+              "params": Object {},
+              "path": "/",
+              "url": "/",
+            },
+          },
+          "unlisten": [Function],
+          "updater": Object {
+            "enqueueForceUpdate": [Function],
+            "enqueueReplaceState": [Function],
+            "enqueueSetState": [Function],
+            "isMounted": [Function],
+          },
+        },
+        "key": undefined,
+        "nodeType": "class",
+        "props": Object {
+          "children": <AuthenticatedRoute
+            authenticated={true}
+            component={[Function]}
+            path="/dashboard"
+          />,
+          "history": Object {
+            "action": "POP",
+            "block": [Function],
+            "createHref": [Function],
+            "go": [Function],
+            "goBack": [Function],
+            "goForward": [Function],
+            "length": 1,
+            "listen": [Function],
+            "location": Object {
+              "hash": "",
+              "pathname": "/",
+              "search": "",
+              "state": undefined,
+            },
+            "push": [Function],
+            "replace": [Function],
+          },
+        },
+        "ref": null,
+        "rendered": Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "function",
+          "props": Object {
+            "authenticated": true,
+            "component": [Function],
+            "path": "/dashboard",
+          },
+          "ref": null,
+          "rendered": Object {
+            "instance": Route {
+              "__reactInternalMemoizedMaskedChildContext": Object {
+                "router": Object {
+                  "history": Object {
+                    "action": "POP",
+                    "block": [Function],
+                    "createHref": [Function],
+                    "go": [Function],
+                    "goBack": [Function],
+                    "goForward": [Function],
+                    "length": 1,
+                    "listen": [Function],
+                    "location": Object {
+                      "hash": "",
+                      "pathname": "/",
+                      "search": "",
+                      "state": undefined,
+                    },
+                    "push": [Function],
+                    "replace": [Function],
+                  },
+                  "route": Object {
+                    "location": Object {
+                      "hash": "",
+                      "pathname": "/",
+                      "search": "",
+                      "state": undefined,
+                    },
+                    "match": Object {
+                      "isExact": true,
+                      "params": Object {},
+                      "path": "/",
+                      "url": "/",
+                    },
+                  },
+                },
+              },
+              "__reactInternalMemoizedMergedChildContext": Object {
+                "router": Object {
+                  "history": Object {
+                    "action": "POP",
+                    "block": [Function],
+                    "createHref": [Function],
+                    "go": [Function],
+                    "goBack": [Function],
+                    "goForward": [Function],
+                    "length": 1,
+                    "listen": [Function],
+                    "location": Object {
+                      "hash": "",
+                      "pathname": "/",
+                      "search": "",
+                      "state": undefined,
+                    },
+                    "push": [Function],
+                    "replace": [Function],
+                  },
+                  "route": Object {
+                    "location": Object {
+                      "hash": "",
+                      "pathname": "/",
+                      "search": "",
+                      "state": undefined,
+                    },
+                    "match": null,
+                  },
+                },
+              },
+              "__reactInternalMemoizedUnmaskedChildContext": Object {
+                "router": Object {
+                  "history": Object {
+                    "action": "POP",
+                    "block": [Function],
+                    "createHref": [Function],
+                    "go": [Function],
+                    "goBack": [Function],
+                    "goForward": [Function],
+                    "length": 1,
+                    "listen": [Function],
+                    "location": Object {
+                      "hash": "",
+                      "pathname": "/",
+                      "search": "",
+                      "state": undefined,
+                    },
+                    "push": [Function],
+                    "replace": [Function],
+                  },
+                  "route": Object {
+                    "location": Object {
+                      "hash": "",
+                      "pathname": "/",
+                      "search": "",
+                      "state": undefined,
+                    },
+                    "match": Object {
+                      "isExact": true,
+                      "params": Object {},
+                      "path": "/",
+                      "url": "/",
+                    },
+                  },
+                },
+              },
+              "_reactInternalFiber": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 66,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 65,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": null,
+                  "_debugSource": Object {
+                    "fileName": "/Users/chucky/Code/Bench/bp-esa-frontend/src/App.test.jsx",
+                    "lineNumber": 123,
+                  },
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": null,
+                  "child": [Circular],
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 1,
+                  "elementType": [Function],
+                  "expirationTime": 0,
+                  "firstEffect": null,
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": null,
+                  "memoizedProps": Object {
+                    "authenticated": true,
+                    "component": [Function],
+                    "path": "/dashboard",
+                  },
+                  "memoizedState": null,
+                  "mode": 0,
+                  "nextEffect": null,
+                  "pendingProps": Object {
+                    "authenticated": true,
+                    "component": [Function],
+                    "path": "/dashboard",
+                  },
+                  "ref": null,
+                  "return": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 64,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": FiberNode {
+                      "_debugHookTypes": null,
+                      "_debugID": 63,
+                      "_debugIsCurrentlyTiming": false,
+                      "_debugOwner": FiberNode {
+                        "_debugHookTypes": null,
+                        "_debugID": 62,
+                        "_debugIsCurrentlyTiming": false,
+                        "_debugOwner": null,
+                        "_debugSource": null,
+                        "actualDuration": 0,
+                        "actualStartTime": -1,
+                        "alternate": null,
+                        "child": [Circular],
+                        "childExpirationTime": 0,
+                        "contextDependencies": null,
+                        "effectTag": 1,
+                        "elementType": [Function],
+                        "expirationTime": 0,
+                        "firstEffect": null,
+                        "index": 0,
+                        "key": null,
+                        "lastEffect": null,
+                        "memoizedProps": Object {
+                          "Component": [Function],
+                          "context": null,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "memoizedState": Object {
+                          "context": null,
+                          "mount": true,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "mode": 0,
+                        "nextEffect": FiberNode {
+                          "_debugHookTypes": null,
+                          "_debugID": 60,
+                          "_debugIsCurrentlyTiming": false,
+                          "_debugOwner": null,
+                          "_debugSource": null,
+                          "actualDuration": 0,
+                          "actualStartTime": -1,
+                          "alternate": FiberNode {
+                            "_debugHookTypes": null,
+                            "_debugID": 60,
+                            "_debugIsCurrentlyTiming": false,
+                            "_debugOwner": null,
+                            "_debugSource": null,
+                            "actualDuration": 0,
+                            "actualStartTime": -1,
+                            "alternate": [Circular],
+                            "child": null,
+                            "childExpirationTime": 0,
+                            "contextDependencies": null,
+                            "effectTag": 0,
+                            "elementType": null,
+                            "expirationTime": 1073741823,
+                            "firstEffect": null,
+                            "index": 0,
+                            "key": null,
+                            "lastEffect": null,
+                            "memoizedProps": null,
+                            "memoizedState": null,
+                            "mode": 0,
+                            "nextEffect": null,
+                            "pendingProps": null,
+                            "ref": null,
+                            "return": null,
+                            "selfBaseDuration": 0,
+                            "sibling": null,
+                            "stateNode": Object {
+                              "containerInfo": <div />,
+                              "context": Object {},
+                              "current": [Circular],
+                              "didError": false,
+                              "earliestPendingTime": 0,
+                              "earliestSuspendedTime": 0,
+                              "expirationTime": 0,
+                              "finishedWork": null,
+                              "firstBatch": null,
+                              "hydrate": false,
+                              "interactionThreadID": 15,
+                              "latestPendingTime": 0,
+                              "latestPingedTime": 0,
+                              "latestSuspendedTime": 0,
+                              "memoizedInteractions": Set {},
+                              "nextExpirationTimeToWorkOn": 0,
+                              "nextScheduledRoot": null,
+                              "pendingChildren": null,
+                              "pendingCommitExpirationTime": 0,
+                              "pendingContext": null,
+                              "pendingInteractionMap": Map {},
+                              "pingCache": null,
+                              "timeoutHandle": -1,
+                            },
+                            "tag": 3,
+                            "treeBaseDuration": 0,
+                            "type": null,
+                            "updateQueue": Object {
+                              "baseState": null,
+                              "firstCapturedEffect": null,
+                              "firstCapturedUpdate": null,
+                              "firstEffect": null,
+                              "firstUpdate": Object {
+                                "callback": null,
+                                "expirationTime": 1073741823,
+                                "next": null,
+                                "nextEffect": null,
+                                "payload": Object {
+                                  "element": <WrapperComponent
+                                    Component={[Function]}
+                                    context={null}
+                                    props={
+                                      Object {
+                                        "children": <AuthenticatedRoute
+                                          authenticated={true}
+                                          component={[Function]}
+                                          path="/dashboard"
+                                        />,
+                                      }
+                                    }
+                                    wrappingComponentProps={null}
+                                  />,
+                                },
+                                "tag": 0,
+                              },
+                              "lastCapturedEffect": null,
+                              "lastCapturedUpdate": null,
+                              "lastEffect": null,
+                              "lastUpdate": Object {
+                                "callback": null,
+                                "expirationTime": 1073741823,
+                                "next": null,
+                                "nextEffect": null,
+                                "payload": Object {
+                                  "element": <WrapperComponent
+                                    Component={[Function]}
+                                    context={null}
+                                    props={
+                                      Object {
+                                        "children": <AuthenticatedRoute
+                                          authenticated={true}
+                                          component={[Function]}
+                                          path="/dashboard"
+                                        />,
+                                      }
+                                    }
+                                    wrappingComponentProps={null}
+                                  />,
+                                },
+                                "tag": 0,
+                              },
+                            },
+                          },
+                          "child": [Circular],
+                          "childExpirationTime": 0,
+                          "contextDependencies": null,
+                          "effectTag": 32,
+                          "elementType": null,
+                          "expirationTime": 0,
+                          "firstEffect": [Circular],
+                          "index": 0,
+                          "key": null,
+                          "lastEffect": [Circular],
+                          "memoizedProps": null,
+                          "memoizedState": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={
+                                Object {
+                                  "children": <AuthenticatedRoute
+                                    authenticated={true}
+                                    component={[Function]}
+                                    path="/dashboard"
+                                  />,
+                                }
+                              }
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "mode": 0,
+                          "nextEffect": null,
+                          "pendingProps": null,
+                          "ref": null,
+                          "return": null,
+                          "selfBaseDuration": 0,
+                          "sibling": null,
+                          "stateNode": Object {
+                            "containerInfo": <div />,
+                            "context": Object {},
+                            "current": [Circular],
+                            "didError": false,
+                            "earliestPendingTime": 0,
+                            "earliestSuspendedTime": 0,
+                            "expirationTime": 0,
+                            "finishedWork": null,
+                            "firstBatch": null,
+                            "hydrate": false,
+                            "interactionThreadID": 15,
+                            "latestPendingTime": 0,
+                            "latestPingedTime": 0,
+                            "latestSuspendedTime": 0,
+                            "memoizedInteractions": Set {},
+                            "nextExpirationTimeToWorkOn": 0,
+                            "nextScheduledRoot": null,
+                            "pendingChildren": null,
+                            "pendingCommitExpirationTime": 0,
+                            "pendingContext": null,
+                            "pendingInteractionMap": Map {},
+                            "pingCache": null,
+                            "timeoutHandle": -1,
+                          },
+                          "tag": 3,
+                          "treeBaseDuration": 0,
+                          "type": null,
+                          "updateQueue": Object {
+                            "baseState": Object {
+                              "element": <WrapperComponent
+                                Component={[Function]}
+                                context={null}
+                                props={
+                                  Object {
+                                    "children": <AuthenticatedRoute
+                                      authenticated={true}
+                                      component={[Function]}
+                                      path="/dashboard"
+                                    />,
+                                  }
+                                }
+                                wrappingComponentProps={null}
+                              />,
+                            },
+                            "firstCapturedEffect": null,
+                            "firstCapturedUpdate": null,
+                            "firstEffect": null,
+                            "firstUpdate": null,
+                            "lastCapturedEffect": null,
+                            "lastCapturedUpdate": null,
+                            "lastEffect": null,
+                            "lastUpdate": null,
+                          },
+                        },
+                        "pendingProps": Object {
+                          "Component": [Function],
+                          "context": null,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "ref": null,
+                        "return": FiberNode {
+                          "_debugHookTypes": null,
+                          "_debugID": 60,
+                          "_debugIsCurrentlyTiming": false,
+                          "_debugOwner": null,
+                          "_debugSource": null,
+                          "actualDuration": 0,
+                          "actualStartTime": -1,
+                          "alternate": FiberNode {
+                            "_debugHookTypes": null,
+                            "_debugID": 60,
+                            "_debugIsCurrentlyTiming": false,
+                            "_debugOwner": null,
+                            "_debugSource": null,
+                            "actualDuration": 0,
+                            "actualStartTime": -1,
+                            "alternate": [Circular],
+                            "child": null,
+                            "childExpirationTime": 0,
+                            "contextDependencies": null,
+                            "effectTag": 0,
+                            "elementType": null,
+                            "expirationTime": 1073741823,
+                            "firstEffect": null,
+                            "index": 0,
+                            "key": null,
+                            "lastEffect": null,
+                            "memoizedProps": null,
+                            "memoizedState": null,
+                            "mode": 0,
+                            "nextEffect": null,
+                            "pendingProps": null,
+                            "ref": null,
+                            "return": null,
+                            "selfBaseDuration": 0,
+                            "sibling": null,
+                            "stateNode": Object {
+                              "containerInfo": <div />,
+                              "context": Object {},
+                              "current": [Circular],
+                              "didError": false,
+                              "earliestPendingTime": 0,
+                              "earliestSuspendedTime": 0,
+                              "expirationTime": 0,
+                              "finishedWork": null,
+                              "firstBatch": null,
+                              "hydrate": false,
+                              "interactionThreadID": 15,
+                              "latestPendingTime": 0,
+                              "latestPingedTime": 0,
+                              "latestSuspendedTime": 0,
+                              "memoizedInteractions": Set {},
+                              "nextExpirationTimeToWorkOn": 0,
+                              "nextScheduledRoot": null,
+                              "pendingChildren": null,
+                              "pendingCommitExpirationTime": 0,
+                              "pendingContext": null,
+                              "pendingInteractionMap": Map {},
+                              "pingCache": null,
+                              "timeoutHandle": -1,
+                            },
+                            "tag": 3,
+                            "treeBaseDuration": 0,
+                            "type": null,
+                            "updateQueue": Object {
+                              "baseState": null,
+                              "firstCapturedEffect": null,
+                              "firstCapturedUpdate": null,
+                              "firstEffect": null,
+                              "firstUpdate": Object {
+                                "callback": null,
+                                "expirationTime": 1073741823,
+                                "next": null,
+                                "nextEffect": null,
+                                "payload": Object {
+                                  "element": <WrapperComponent
+                                    Component={[Function]}
+                                    context={null}
+                                    props={
+                                      Object {
+                                        "children": <AuthenticatedRoute
+                                          authenticated={true}
+                                          component={[Function]}
+                                          path="/dashboard"
+                                        />,
+                                      }
+                                    }
+                                    wrappingComponentProps={null}
+                                  />,
+                                },
+                                "tag": 0,
+                              },
+                              "lastCapturedEffect": null,
+                              "lastCapturedUpdate": null,
+                              "lastEffect": null,
+                              "lastUpdate": Object {
+                                "callback": null,
+                                "expirationTime": 1073741823,
+                                "next": null,
+                                "nextEffect": null,
+                                "payload": Object {
+                                  "element": <WrapperComponent
+                                    Component={[Function]}
+                                    context={null}
+                                    props={
+                                      Object {
+                                        "children": <AuthenticatedRoute
+                                          authenticated={true}
+                                          component={[Function]}
+                                          path="/dashboard"
+                                        />,
+                                      }
+                                    }
+                                    wrappingComponentProps={null}
+                                  />,
+                                },
+                                "tag": 0,
+                              },
+                            },
+                          },
+                          "child": [Circular],
+                          "childExpirationTime": 0,
+                          "contextDependencies": null,
+                          "effectTag": 32,
+                          "elementType": null,
+                          "expirationTime": 0,
+                          "firstEffect": [Circular],
+                          "index": 0,
+                          "key": null,
+                          "lastEffect": [Circular],
+                          "memoizedProps": null,
+                          "memoizedState": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={
+                                Object {
+                                  "children": <AuthenticatedRoute
+                                    authenticated={true}
+                                    component={[Function]}
+                                    path="/dashboard"
+                                  />,
+                                }
+                              }
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "mode": 0,
+                          "nextEffect": null,
+                          "pendingProps": null,
+                          "ref": null,
+                          "return": null,
+                          "selfBaseDuration": 0,
+                          "sibling": null,
+                          "stateNode": Object {
+                            "containerInfo": <div />,
+                            "context": Object {},
+                            "current": [Circular],
+                            "didError": false,
+                            "earliestPendingTime": 0,
+                            "earliestSuspendedTime": 0,
+                            "expirationTime": 0,
+                            "finishedWork": null,
+                            "firstBatch": null,
+                            "hydrate": false,
+                            "interactionThreadID": 15,
+                            "latestPendingTime": 0,
+                            "latestPingedTime": 0,
+                            "latestSuspendedTime": 0,
+                            "memoizedInteractions": Set {},
+                            "nextExpirationTimeToWorkOn": 0,
+                            "nextScheduledRoot": null,
+                            "pendingChildren": null,
+                            "pendingCommitExpirationTime": 0,
+                            "pendingContext": null,
+                            "pendingInteractionMap": Map {},
+                            "pingCache": null,
+                            "timeoutHandle": -1,
+                          },
+                          "tag": 3,
+                          "treeBaseDuration": 0,
+                          "type": null,
+                          "updateQueue": Object {
+                            "baseState": Object {
+                              "element": <WrapperComponent
+                                Component={[Function]}
+                                context={null}
+                                props={
+                                  Object {
+                                    "children": <AuthenticatedRoute
+                                      authenticated={true}
+                                      component={[Function]}
+                                      path="/dashboard"
+                                    />,
+                                  }
+                                }
+                                wrappingComponentProps={null}
+                              />,
+                            },
+                            "firstCapturedEffect": null,
+                            "firstCapturedUpdate": null,
+                            "firstEffect": null,
+                            "firstUpdate": null,
+                            "lastCapturedEffect": null,
+                            "lastCapturedUpdate": null,
+                            "lastEffect": null,
+                            "lastUpdate": null,
+                          },
+                        },
+                        "selfBaseDuration": 0,
+                        "sibling": null,
+                        "stateNode": WrapperComponent {
+                          "_reactInternalFiber": [Circular],
+                          "_reactInternalInstance": Object {},
+                          "context": Object {},
+                          "props": Object {
+                            "Component": [Function],
+                            "context": null,
+                            "props": Object {
+                              "children": <AuthenticatedRoute
+                                authenticated={true}
+                                component={[Function]}
+                                path="/dashboard"
+                              />,
+                            },
+                            "wrappingComponentProps": null,
+                          },
+                          "refs": Object {},
+                          "rootFinderInstance": null,
+                          "state": Object {
+                            "context": null,
+                            "mount": true,
+                            "props": Object {
+                              "children": <AuthenticatedRoute
+                                authenticated={true}
+                                component={[Function]}
+                                path="/dashboard"
+                              />,
+                            },
+                            "wrappingComponentProps": null,
+                          },
+                          "updater": Object {
+                            "enqueueForceUpdate": [Function],
+                            "enqueueReplaceState": [Function],
+                            "enqueueSetState": [Function],
+                            "isMounted": [Function],
+                          },
+                        },
+                        "tag": 1,
+                        "treeBaseDuration": 0,
+                        "type": [Function],
+                        "updateQueue": null,
+                      },
+                      "_debugSource": null,
+                      "actualDuration": 0,
+                      "actualStartTime": -1,
+                      "alternate": null,
+                      "child": [Circular],
+                      "childExpirationTime": 0,
+                      "contextDependencies": null,
+                      "effectTag": 1,
+                      "elementType": [Function],
+                      "expirationTime": 0,
+                      "firstEffect": null,
+                      "index": 0,
+                      "key": null,
+                      "lastEffect": null,
+                      "memoizedProps": Object {
+                        "children": <AuthenticatedRoute
+                          authenticated={true}
+                          component={[Function]}
+                          path="/dashboard"
+                        />,
+                      },
+                      "memoizedState": null,
+                      "mode": 0,
+                      "nextEffect": null,
+                      "pendingProps": Object {
+                        "children": <AuthenticatedRoute
+                          authenticated={true}
+                          component={[Function]}
+                          path="/dashboard"
+                        />,
+                      },
+                      "ref": null,
+                      "return": FiberNode {
+                        "_debugHookTypes": null,
+                        "_debugID": 62,
+                        "_debugIsCurrentlyTiming": false,
+                        "_debugOwner": null,
+                        "_debugSource": null,
+                        "actualDuration": 0,
+                        "actualStartTime": -1,
+                        "alternate": null,
+                        "child": [Circular],
+                        "childExpirationTime": 0,
+                        "contextDependencies": null,
+                        "effectTag": 1,
+                        "elementType": [Function],
+                        "expirationTime": 0,
+                        "firstEffect": null,
+                        "index": 0,
+                        "key": null,
+                        "lastEffect": null,
+                        "memoizedProps": Object {
+                          "Component": [Function],
+                          "context": null,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "memoizedState": Object {
+                          "context": null,
+                          "mount": true,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "mode": 0,
+                        "nextEffect": FiberNode {
+                          "_debugHookTypes": null,
+                          "_debugID": 60,
+                          "_debugIsCurrentlyTiming": false,
+                          "_debugOwner": null,
+                          "_debugSource": null,
+                          "actualDuration": 0,
+                          "actualStartTime": -1,
+                          "alternate": FiberNode {
+                            "_debugHookTypes": null,
+                            "_debugID": 60,
+                            "_debugIsCurrentlyTiming": false,
+                            "_debugOwner": null,
+                            "_debugSource": null,
+                            "actualDuration": 0,
+                            "actualStartTime": -1,
+                            "alternate": [Circular],
+                            "child": null,
+                            "childExpirationTime": 0,
+                            "contextDependencies": null,
+                            "effectTag": 0,
+                            "elementType": null,
+                            "expirationTime": 1073741823,
+                            "firstEffect": null,
+                            "index": 0,
+                            "key": null,
+                            "lastEffect": null,
+                            "memoizedProps": null,
+                            "memoizedState": null,
+                            "mode": 0,
+                            "nextEffect": null,
+                            "pendingProps": null,
+                            "ref": null,
+                            "return": null,
+                            "selfBaseDuration": 0,
+                            "sibling": null,
+                            "stateNode": Object {
+                              "containerInfo": <div />,
+                              "context": Object {},
+                              "current": [Circular],
+                              "didError": false,
+                              "earliestPendingTime": 0,
+                              "earliestSuspendedTime": 0,
+                              "expirationTime": 0,
+                              "finishedWork": null,
+                              "firstBatch": null,
+                              "hydrate": false,
+                              "interactionThreadID": 15,
+                              "latestPendingTime": 0,
+                              "latestPingedTime": 0,
+                              "latestSuspendedTime": 0,
+                              "memoizedInteractions": Set {},
+                              "nextExpirationTimeToWorkOn": 0,
+                              "nextScheduledRoot": null,
+                              "pendingChildren": null,
+                              "pendingCommitExpirationTime": 0,
+                              "pendingContext": null,
+                              "pendingInteractionMap": Map {},
+                              "pingCache": null,
+                              "timeoutHandle": -1,
+                            },
+                            "tag": 3,
+                            "treeBaseDuration": 0,
+                            "type": null,
+                            "updateQueue": Object {
+                              "baseState": null,
+                              "firstCapturedEffect": null,
+                              "firstCapturedUpdate": null,
+                              "firstEffect": null,
+                              "firstUpdate": Object {
+                                "callback": null,
+                                "expirationTime": 1073741823,
+                                "next": null,
+                                "nextEffect": null,
+                                "payload": Object {
+                                  "element": <WrapperComponent
+                                    Component={[Function]}
+                                    context={null}
+                                    props={
+                                      Object {
+                                        "children": <AuthenticatedRoute
+                                          authenticated={true}
+                                          component={[Function]}
+                                          path="/dashboard"
+                                        />,
+                                      }
+                                    }
+                                    wrappingComponentProps={null}
+                                  />,
+                                },
+                                "tag": 0,
+                              },
+                              "lastCapturedEffect": null,
+                              "lastCapturedUpdate": null,
+                              "lastEffect": null,
+                              "lastUpdate": Object {
+                                "callback": null,
+                                "expirationTime": 1073741823,
+                                "next": null,
+                                "nextEffect": null,
+                                "payload": Object {
+                                  "element": <WrapperComponent
+                                    Component={[Function]}
+                                    context={null}
+                                    props={
+                                      Object {
+                                        "children": <AuthenticatedRoute
+                                          authenticated={true}
+                                          component={[Function]}
+                                          path="/dashboard"
+                                        />,
+                                      }
+                                    }
+                                    wrappingComponentProps={null}
+                                  />,
+                                },
+                                "tag": 0,
+                              },
+                            },
+                          },
+                          "child": [Circular],
+                          "childExpirationTime": 0,
+                          "contextDependencies": null,
+                          "effectTag": 32,
+                          "elementType": null,
+                          "expirationTime": 0,
+                          "firstEffect": [Circular],
+                          "index": 0,
+                          "key": null,
+                          "lastEffect": [Circular],
+                          "memoizedProps": null,
+                          "memoizedState": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={
+                                Object {
+                                  "children": <AuthenticatedRoute
+                                    authenticated={true}
+                                    component={[Function]}
+                                    path="/dashboard"
+                                  />,
+                                }
+                              }
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "mode": 0,
+                          "nextEffect": null,
+                          "pendingProps": null,
+                          "ref": null,
+                          "return": null,
+                          "selfBaseDuration": 0,
+                          "sibling": null,
+                          "stateNode": Object {
+                            "containerInfo": <div />,
+                            "context": Object {},
+                            "current": [Circular],
+                            "didError": false,
+                            "earliestPendingTime": 0,
+                            "earliestSuspendedTime": 0,
+                            "expirationTime": 0,
+                            "finishedWork": null,
+                            "firstBatch": null,
+                            "hydrate": false,
+                            "interactionThreadID": 15,
+                            "latestPendingTime": 0,
+                            "latestPingedTime": 0,
+                            "latestSuspendedTime": 0,
+                            "memoizedInteractions": Set {},
+                            "nextExpirationTimeToWorkOn": 0,
+                            "nextScheduledRoot": null,
+                            "pendingChildren": null,
+                            "pendingCommitExpirationTime": 0,
+                            "pendingContext": null,
+                            "pendingInteractionMap": Map {},
+                            "pingCache": null,
+                            "timeoutHandle": -1,
+                          },
+                          "tag": 3,
+                          "treeBaseDuration": 0,
+                          "type": null,
+                          "updateQueue": Object {
+                            "baseState": Object {
+                              "element": <WrapperComponent
+                                Component={[Function]}
+                                context={null}
+                                props={
+                                  Object {
+                                    "children": <AuthenticatedRoute
+                                      authenticated={true}
+                                      component={[Function]}
+                                      path="/dashboard"
+                                    />,
+                                  }
+                                }
+                                wrappingComponentProps={null}
+                              />,
+                            },
+                            "firstCapturedEffect": null,
+                            "firstCapturedUpdate": null,
+                            "firstEffect": null,
+                            "firstUpdate": null,
+                            "lastCapturedEffect": null,
+                            "lastCapturedUpdate": null,
+                            "lastEffect": null,
+                            "lastUpdate": null,
+                          },
+                        },
+                        "pendingProps": Object {
+                          "Component": [Function],
+                          "context": null,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "ref": null,
+                        "return": FiberNode {
+                          "_debugHookTypes": null,
+                          "_debugID": 60,
+                          "_debugIsCurrentlyTiming": false,
+                          "_debugOwner": null,
+                          "_debugSource": null,
+                          "actualDuration": 0,
+                          "actualStartTime": -1,
+                          "alternate": FiberNode {
+                            "_debugHookTypes": null,
+                            "_debugID": 60,
+                            "_debugIsCurrentlyTiming": false,
+                            "_debugOwner": null,
+                            "_debugSource": null,
+                            "actualDuration": 0,
+                            "actualStartTime": -1,
+                            "alternate": [Circular],
+                            "child": null,
+                            "childExpirationTime": 0,
+                            "contextDependencies": null,
+                            "effectTag": 0,
+                            "elementType": null,
+                            "expirationTime": 1073741823,
+                            "firstEffect": null,
+                            "index": 0,
+                            "key": null,
+                            "lastEffect": null,
+                            "memoizedProps": null,
+                            "memoizedState": null,
+                            "mode": 0,
+                            "nextEffect": null,
+                            "pendingProps": null,
+                            "ref": null,
+                            "return": null,
+                            "selfBaseDuration": 0,
+                            "sibling": null,
+                            "stateNode": Object {
+                              "containerInfo": <div />,
+                              "context": Object {},
+                              "current": [Circular],
+                              "didError": false,
+                              "earliestPendingTime": 0,
+                              "earliestSuspendedTime": 0,
+                              "expirationTime": 0,
+                              "finishedWork": null,
+                              "firstBatch": null,
+                              "hydrate": false,
+                              "interactionThreadID": 15,
+                              "latestPendingTime": 0,
+                              "latestPingedTime": 0,
+                              "latestSuspendedTime": 0,
+                              "memoizedInteractions": Set {},
+                              "nextExpirationTimeToWorkOn": 0,
+                              "nextScheduledRoot": null,
+                              "pendingChildren": null,
+                              "pendingCommitExpirationTime": 0,
+                              "pendingContext": null,
+                              "pendingInteractionMap": Map {},
+                              "pingCache": null,
+                              "timeoutHandle": -1,
+                            },
+                            "tag": 3,
+                            "treeBaseDuration": 0,
+                            "type": null,
+                            "updateQueue": Object {
+                              "baseState": null,
+                              "firstCapturedEffect": null,
+                              "firstCapturedUpdate": null,
+                              "firstEffect": null,
+                              "firstUpdate": Object {
+                                "callback": null,
+                                "expirationTime": 1073741823,
+                                "next": null,
+                                "nextEffect": null,
+                                "payload": Object {
+                                  "element": <WrapperComponent
+                                    Component={[Function]}
+                                    context={null}
+                                    props={
+                                      Object {
+                                        "children": <AuthenticatedRoute
+                                          authenticated={true}
+                                          component={[Function]}
+                                          path="/dashboard"
+                                        />,
+                                      }
+                                    }
+                                    wrappingComponentProps={null}
+                                  />,
+                                },
+                                "tag": 0,
+                              },
+                              "lastCapturedEffect": null,
+                              "lastCapturedUpdate": null,
+                              "lastEffect": null,
+                              "lastUpdate": Object {
+                                "callback": null,
+                                "expirationTime": 1073741823,
+                                "next": null,
+                                "nextEffect": null,
+                                "payload": Object {
+                                  "element": <WrapperComponent
+                                    Component={[Function]}
+                                    context={null}
+                                    props={
+                                      Object {
+                                        "children": <AuthenticatedRoute
+                                          authenticated={true}
+                                          component={[Function]}
+                                          path="/dashboard"
+                                        />,
+                                      }
+                                    }
+                                    wrappingComponentProps={null}
+                                  />,
+                                },
+                                "tag": 0,
+                              },
+                            },
+                          },
+                          "child": [Circular],
+                          "childExpirationTime": 0,
+                          "contextDependencies": null,
+                          "effectTag": 32,
+                          "elementType": null,
+                          "expirationTime": 0,
+                          "firstEffect": [Circular],
+                          "index": 0,
+                          "key": null,
+                          "lastEffect": [Circular],
+                          "memoizedProps": null,
+                          "memoizedState": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={
+                                Object {
+                                  "children": <AuthenticatedRoute
+                                    authenticated={true}
+                                    component={[Function]}
+                                    path="/dashboard"
+                                  />,
+                                }
+                              }
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "mode": 0,
+                          "nextEffect": null,
+                          "pendingProps": null,
+                          "ref": null,
+                          "return": null,
+                          "selfBaseDuration": 0,
+                          "sibling": null,
+                          "stateNode": Object {
+                            "containerInfo": <div />,
+                            "context": Object {},
+                            "current": [Circular],
+                            "didError": false,
+                            "earliestPendingTime": 0,
+                            "earliestSuspendedTime": 0,
+                            "expirationTime": 0,
+                            "finishedWork": null,
+                            "firstBatch": null,
+                            "hydrate": false,
+                            "interactionThreadID": 15,
+                            "latestPendingTime": 0,
+                            "latestPingedTime": 0,
+                            "latestSuspendedTime": 0,
+                            "memoizedInteractions": Set {},
+                            "nextExpirationTimeToWorkOn": 0,
+                            "nextScheduledRoot": null,
+                            "pendingChildren": null,
+                            "pendingCommitExpirationTime": 0,
+                            "pendingContext": null,
+                            "pendingInteractionMap": Map {},
+                            "pingCache": null,
+                            "timeoutHandle": -1,
+                          },
+                          "tag": 3,
+                          "treeBaseDuration": 0,
+                          "type": null,
+                          "updateQueue": Object {
+                            "baseState": Object {
+                              "element": <WrapperComponent
+                                Component={[Function]}
+                                context={null}
+                                props={
+                                  Object {
+                                    "children": <AuthenticatedRoute
+                                      authenticated={true}
+                                      component={[Function]}
+                                      path="/dashboard"
+                                    />,
+                                  }
+                                }
+                                wrappingComponentProps={null}
+                              />,
+                            },
+                            "firstCapturedEffect": null,
+                            "firstCapturedUpdate": null,
+                            "firstEffect": null,
+                            "firstUpdate": null,
+                            "lastCapturedEffect": null,
+                            "lastCapturedUpdate": null,
+                            "lastEffect": null,
+                            "lastUpdate": null,
+                          },
+                        },
+                        "selfBaseDuration": 0,
+                        "sibling": null,
+                        "stateNode": WrapperComponent {
+                          "_reactInternalFiber": [Circular],
+                          "_reactInternalInstance": Object {},
+                          "context": Object {},
+                          "props": Object {
+                            "Component": [Function],
+                            "context": null,
+                            "props": Object {
+                              "children": <AuthenticatedRoute
+                                authenticated={true}
+                                component={[Function]}
+                                path="/dashboard"
+                              />,
+                            },
+                            "wrappingComponentProps": null,
+                          },
+                          "refs": Object {},
+                          "rootFinderInstance": null,
+                          "state": Object {
+                            "context": null,
+                            "mount": true,
+                            "props": Object {
+                              "children": <AuthenticatedRoute
+                                authenticated={true}
+                                component={[Function]}
+                                path="/dashboard"
+                              />,
+                            },
+                            "wrappingComponentProps": null,
+                          },
+                          "updater": Object {
+                            "enqueueForceUpdate": [Function],
+                            "enqueueReplaceState": [Function],
+                            "enqueueSetState": [Function],
+                            "isMounted": [Function],
+                          },
+                        },
+                        "tag": 1,
+                        "treeBaseDuration": 0,
+                        "type": [Function],
+                        "updateQueue": null,
+                      },
+                      "selfBaseDuration": 0,
+                      "sibling": null,
+                      "stateNode": BrowserRouter {
+                        "_reactInternalFiber": [Circular],
+                        "_reactInternalInstance": Object {},
+                        "context": Object {},
+                        "history": Object {
+                          "action": "POP",
+                          "block": [Function],
+                          "createHref": [Function],
+                          "go": [Function],
+                          "goBack": [Function],
+                          "goForward": [Function],
+                          "length": 1,
+                          "listen": [Function],
+                          "location": Object {
+                            "hash": "",
+                            "pathname": "/",
+                            "search": "",
+                            "state": undefined,
+                          },
+                          "push": [Function],
+                          "replace": [Function],
+                        },
+                        "props": Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        },
+                        "refs": Object {},
+                        "state": null,
+                        "updater": Object {
+                          "enqueueForceUpdate": [Function],
+                          "enqueueReplaceState": [Function],
+                          "enqueueSetState": [Function],
+                          "isMounted": [Function],
+                        },
+                      },
+                      "tag": 1,
+                      "treeBaseDuration": 0,
+                      "type": [Function],
+                      "updateQueue": null,
+                    },
+                    "_debugSource": null,
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": null,
+                    "child": [Circular],
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 1,
+                    "elementType": [Function],
+                    "expirationTime": 0,
+                    "firstEffect": null,
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": null,
+                    "memoizedProps": Object {
+                      "children": <AuthenticatedRoute
+                        authenticated={true}
+                        component={[Function]}
+                        path="/dashboard"
+                      />,
+                      "history": Object {
+                        "action": "POP",
+                        "block": [Function],
+                        "createHref": [Function],
+                        "go": [Function],
+                        "goBack": [Function],
+                        "goForward": [Function],
+                        "length": 1,
+                        "listen": [Function],
+                        "location": Object {
+                          "hash": "",
+                          "pathname": "/",
+                          "search": "",
+                          "state": undefined,
+                        },
+                        "push": [Function],
+                        "replace": [Function],
+                      },
+                    },
+                    "memoizedState": Object {
+                      "match": Object {
+                        "isExact": true,
+                        "params": Object {},
+                        "path": "/",
+                        "url": "/",
+                      },
+                    },
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": Object {
+                      "children": <AuthenticatedRoute
+                        authenticated={true}
+                        component={[Function]}
+                        path="/dashboard"
+                      />,
+                      "history": Object {
+                        "action": "POP",
+                        "block": [Function],
+                        "createHref": [Function],
+                        "go": [Function],
+                        "goBack": [Function],
+                        "goForward": [Function],
+                        "length": 1,
+                        "listen": [Function],
+                        "location": Object {
+                          "hash": "",
+                          "pathname": "/",
+                          "search": "",
+                          "state": undefined,
+                        },
+                        "push": [Function],
+                        "replace": [Function],
+                      },
+                    },
+                    "ref": null,
+                    "return": FiberNode {
+                      "_debugHookTypes": null,
+                      "_debugID": 63,
+                      "_debugIsCurrentlyTiming": false,
+                      "_debugOwner": FiberNode {
+                        "_debugHookTypes": null,
+                        "_debugID": 62,
+                        "_debugIsCurrentlyTiming": false,
+                        "_debugOwner": null,
+                        "_debugSource": null,
+                        "actualDuration": 0,
+                        "actualStartTime": -1,
+                        "alternate": null,
+                        "child": [Circular],
+                        "childExpirationTime": 0,
+                        "contextDependencies": null,
+                        "effectTag": 1,
+                        "elementType": [Function],
+                        "expirationTime": 0,
+                        "firstEffect": null,
+                        "index": 0,
+                        "key": null,
+                        "lastEffect": null,
+                        "memoizedProps": Object {
+                          "Component": [Function],
+                          "context": null,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "memoizedState": Object {
+                          "context": null,
+                          "mount": true,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "mode": 0,
+                        "nextEffect": FiberNode {
+                          "_debugHookTypes": null,
+                          "_debugID": 60,
+                          "_debugIsCurrentlyTiming": false,
+                          "_debugOwner": null,
+                          "_debugSource": null,
+                          "actualDuration": 0,
+                          "actualStartTime": -1,
+                          "alternate": FiberNode {
+                            "_debugHookTypes": null,
+                            "_debugID": 60,
+                            "_debugIsCurrentlyTiming": false,
+                            "_debugOwner": null,
+                            "_debugSource": null,
+                            "actualDuration": 0,
+                            "actualStartTime": -1,
+                            "alternate": [Circular],
+                            "child": null,
+                            "childExpirationTime": 0,
+                            "contextDependencies": null,
+                            "effectTag": 0,
+                            "elementType": null,
+                            "expirationTime": 1073741823,
+                            "firstEffect": null,
+                            "index": 0,
+                            "key": null,
+                            "lastEffect": null,
+                            "memoizedProps": null,
+                            "memoizedState": null,
+                            "mode": 0,
+                            "nextEffect": null,
+                            "pendingProps": null,
+                            "ref": null,
+                            "return": null,
+                            "selfBaseDuration": 0,
+                            "sibling": null,
+                            "stateNode": Object {
+                              "containerInfo": <div />,
+                              "context": Object {},
+                              "current": [Circular],
+                              "didError": false,
+                              "earliestPendingTime": 0,
+                              "earliestSuspendedTime": 0,
+                              "expirationTime": 0,
+                              "finishedWork": null,
+                              "firstBatch": null,
+                              "hydrate": false,
+                              "interactionThreadID": 15,
+                              "latestPendingTime": 0,
+                              "latestPingedTime": 0,
+                              "latestSuspendedTime": 0,
+                              "memoizedInteractions": Set {},
+                              "nextExpirationTimeToWorkOn": 0,
+                              "nextScheduledRoot": null,
+                              "pendingChildren": null,
+                              "pendingCommitExpirationTime": 0,
+                              "pendingContext": null,
+                              "pendingInteractionMap": Map {},
+                              "pingCache": null,
+                              "timeoutHandle": -1,
+                            },
+                            "tag": 3,
+                            "treeBaseDuration": 0,
+                            "type": null,
+                            "updateQueue": Object {
+                              "baseState": null,
+                              "firstCapturedEffect": null,
+                              "firstCapturedUpdate": null,
+                              "firstEffect": null,
+                              "firstUpdate": Object {
+                                "callback": null,
+                                "expirationTime": 1073741823,
+                                "next": null,
+                                "nextEffect": null,
+                                "payload": Object {
+                                  "element": <WrapperComponent
+                                    Component={[Function]}
+                                    context={null}
+                                    props={
+                                      Object {
+                                        "children": <AuthenticatedRoute
+                                          authenticated={true}
+                                          component={[Function]}
+                                          path="/dashboard"
+                                        />,
+                                      }
+                                    }
+                                    wrappingComponentProps={null}
+                                  />,
+                                },
+                                "tag": 0,
+                              },
+                              "lastCapturedEffect": null,
+                              "lastCapturedUpdate": null,
+                              "lastEffect": null,
+                              "lastUpdate": Object {
+                                "callback": null,
+                                "expirationTime": 1073741823,
+                                "next": null,
+                                "nextEffect": null,
+                                "payload": Object {
+                                  "element": <WrapperComponent
+                                    Component={[Function]}
+                                    context={null}
+                                    props={
+                                      Object {
+                                        "children": <AuthenticatedRoute
+                                          authenticated={true}
+                                          component={[Function]}
+                                          path="/dashboard"
+                                        />,
+                                      }
+                                    }
+                                    wrappingComponentProps={null}
+                                  />,
+                                },
+                                "tag": 0,
+                              },
+                            },
+                          },
+                          "child": [Circular],
+                          "childExpirationTime": 0,
+                          "contextDependencies": null,
+                          "effectTag": 32,
+                          "elementType": null,
+                          "expirationTime": 0,
+                          "firstEffect": [Circular],
+                          "index": 0,
+                          "key": null,
+                          "lastEffect": [Circular],
+                          "memoizedProps": null,
+                          "memoizedState": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={
+                                Object {
+                                  "children": <AuthenticatedRoute
+                                    authenticated={true}
+                                    component={[Function]}
+                                    path="/dashboard"
+                                  />,
+                                }
+                              }
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "mode": 0,
+                          "nextEffect": null,
+                          "pendingProps": null,
+                          "ref": null,
+                          "return": null,
+                          "selfBaseDuration": 0,
+                          "sibling": null,
+                          "stateNode": Object {
+                            "containerInfo": <div />,
+                            "context": Object {},
+                            "current": [Circular],
+                            "didError": false,
+                            "earliestPendingTime": 0,
+                            "earliestSuspendedTime": 0,
+                            "expirationTime": 0,
+                            "finishedWork": null,
+                            "firstBatch": null,
+                            "hydrate": false,
+                            "interactionThreadID": 15,
+                            "latestPendingTime": 0,
+                            "latestPingedTime": 0,
+                            "latestSuspendedTime": 0,
+                            "memoizedInteractions": Set {},
+                            "nextExpirationTimeToWorkOn": 0,
+                            "nextScheduledRoot": null,
+                            "pendingChildren": null,
+                            "pendingCommitExpirationTime": 0,
+                            "pendingContext": null,
+                            "pendingInteractionMap": Map {},
+                            "pingCache": null,
+                            "timeoutHandle": -1,
+                          },
+                          "tag": 3,
+                          "treeBaseDuration": 0,
+                          "type": null,
+                          "updateQueue": Object {
+                            "baseState": Object {
+                              "element": <WrapperComponent
+                                Component={[Function]}
+                                context={null}
+                                props={
+                                  Object {
+                                    "children": <AuthenticatedRoute
+                                      authenticated={true}
+                                      component={[Function]}
+                                      path="/dashboard"
+                                    />,
+                                  }
+                                }
+                                wrappingComponentProps={null}
+                              />,
+                            },
+                            "firstCapturedEffect": null,
+                            "firstCapturedUpdate": null,
+                            "firstEffect": null,
+                            "firstUpdate": null,
+                            "lastCapturedEffect": null,
+                            "lastCapturedUpdate": null,
+                            "lastEffect": null,
+                            "lastUpdate": null,
+                          },
+                        },
+                        "pendingProps": Object {
+                          "Component": [Function],
+                          "context": null,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "ref": null,
+                        "return": FiberNode {
+                          "_debugHookTypes": null,
+                          "_debugID": 60,
+                          "_debugIsCurrentlyTiming": false,
+                          "_debugOwner": null,
+                          "_debugSource": null,
+                          "actualDuration": 0,
+                          "actualStartTime": -1,
+                          "alternate": FiberNode {
+                            "_debugHookTypes": null,
+                            "_debugID": 60,
+                            "_debugIsCurrentlyTiming": false,
+                            "_debugOwner": null,
+                            "_debugSource": null,
+                            "actualDuration": 0,
+                            "actualStartTime": -1,
+                            "alternate": [Circular],
+                            "child": null,
+                            "childExpirationTime": 0,
+                            "contextDependencies": null,
+                            "effectTag": 0,
+                            "elementType": null,
+                            "expirationTime": 1073741823,
+                            "firstEffect": null,
+                            "index": 0,
+                            "key": null,
+                            "lastEffect": null,
+                            "memoizedProps": null,
+                            "memoizedState": null,
+                            "mode": 0,
+                            "nextEffect": null,
+                            "pendingProps": null,
+                            "ref": null,
+                            "return": null,
+                            "selfBaseDuration": 0,
+                            "sibling": null,
+                            "stateNode": Object {
+                              "containerInfo": <div />,
+                              "context": Object {},
+                              "current": [Circular],
+                              "didError": false,
+                              "earliestPendingTime": 0,
+                              "earliestSuspendedTime": 0,
+                              "expirationTime": 0,
+                              "finishedWork": null,
+                              "firstBatch": null,
+                              "hydrate": false,
+                              "interactionThreadID": 15,
+                              "latestPendingTime": 0,
+                              "latestPingedTime": 0,
+                              "latestSuspendedTime": 0,
+                              "memoizedInteractions": Set {},
+                              "nextExpirationTimeToWorkOn": 0,
+                              "nextScheduledRoot": null,
+                              "pendingChildren": null,
+                              "pendingCommitExpirationTime": 0,
+                              "pendingContext": null,
+                              "pendingInteractionMap": Map {},
+                              "pingCache": null,
+                              "timeoutHandle": -1,
+                            },
+                            "tag": 3,
+                            "treeBaseDuration": 0,
+                            "type": null,
+                            "updateQueue": Object {
+                              "baseState": null,
+                              "firstCapturedEffect": null,
+                              "firstCapturedUpdate": null,
+                              "firstEffect": null,
+                              "firstUpdate": Object {
+                                "callback": null,
+                                "expirationTime": 1073741823,
+                                "next": null,
+                                "nextEffect": null,
+                                "payload": Object {
+                                  "element": <WrapperComponent
+                                    Component={[Function]}
+                                    context={null}
+                                    props={
+                                      Object {
+                                        "children": <AuthenticatedRoute
+                                          authenticated={true}
+                                          component={[Function]}
+                                          path="/dashboard"
+                                        />,
+                                      }
+                                    }
+                                    wrappingComponentProps={null}
+                                  />,
+                                },
+                                "tag": 0,
+                              },
+                              "lastCapturedEffect": null,
+                              "lastCapturedUpdate": null,
+                              "lastEffect": null,
+                              "lastUpdate": Object {
+                                "callback": null,
+                                "expirationTime": 1073741823,
+                                "next": null,
+                                "nextEffect": null,
+                                "payload": Object {
+                                  "element": <WrapperComponent
+                                    Component={[Function]}
+                                    context={null}
+                                    props={
+                                      Object {
+                                        "children": <AuthenticatedRoute
+                                          authenticated={true}
+                                          component={[Function]}
+                                          path="/dashboard"
+                                        />,
+                                      }
+                                    }
+                                    wrappingComponentProps={null}
+                                  />,
+                                },
+                                "tag": 0,
+                              },
+                            },
+                          },
+                          "child": [Circular],
+                          "childExpirationTime": 0,
+                          "contextDependencies": null,
+                          "effectTag": 32,
+                          "elementType": null,
+                          "expirationTime": 0,
+                          "firstEffect": [Circular],
+                          "index": 0,
+                          "key": null,
+                          "lastEffect": [Circular],
+                          "memoizedProps": null,
+                          "memoizedState": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={
+                                Object {
+                                  "children": <AuthenticatedRoute
+                                    authenticated={true}
+                                    component={[Function]}
+                                    path="/dashboard"
+                                  />,
+                                }
+                              }
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "mode": 0,
+                          "nextEffect": null,
+                          "pendingProps": null,
+                          "ref": null,
+                          "return": null,
+                          "selfBaseDuration": 0,
+                          "sibling": null,
+                          "stateNode": Object {
+                            "containerInfo": <div />,
+                            "context": Object {},
+                            "current": [Circular],
+                            "didError": false,
+                            "earliestPendingTime": 0,
+                            "earliestSuspendedTime": 0,
+                            "expirationTime": 0,
+                            "finishedWork": null,
+                            "firstBatch": null,
+                            "hydrate": false,
+                            "interactionThreadID": 15,
+                            "latestPendingTime": 0,
+                            "latestPingedTime": 0,
+                            "latestSuspendedTime": 0,
+                            "memoizedInteractions": Set {},
+                            "nextExpirationTimeToWorkOn": 0,
+                            "nextScheduledRoot": null,
+                            "pendingChildren": null,
+                            "pendingCommitExpirationTime": 0,
+                            "pendingContext": null,
+                            "pendingInteractionMap": Map {},
+                            "pingCache": null,
+                            "timeoutHandle": -1,
+                          },
+                          "tag": 3,
+                          "treeBaseDuration": 0,
+                          "type": null,
+                          "updateQueue": Object {
+                            "baseState": Object {
+                              "element": <WrapperComponent
+                                Component={[Function]}
+                                context={null}
+                                props={
+                                  Object {
+                                    "children": <AuthenticatedRoute
+                                      authenticated={true}
+                                      component={[Function]}
+                                      path="/dashboard"
+                                    />,
+                                  }
+                                }
+                                wrappingComponentProps={null}
+                              />,
+                            },
+                            "firstCapturedEffect": null,
+                            "firstCapturedUpdate": null,
+                            "firstEffect": null,
+                            "firstUpdate": null,
+                            "lastCapturedEffect": null,
+                            "lastCapturedUpdate": null,
+                            "lastEffect": null,
+                            "lastUpdate": null,
+                          },
+                        },
+                        "selfBaseDuration": 0,
+                        "sibling": null,
+                        "stateNode": WrapperComponent {
+                          "_reactInternalFiber": [Circular],
+                          "_reactInternalInstance": Object {},
+                          "context": Object {},
+                          "props": Object {
+                            "Component": [Function],
+                            "context": null,
+                            "props": Object {
+                              "children": <AuthenticatedRoute
+                                authenticated={true}
+                                component={[Function]}
+                                path="/dashboard"
+                              />,
+                            },
+                            "wrappingComponentProps": null,
+                          },
+                          "refs": Object {},
+                          "rootFinderInstance": null,
+                          "state": Object {
+                            "context": null,
+                            "mount": true,
+                            "props": Object {
+                              "children": <AuthenticatedRoute
+                                authenticated={true}
+                                component={[Function]}
+                                path="/dashboard"
+                              />,
+                            },
+                            "wrappingComponentProps": null,
+                          },
+                          "updater": Object {
+                            "enqueueForceUpdate": [Function],
+                            "enqueueReplaceState": [Function],
+                            "enqueueSetState": [Function],
+                            "isMounted": [Function],
+                          },
+                        },
+                        "tag": 1,
+                        "treeBaseDuration": 0,
+                        "type": [Function],
+                        "updateQueue": null,
+                      },
+                      "_debugSource": null,
+                      "actualDuration": 0,
+                      "actualStartTime": -1,
+                      "alternate": null,
+                      "child": [Circular],
+                      "childExpirationTime": 0,
+                      "contextDependencies": null,
+                      "effectTag": 1,
+                      "elementType": [Function],
+                      "expirationTime": 0,
+                      "firstEffect": null,
+                      "index": 0,
+                      "key": null,
+                      "lastEffect": null,
+                      "memoizedProps": Object {
+                        "children": <AuthenticatedRoute
+                          authenticated={true}
+                          component={[Function]}
+                          path="/dashboard"
+                        />,
+                      },
+                      "memoizedState": null,
+                      "mode": 0,
+                      "nextEffect": null,
+                      "pendingProps": Object {
+                        "children": <AuthenticatedRoute
+                          authenticated={true}
+                          component={[Function]}
+                          path="/dashboard"
+                        />,
+                      },
+                      "ref": null,
+                      "return": FiberNode {
+                        "_debugHookTypes": null,
+                        "_debugID": 62,
+                        "_debugIsCurrentlyTiming": false,
+                        "_debugOwner": null,
+                        "_debugSource": null,
+                        "actualDuration": 0,
+                        "actualStartTime": -1,
+                        "alternate": null,
+                        "child": [Circular],
+                        "childExpirationTime": 0,
+                        "contextDependencies": null,
+                        "effectTag": 1,
+                        "elementType": [Function],
+                        "expirationTime": 0,
+                        "firstEffect": null,
+                        "index": 0,
+                        "key": null,
+                        "lastEffect": null,
+                        "memoizedProps": Object {
+                          "Component": [Function],
+                          "context": null,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "memoizedState": Object {
+                          "context": null,
+                          "mount": true,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "mode": 0,
+                        "nextEffect": FiberNode {
+                          "_debugHookTypes": null,
+                          "_debugID": 60,
+                          "_debugIsCurrentlyTiming": false,
+                          "_debugOwner": null,
+                          "_debugSource": null,
+                          "actualDuration": 0,
+                          "actualStartTime": -1,
+                          "alternate": FiberNode {
+                            "_debugHookTypes": null,
+                            "_debugID": 60,
+                            "_debugIsCurrentlyTiming": false,
+                            "_debugOwner": null,
+                            "_debugSource": null,
+                            "actualDuration": 0,
+                            "actualStartTime": -1,
+                            "alternate": [Circular],
+                            "child": null,
+                            "childExpirationTime": 0,
+                            "contextDependencies": null,
+                            "effectTag": 0,
+                            "elementType": null,
+                            "expirationTime": 1073741823,
+                            "firstEffect": null,
+                            "index": 0,
+                            "key": null,
+                            "lastEffect": null,
+                            "memoizedProps": null,
+                            "memoizedState": null,
+                            "mode": 0,
+                            "nextEffect": null,
+                            "pendingProps": null,
+                            "ref": null,
+                            "return": null,
+                            "selfBaseDuration": 0,
+                            "sibling": null,
+                            "stateNode": Object {
+                              "containerInfo": <div />,
+                              "context": Object {},
+                              "current": [Circular],
+                              "didError": false,
+                              "earliestPendingTime": 0,
+                              "earliestSuspendedTime": 0,
+                              "expirationTime": 0,
+                              "finishedWork": null,
+                              "firstBatch": null,
+                              "hydrate": false,
+                              "interactionThreadID": 15,
+                              "latestPendingTime": 0,
+                              "latestPingedTime": 0,
+                              "latestSuspendedTime": 0,
+                              "memoizedInteractions": Set {},
+                              "nextExpirationTimeToWorkOn": 0,
+                              "nextScheduledRoot": null,
+                              "pendingChildren": null,
+                              "pendingCommitExpirationTime": 0,
+                              "pendingContext": null,
+                              "pendingInteractionMap": Map {},
+                              "pingCache": null,
+                              "timeoutHandle": -1,
+                            },
+                            "tag": 3,
+                            "treeBaseDuration": 0,
+                            "type": null,
+                            "updateQueue": Object {
+                              "baseState": null,
+                              "firstCapturedEffect": null,
+                              "firstCapturedUpdate": null,
+                              "firstEffect": null,
+                              "firstUpdate": Object {
+                                "callback": null,
+                                "expirationTime": 1073741823,
+                                "next": null,
+                                "nextEffect": null,
+                                "payload": Object {
+                                  "element": <WrapperComponent
+                                    Component={[Function]}
+                                    context={null}
+                                    props={
+                                      Object {
+                                        "children": <AuthenticatedRoute
+                                          authenticated={true}
+                                          component={[Function]}
+                                          path="/dashboard"
+                                        />,
+                                      }
+                                    }
+                                    wrappingComponentProps={null}
+                                  />,
+                                },
+                                "tag": 0,
+                              },
+                              "lastCapturedEffect": null,
+                              "lastCapturedUpdate": null,
+                              "lastEffect": null,
+                              "lastUpdate": Object {
+                                "callback": null,
+                                "expirationTime": 1073741823,
+                                "next": null,
+                                "nextEffect": null,
+                                "payload": Object {
+                                  "element": <WrapperComponent
+                                    Component={[Function]}
+                                    context={null}
+                                    props={
+                                      Object {
+                                        "children": <AuthenticatedRoute
+                                          authenticated={true}
+                                          component={[Function]}
+                                          path="/dashboard"
+                                        />,
+                                      }
+                                    }
+                                    wrappingComponentProps={null}
+                                  />,
+                                },
+                                "tag": 0,
+                              },
+                            },
+                          },
+                          "child": [Circular],
+                          "childExpirationTime": 0,
+                          "contextDependencies": null,
+                          "effectTag": 32,
+                          "elementType": null,
+                          "expirationTime": 0,
+                          "firstEffect": [Circular],
+                          "index": 0,
+                          "key": null,
+                          "lastEffect": [Circular],
+                          "memoizedProps": null,
+                          "memoizedState": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={
+                                Object {
+                                  "children": <AuthenticatedRoute
+                                    authenticated={true}
+                                    component={[Function]}
+                                    path="/dashboard"
+                                  />,
+                                }
+                              }
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "mode": 0,
+                          "nextEffect": null,
+                          "pendingProps": null,
+                          "ref": null,
+                          "return": null,
+                          "selfBaseDuration": 0,
+                          "sibling": null,
+                          "stateNode": Object {
+                            "containerInfo": <div />,
+                            "context": Object {},
+                            "current": [Circular],
+                            "didError": false,
+                            "earliestPendingTime": 0,
+                            "earliestSuspendedTime": 0,
+                            "expirationTime": 0,
+                            "finishedWork": null,
+                            "firstBatch": null,
+                            "hydrate": false,
+                            "interactionThreadID": 15,
+                            "latestPendingTime": 0,
+                            "latestPingedTime": 0,
+                            "latestSuspendedTime": 0,
+                            "memoizedInteractions": Set {},
+                            "nextExpirationTimeToWorkOn": 0,
+                            "nextScheduledRoot": null,
+                            "pendingChildren": null,
+                            "pendingCommitExpirationTime": 0,
+                            "pendingContext": null,
+                            "pendingInteractionMap": Map {},
+                            "pingCache": null,
+                            "timeoutHandle": -1,
+                          },
+                          "tag": 3,
+                          "treeBaseDuration": 0,
+                          "type": null,
+                          "updateQueue": Object {
+                            "baseState": Object {
+                              "element": <WrapperComponent
+                                Component={[Function]}
+                                context={null}
+                                props={
+                                  Object {
+                                    "children": <AuthenticatedRoute
+                                      authenticated={true}
+                                      component={[Function]}
+                                      path="/dashboard"
+                                    />,
+                                  }
+                                }
+                                wrappingComponentProps={null}
+                              />,
+                            },
+                            "firstCapturedEffect": null,
+                            "firstCapturedUpdate": null,
+                            "firstEffect": null,
+                            "firstUpdate": null,
+                            "lastCapturedEffect": null,
+                            "lastCapturedUpdate": null,
+                            "lastEffect": null,
+                            "lastUpdate": null,
+                          },
+                        },
+                        "pendingProps": Object {
+                          "Component": [Function],
+                          "context": null,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "ref": null,
+                        "return": FiberNode {
+                          "_debugHookTypes": null,
+                          "_debugID": 60,
+                          "_debugIsCurrentlyTiming": false,
+                          "_debugOwner": null,
+                          "_debugSource": null,
+                          "actualDuration": 0,
+                          "actualStartTime": -1,
+                          "alternate": FiberNode {
+                            "_debugHookTypes": null,
+                            "_debugID": 60,
+                            "_debugIsCurrentlyTiming": false,
+                            "_debugOwner": null,
+                            "_debugSource": null,
+                            "actualDuration": 0,
+                            "actualStartTime": -1,
+                            "alternate": [Circular],
+                            "child": null,
+                            "childExpirationTime": 0,
+                            "contextDependencies": null,
+                            "effectTag": 0,
+                            "elementType": null,
+                            "expirationTime": 1073741823,
+                            "firstEffect": null,
+                            "index": 0,
+                            "key": null,
+                            "lastEffect": null,
+                            "memoizedProps": null,
+                            "memoizedState": null,
+                            "mode": 0,
+                            "nextEffect": null,
+                            "pendingProps": null,
+                            "ref": null,
+                            "return": null,
+                            "selfBaseDuration": 0,
+                            "sibling": null,
+                            "stateNode": Object {
+                              "containerInfo": <div />,
+                              "context": Object {},
+                              "current": [Circular],
+                              "didError": false,
+                              "earliestPendingTime": 0,
+                              "earliestSuspendedTime": 0,
+                              "expirationTime": 0,
+                              "finishedWork": null,
+                              "firstBatch": null,
+                              "hydrate": false,
+                              "interactionThreadID": 15,
+                              "latestPendingTime": 0,
+                              "latestPingedTime": 0,
+                              "latestSuspendedTime": 0,
+                              "memoizedInteractions": Set {},
+                              "nextExpirationTimeToWorkOn": 0,
+                              "nextScheduledRoot": null,
+                              "pendingChildren": null,
+                              "pendingCommitExpirationTime": 0,
+                              "pendingContext": null,
+                              "pendingInteractionMap": Map {},
+                              "pingCache": null,
+                              "timeoutHandle": -1,
+                            },
+                            "tag": 3,
+                            "treeBaseDuration": 0,
+                            "type": null,
+                            "updateQueue": Object {
+                              "baseState": null,
+                              "firstCapturedEffect": null,
+                              "firstCapturedUpdate": null,
+                              "firstEffect": null,
+                              "firstUpdate": Object {
+                                "callback": null,
+                                "expirationTime": 1073741823,
+                                "next": null,
+                                "nextEffect": null,
+                                "payload": Object {
+                                  "element": <WrapperComponent
+                                    Component={[Function]}
+                                    context={null}
+                                    props={
+                                      Object {
+                                        "children": <AuthenticatedRoute
+                                          authenticated={true}
+                                          component={[Function]}
+                                          path="/dashboard"
+                                        />,
+                                      }
+                                    }
+                                    wrappingComponentProps={null}
+                                  />,
+                                },
+                                "tag": 0,
+                              },
+                              "lastCapturedEffect": null,
+                              "lastCapturedUpdate": null,
+                              "lastEffect": null,
+                              "lastUpdate": Object {
+                                "callback": null,
+                                "expirationTime": 1073741823,
+                                "next": null,
+                                "nextEffect": null,
+                                "payload": Object {
+                                  "element": <WrapperComponent
+                                    Component={[Function]}
+                                    context={null}
+                                    props={
+                                      Object {
+                                        "children": <AuthenticatedRoute
+                                          authenticated={true}
+                                          component={[Function]}
+                                          path="/dashboard"
+                                        />,
+                                      }
+                                    }
+                                    wrappingComponentProps={null}
+                                  />,
+                                },
+                                "tag": 0,
+                              },
+                            },
+                          },
+                          "child": [Circular],
+                          "childExpirationTime": 0,
+                          "contextDependencies": null,
+                          "effectTag": 32,
+                          "elementType": null,
+                          "expirationTime": 0,
+                          "firstEffect": [Circular],
+                          "index": 0,
+                          "key": null,
+                          "lastEffect": [Circular],
+                          "memoizedProps": null,
+                          "memoizedState": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={
+                                Object {
+                                  "children": <AuthenticatedRoute
+                                    authenticated={true}
+                                    component={[Function]}
+                                    path="/dashboard"
+                                  />,
+                                }
+                              }
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "mode": 0,
+                          "nextEffect": null,
+                          "pendingProps": null,
+                          "ref": null,
+                          "return": null,
+                          "selfBaseDuration": 0,
+                          "sibling": null,
+                          "stateNode": Object {
+                            "containerInfo": <div />,
+                            "context": Object {},
+                            "current": [Circular],
+                            "didError": false,
+                            "earliestPendingTime": 0,
+                            "earliestSuspendedTime": 0,
+                            "expirationTime": 0,
+                            "finishedWork": null,
+                            "firstBatch": null,
+                            "hydrate": false,
+                            "interactionThreadID": 15,
+                            "latestPendingTime": 0,
+                            "latestPingedTime": 0,
+                            "latestSuspendedTime": 0,
+                            "memoizedInteractions": Set {},
+                            "nextExpirationTimeToWorkOn": 0,
+                            "nextScheduledRoot": null,
+                            "pendingChildren": null,
+                            "pendingCommitExpirationTime": 0,
+                            "pendingContext": null,
+                            "pendingInteractionMap": Map {},
+                            "pingCache": null,
+                            "timeoutHandle": -1,
+                          },
+                          "tag": 3,
+                          "treeBaseDuration": 0,
+                          "type": null,
+                          "updateQueue": Object {
+                            "baseState": Object {
+                              "element": <WrapperComponent
+                                Component={[Function]}
+                                context={null}
+                                props={
+                                  Object {
+                                    "children": <AuthenticatedRoute
+                                      authenticated={true}
+                                      component={[Function]}
+                                      path="/dashboard"
+                                    />,
+                                  }
+                                }
+                                wrappingComponentProps={null}
+                              />,
+                            },
+                            "firstCapturedEffect": null,
+                            "firstCapturedUpdate": null,
+                            "firstEffect": null,
+                            "firstUpdate": null,
+                            "lastCapturedEffect": null,
+                            "lastCapturedUpdate": null,
+                            "lastEffect": null,
+                            "lastUpdate": null,
+                          },
+                        },
+                        "selfBaseDuration": 0,
+                        "sibling": null,
+                        "stateNode": WrapperComponent {
+                          "_reactInternalFiber": [Circular],
+                          "_reactInternalInstance": Object {},
+                          "context": Object {},
+                          "props": Object {
+                            "Component": [Function],
+                            "context": null,
+                            "props": Object {
+                              "children": <AuthenticatedRoute
+                                authenticated={true}
+                                component={[Function]}
+                                path="/dashboard"
+                              />,
+                            },
+                            "wrappingComponentProps": null,
+                          },
+                          "refs": Object {},
+                          "rootFinderInstance": null,
+                          "state": Object {
+                            "context": null,
+                            "mount": true,
+                            "props": Object {
+                              "children": <AuthenticatedRoute
+                                authenticated={true}
+                                component={[Function]}
+                                path="/dashboard"
+                              />,
+                            },
+                            "wrappingComponentProps": null,
+                          },
+                          "updater": Object {
+                            "enqueueForceUpdate": [Function],
+                            "enqueueReplaceState": [Function],
+                            "enqueueSetState": [Function],
+                            "isMounted": [Function],
+                          },
+                        },
+                        "tag": 1,
+                        "treeBaseDuration": 0,
+                        "type": [Function],
+                        "updateQueue": null,
+                      },
+                      "selfBaseDuration": 0,
+                      "sibling": null,
+                      "stateNode": BrowserRouter {
+                        "_reactInternalFiber": [Circular],
+                        "_reactInternalInstance": Object {},
+                        "context": Object {},
+                        "history": Object {
+                          "action": "POP",
+                          "block": [Function],
+                          "createHref": [Function],
+                          "go": [Function],
+                          "goBack": [Function],
+                          "goForward": [Function],
+                          "length": 1,
+                          "listen": [Function],
+                          "location": Object {
+                            "hash": "",
+                            "pathname": "/",
+                            "search": "",
+                            "state": undefined,
+                          },
+                          "push": [Function],
+                          "replace": [Function],
+                        },
+                        "props": Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        },
+                        "refs": Object {},
+                        "state": null,
+                        "updater": Object {
+                          "enqueueForceUpdate": [Function],
+                          "enqueueReplaceState": [Function],
+                          "enqueueSetState": [Function],
+                          "isMounted": [Function],
+                        },
+                      },
+                      "tag": 1,
+                      "treeBaseDuration": 0,
+                      "type": [Function],
+                      "updateQueue": null,
+                    },
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": Router {
+                      "__reactInternalMemoizedMaskedChildContext": Object {
+                        "router": undefined,
+                      },
+                      "__reactInternalMemoizedMergedChildContext": Object {
+                        "router": Object {
+                          "history": Object {
+                            "action": "POP",
+                            "block": [Function],
+                            "createHref": [Function],
+                            "go": [Function],
+                            "goBack": [Function],
+                            "goForward": [Function],
+                            "length": 1,
+                            "listen": [Function],
+                            "location": Object {
+                              "hash": "",
+                              "pathname": "/",
+                              "search": "",
+                              "state": undefined,
+                            },
+                            "push": [Function],
+                            "replace": [Function],
+                          },
+                          "route": Object {
+                            "location": Object {
+                              "hash": "",
+                              "pathname": "/",
+                              "search": "",
+                              "state": undefined,
+                            },
+                            "match": Object {
+                              "isExact": true,
+                              "params": Object {},
+                              "path": "/",
+                              "url": "/",
+                            },
+                          },
+                        },
+                      },
+                      "__reactInternalMemoizedUnmaskedChildContext": Object {},
+                      "_reactInternalFiber": [Circular],
+                      "_reactInternalInstance": Object {},
+                      "context": Object {
+                        "router": undefined,
+                      },
+                      "props": Object {
+                        "children": <AuthenticatedRoute
+                          authenticated={true}
+                          component={[Function]}
+                          path="/dashboard"
+                        />,
+                        "history": Object {
+                          "action": "POP",
+                          "block": [Function],
+                          "createHref": [Function],
+                          "go": [Function],
+                          "goBack": [Function],
+                          "goForward": [Function],
+                          "length": 1,
+                          "listen": [Function],
+                          "location": Object {
+                            "hash": "",
+                            "pathname": "/",
+                            "search": "",
+                            "state": undefined,
+                          },
+                          "push": [Function],
+                          "replace": [Function],
+                        },
+                      },
+                      "refs": Object {},
+                      "state": Object {
+                        "match": Object {
+                          "isExact": true,
+                          "params": Object {},
+                          "path": "/",
+                          "url": "/",
+                        },
+                      },
+                      "unlisten": [Function],
+                      "updater": Object {
+                        "enqueueForceUpdate": [Function],
+                        "enqueueReplaceState": [Function],
+                        "enqueueSetState": [Function],
+                        "isMounted": [Function],
+                      },
+                    },
+                    "tag": 1,
+                    "treeBaseDuration": 0,
+                    "type": [Function],
+                    "updateQueue": null,
+                  },
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": null,
+                  "tag": 0,
+                  "treeBaseDuration": 0,
+                  "type": [Function],
+                  "updateQueue": null,
+                },
+                "_debugSource": Object {
+                  "fileName": "/Users/chucky/Code/Bench/bp-esa-frontend/src/App.jsx",
+                  "lineNumber": 15,
+                },
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": null,
+                "child": null,
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 1,
+                "elementType": [Function],
+                "expirationTime": 0,
+                "firstEffect": null,
+                "index": 0,
+                "key": null,
+                "lastEffect": null,
+                "memoizedProps": Object {
+                  "path": "/dashboard",
+                  "render": [Function],
+                },
+                "memoizedState": Object {
+                  "match": null,
+                },
+                "mode": 0,
+                "nextEffect": null,
+                "pendingProps": Object {
+                  "path": "/dashboard",
+                  "render": [Function],
+                },
+                "ref": null,
+                "return": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 65,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": null,
+                  "_debugSource": Object {
+                    "fileName": "/Users/chucky/Code/Bench/bp-esa-frontend/src/App.test.jsx",
+                    "lineNumber": 123,
+                  },
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": null,
+                  "child": [Circular],
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 1,
+                  "elementType": [Function],
+                  "expirationTime": 0,
+                  "firstEffect": null,
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": null,
+                  "memoizedProps": Object {
+                    "authenticated": true,
+                    "component": [Function],
+                    "path": "/dashboard",
+                  },
+                  "memoizedState": null,
+                  "mode": 0,
+                  "nextEffect": null,
+                  "pendingProps": Object {
+                    "authenticated": true,
+                    "component": [Function],
+                    "path": "/dashboard",
+                  },
+                  "ref": null,
+                  "return": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 64,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": FiberNode {
+                      "_debugHookTypes": null,
+                      "_debugID": 63,
+                      "_debugIsCurrentlyTiming": false,
+                      "_debugOwner": FiberNode {
+                        "_debugHookTypes": null,
+                        "_debugID": 62,
+                        "_debugIsCurrentlyTiming": false,
+                        "_debugOwner": null,
+                        "_debugSource": null,
+                        "actualDuration": 0,
+                        "actualStartTime": -1,
+                        "alternate": null,
+                        "child": [Circular],
+                        "childExpirationTime": 0,
+                        "contextDependencies": null,
+                        "effectTag": 1,
+                        "elementType": [Function],
+                        "expirationTime": 0,
+                        "firstEffect": null,
+                        "index": 0,
+                        "key": null,
+                        "lastEffect": null,
+                        "memoizedProps": Object {
+                          "Component": [Function],
+                          "context": null,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "memoizedState": Object {
+                          "context": null,
+                          "mount": true,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "mode": 0,
+                        "nextEffect": FiberNode {
+                          "_debugHookTypes": null,
+                          "_debugID": 60,
+                          "_debugIsCurrentlyTiming": false,
+                          "_debugOwner": null,
+                          "_debugSource": null,
+                          "actualDuration": 0,
+                          "actualStartTime": -1,
+                          "alternate": FiberNode {
+                            "_debugHookTypes": null,
+                            "_debugID": 60,
+                            "_debugIsCurrentlyTiming": false,
+                            "_debugOwner": null,
+                            "_debugSource": null,
+                            "actualDuration": 0,
+                            "actualStartTime": -1,
+                            "alternate": [Circular],
+                            "child": null,
+                            "childExpirationTime": 0,
+                            "contextDependencies": null,
+                            "effectTag": 0,
+                            "elementType": null,
+                            "expirationTime": 1073741823,
+                            "firstEffect": null,
+                            "index": 0,
+                            "key": null,
+                            "lastEffect": null,
+                            "memoizedProps": null,
+                            "memoizedState": null,
+                            "mode": 0,
+                            "nextEffect": null,
+                            "pendingProps": null,
+                            "ref": null,
+                            "return": null,
+                            "selfBaseDuration": 0,
+                            "sibling": null,
+                            "stateNode": Object {
+                              "containerInfo": <div />,
+                              "context": Object {},
+                              "current": [Circular],
+                              "didError": false,
+                              "earliestPendingTime": 0,
+                              "earliestSuspendedTime": 0,
+                              "expirationTime": 0,
+                              "finishedWork": null,
+                              "firstBatch": null,
+                              "hydrate": false,
+                              "interactionThreadID": 15,
+                              "latestPendingTime": 0,
+                              "latestPingedTime": 0,
+                              "latestSuspendedTime": 0,
+                              "memoizedInteractions": Set {},
+                              "nextExpirationTimeToWorkOn": 0,
+                              "nextScheduledRoot": null,
+                              "pendingChildren": null,
+                              "pendingCommitExpirationTime": 0,
+                              "pendingContext": null,
+                              "pendingInteractionMap": Map {},
+                              "pingCache": null,
+                              "timeoutHandle": -1,
+                            },
+                            "tag": 3,
+                            "treeBaseDuration": 0,
+                            "type": null,
+                            "updateQueue": Object {
+                              "baseState": null,
+                              "firstCapturedEffect": null,
+                              "firstCapturedUpdate": null,
+                              "firstEffect": null,
+                              "firstUpdate": Object {
+                                "callback": null,
+                                "expirationTime": 1073741823,
+                                "next": null,
+                                "nextEffect": null,
+                                "payload": Object {
+                                  "element": <WrapperComponent
+                                    Component={[Function]}
+                                    context={null}
+                                    props={
+                                      Object {
+                                        "children": <AuthenticatedRoute
+                                          authenticated={true}
+                                          component={[Function]}
+                                          path="/dashboard"
+                                        />,
+                                      }
+                                    }
+                                    wrappingComponentProps={null}
+                                  />,
+                                },
+                                "tag": 0,
+                              },
+                              "lastCapturedEffect": null,
+                              "lastCapturedUpdate": null,
+                              "lastEffect": null,
+                              "lastUpdate": Object {
+                                "callback": null,
+                                "expirationTime": 1073741823,
+                                "next": null,
+                                "nextEffect": null,
+                                "payload": Object {
+                                  "element": <WrapperComponent
+                                    Component={[Function]}
+                                    context={null}
+                                    props={
+                                      Object {
+                                        "children": <AuthenticatedRoute
+                                          authenticated={true}
+                                          component={[Function]}
+                                          path="/dashboard"
+                                        />,
+                                      }
+                                    }
+                                    wrappingComponentProps={null}
+                                  />,
+                                },
+                                "tag": 0,
+                              },
+                            },
+                          },
+                          "child": [Circular],
+                          "childExpirationTime": 0,
+                          "contextDependencies": null,
+                          "effectTag": 32,
+                          "elementType": null,
+                          "expirationTime": 0,
+                          "firstEffect": [Circular],
+                          "index": 0,
+                          "key": null,
+                          "lastEffect": [Circular],
+                          "memoizedProps": null,
+                          "memoizedState": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={
+                                Object {
+                                  "children": <AuthenticatedRoute
+                                    authenticated={true}
+                                    component={[Function]}
+                                    path="/dashboard"
+                                  />,
+                                }
+                              }
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "mode": 0,
+                          "nextEffect": null,
+                          "pendingProps": null,
+                          "ref": null,
+                          "return": null,
+                          "selfBaseDuration": 0,
+                          "sibling": null,
+                          "stateNode": Object {
+                            "containerInfo": <div />,
+                            "context": Object {},
+                            "current": [Circular],
+                            "didError": false,
+                            "earliestPendingTime": 0,
+                            "earliestSuspendedTime": 0,
+                            "expirationTime": 0,
+                            "finishedWork": null,
+                            "firstBatch": null,
+                            "hydrate": false,
+                            "interactionThreadID": 15,
+                            "latestPendingTime": 0,
+                            "latestPingedTime": 0,
+                            "latestSuspendedTime": 0,
+                            "memoizedInteractions": Set {},
+                            "nextExpirationTimeToWorkOn": 0,
+                            "nextScheduledRoot": null,
+                            "pendingChildren": null,
+                            "pendingCommitExpirationTime": 0,
+                            "pendingContext": null,
+                            "pendingInteractionMap": Map {},
+                            "pingCache": null,
+                            "timeoutHandle": -1,
+                          },
+                          "tag": 3,
+                          "treeBaseDuration": 0,
+                          "type": null,
+                          "updateQueue": Object {
+                            "baseState": Object {
+                              "element": <WrapperComponent
+                                Component={[Function]}
+                                context={null}
+                                props={
+                                  Object {
+                                    "children": <AuthenticatedRoute
+                                      authenticated={true}
+                                      component={[Function]}
+                                      path="/dashboard"
+                                    />,
+                                  }
+                                }
+                                wrappingComponentProps={null}
+                              />,
+                            },
+                            "firstCapturedEffect": null,
+                            "firstCapturedUpdate": null,
+                            "firstEffect": null,
+                            "firstUpdate": null,
+                            "lastCapturedEffect": null,
+                            "lastCapturedUpdate": null,
+                            "lastEffect": null,
+                            "lastUpdate": null,
+                          },
+                        },
+                        "pendingProps": Object {
+                          "Component": [Function],
+                          "context": null,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "ref": null,
+                        "return": FiberNode {
+                          "_debugHookTypes": null,
+                          "_debugID": 60,
+                          "_debugIsCurrentlyTiming": false,
+                          "_debugOwner": null,
+                          "_debugSource": null,
+                          "actualDuration": 0,
+                          "actualStartTime": -1,
+                          "alternate": FiberNode {
+                            "_debugHookTypes": null,
+                            "_debugID": 60,
+                            "_debugIsCurrentlyTiming": false,
+                            "_debugOwner": null,
+                            "_debugSource": null,
+                            "actualDuration": 0,
+                            "actualStartTime": -1,
+                            "alternate": [Circular],
+                            "child": null,
+                            "childExpirationTime": 0,
+                            "contextDependencies": null,
+                            "effectTag": 0,
+                            "elementType": null,
+                            "expirationTime": 1073741823,
+                            "firstEffect": null,
+                            "index": 0,
+                            "key": null,
+                            "lastEffect": null,
+                            "memoizedProps": null,
+                            "memoizedState": null,
+                            "mode": 0,
+                            "nextEffect": null,
+                            "pendingProps": null,
+                            "ref": null,
+                            "return": null,
+                            "selfBaseDuration": 0,
+                            "sibling": null,
+                            "stateNode": Object {
+                              "containerInfo": <div />,
+                              "context": Object {},
+                              "current": [Circular],
+                              "didError": false,
+                              "earliestPendingTime": 0,
+                              "earliestSuspendedTime": 0,
+                              "expirationTime": 0,
+                              "finishedWork": null,
+                              "firstBatch": null,
+                              "hydrate": false,
+                              "interactionThreadID": 15,
+                              "latestPendingTime": 0,
+                              "latestPingedTime": 0,
+                              "latestSuspendedTime": 0,
+                              "memoizedInteractions": Set {},
+                              "nextExpirationTimeToWorkOn": 0,
+                              "nextScheduledRoot": null,
+                              "pendingChildren": null,
+                              "pendingCommitExpirationTime": 0,
+                              "pendingContext": null,
+                              "pendingInteractionMap": Map {},
+                              "pingCache": null,
+                              "timeoutHandle": -1,
+                            },
+                            "tag": 3,
+                            "treeBaseDuration": 0,
+                            "type": null,
+                            "updateQueue": Object {
+                              "baseState": null,
+                              "firstCapturedEffect": null,
+                              "firstCapturedUpdate": null,
+                              "firstEffect": null,
+                              "firstUpdate": Object {
+                                "callback": null,
+                                "expirationTime": 1073741823,
+                                "next": null,
+                                "nextEffect": null,
+                                "payload": Object {
+                                  "element": <WrapperComponent
+                                    Component={[Function]}
+                                    context={null}
+                                    props={
+                                      Object {
+                                        "children": <AuthenticatedRoute
+                                          authenticated={true}
+                                          component={[Function]}
+                                          path="/dashboard"
+                                        />,
+                                      }
+                                    }
+                                    wrappingComponentProps={null}
+                                  />,
+                                },
+                                "tag": 0,
+                              },
+                              "lastCapturedEffect": null,
+                              "lastCapturedUpdate": null,
+                              "lastEffect": null,
+                              "lastUpdate": Object {
+                                "callback": null,
+                                "expirationTime": 1073741823,
+                                "next": null,
+                                "nextEffect": null,
+                                "payload": Object {
+                                  "element": <WrapperComponent
+                                    Component={[Function]}
+                                    context={null}
+                                    props={
+                                      Object {
+                                        "children": <AuthenticatedRoute
+                                          authenticated={true}
+                                          component={[Function]}
+                                          path="/dashboard"
+                                        />,
+                                      }
+                                    }
+                                    wrappingComponentProps={null}
+                                  />,
+                                },
+                                "tag": 0,
+                              },
+                            },
+                          },
+                          "child": [Circular],
+                          "childExpirationTime": 0,
+                          "contextDependencies": null,
+                          "effectTag": 32,
+                          "elementType": null,
+                          "expirationTime": 0,
+                          "firstEffect": [Circular],
+                          "index": 0,
+                          "key": null,
+                          "lastEffect": [Circular],
+                          "memoizedProps": null,
+                          "memoizedState": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={
+                                Object {
+                                  "children": <AuthenticatedRoute
+                                    authenticated={true}
+                                    component={[Function]}
+                                    path="/dashboard"
+                                  />,
+                                }
+                              }
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "mode": 0,
+                          "nextEffect": null,
+                          "pendingProps": null,
+                          "ref": null,
+                          "return": null,
+                          "selfBaseDuration": 0,
+                          "sibling": null,
+                          "stateNode": Object {
+                            "containerInfo": <div />,
+                            "context": Object {},
+                            "current": [Circular],
+                            "didError": false,
+                            "earliestPendingTime": 0,
+                            "earliestSuspendedTime": 0,
+                            "expirationTime": 0,
+                            "finishedWork": null,
+                            "firstBatch": null,
+                            "hydrate": false,
+                            "interactionThreadID": 15,
+                            "latestPendingTime": 0,
+                            "latestPingedTime": 0,
+                            "latestSuspendedTime": 0,
+                            "memoizedInteractions": Set {},
+                            "nextExpirationTimeToWorkOn": 0,
+                            "nextScheduledRoot": null,
+                            "pendingChildren": null,
+                            "pendingCommitExpirationTime": 0,
+                            "pendingContext": null,
+                            "pendingInteractionMap": Map {},
+                            "pingCache": null,
+                            "timeoutHandle": -1,
+                          },
+                          "tag": 3,
+                          "treeBaseDuration": 0,
+                          "type": null,
+                          "updateQueue": Object {
+                            "baseState": Object {
+                              "element": <WrapperComponent
+                                Component={[Function]}
+                                context={null}
+                                props={
+                                  Object {
+                                    "children": <AuthenticatedRoute
+                                      authenticated={true}
+                                      component={[Function]}
+                                      path="/dashboard"
+                                    />,
+                                  }
+                                }
+                                wrappingComponentProps={null}
+                              />,
+                            },
+                            "firstCapturedEffect": null,
+                            "firstCapturedUpdate": null,
+                            "firstEffect": null,
+                            "firstUpdate": null,
+                            "lastCapturedEffect": null,
+                            "lastCapturedUpdate": null,
+                            "lastEffect": null,
+                            "lastUpdate": null,
+                          },
+                        },
+                        "selfBaseDuration": 0,
+                        "sibling": null,
+                        "stateNode": WrapperComponent {
+                          "_reactInternalFiber": [Circular],
+                          "_reactInternalInstance": Object {},
+                          "context": Object {},
+                          "props": Object {
+                            "Component": [Function],
+                            "context": null,
+                            "props": Object {
+                              "children": <AuthenticatedRoute
+                                authenticated={true}
+                                component={[Function]}
+                                path="/dashboard"
+                              />,
+                            },
+                            "wrappingComponentProps": null,
+                          },
+                          "refs": Object {},
+                          "rootFinderInstance": null,
+                          "state": Object {
+                            "context": null,
+                            "mount": true,
+                            "props": Object {
+                              "children": <AuthenticatedRoute
+                                authenticated={true}
+                                component={[Function]}
+                                path="/dashboard"
+                              />,
+                            },
+                            "wrappingComponentProps": null,
+                          },
+                          "updater": Object {
+                            "enqueueForceUpdate": [Function],
+                            "enqueueReplaceState": [Function],
+                            "enqueueSetState": [Function],
+                            "isMounted": [Function],
+                          },
+                        },
+                        "tag": 1,
+                        "treeBaseDuration": 0,
+                        "type": [Function],
+                        "updateQueue": null,
+                      },
+                      "_debugSource": null,
+                      "actualDuration": 0,
+                      "actualStartTime": -1,
+                      "alternate": null,
+                      "child": [Circular],
+                      "childExpirationTime": 0,
+                      "contextDependencies": null,
+                      "effectTag": 1,
+                      "elementType": [Function],
+                      "expirationTime": 0,
+                      "firstEffect": null,
+                      "index": 0,
+                      "key": null,
+                      "lastEffect": null,
+                      "memoizedProps": Object {
+                        "children": <AuthenticatedRoute
+                          authenticated={true}
+                          component={[Function]}
+                          path="/dashboard"
+                        />,
+                      },
+                      "memoizedState": null,
+                      "mode": 0,
+                      "nextEffect": null,
+                      "pendingProps": Object {
+                        "children": <AuthenticatedRoute
+                          authenticated={true}
+                          component={[Function]}
+                          path="/dashboard"
+                        />,
+                      },
+                      "ref": null,
+                      "return": FiberNode {
+                        "_debugHookTypes": null,
+                        "_debugID": 62,
+                        "_debugIsCurrentlyTiming": false,
+                        "_debugOwner": null,
+                        "_debugSource": null,
+                        "actualDuration": 0,
+                        "actualStartTime": -1,
+                        "alternate": null,
+                        "child": [Circular],
+                        "childExpirationTime": 0,
+                        "contextDependencies": null,
+                        "effectTag": 1,
+                        "elementType": [Function],
+                        "expirationTime": 0,
+                        "firstEffect": null,
+                        "index": 0,
+                        "key": null,
+                        "lastEffect": null,
+                        "memoizedProps": Object {
+                          "Component": [Function],
+                          "context": null,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "memoizedState": Object {
+                          "context": null,
+                          "mount": true,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "mode": 0,
+                        "nextEffect": FiberNode {
+                          "_debugHookTypes": null,
+                          "_debugID": 60,
+                          "_debugIsCurrentlyTiming": false,
+                          "_debugOwner": null,
+                          "_debugSource": null,
+                          "actualDuration": 0,
+                          "actualStartTime": -1,
+                          "alternate": FiberNode {
+                            "_debugHookTypes": null,
+                            "_debugID": 60,
+                            "_debugIsCurrentlyTiming": false,
+                            "_debugOwner": null,
+                            "_debugSource": null,
+                            "actualDuration": 0,
+                            "actualStartTime": -1,
+                            "alternate": [Circular],
+                            "child": null,
+                            "childExpirationTime": 0,
+                            "contextDependencies": null,
+                            "effectTag": 0,
+                            "elementType": null,
+                            "expirationTime": 1073741823,
+                            "firstEffect": null,
+                            "index": 0,
+                            "key": null,
+                            "lastEffect": null,
+                            "memoizedProps": null,
+                            "memoizedState": null,
+                            "mode": 0,
+                            "nextEffect": null,
+                            "pendingProps": null,
+                            "ref": null,
+                            "return": null,
+                            "selfBaseDuration": 0,
+                            "sibling": null,
+                            "stateNode": Object {
+                              "containerInfo": <div />,
+                              "context": Object {},
+                              "current": [Circular],
+                              "didError": false,
+                              "earliestPendingTime": 0,
+                              "earliestSuspendedTime": 0,
+                              "expirationTime": 0,
+                              "finishedWork": null,
+                              "firstBatch": null,
+                              "hydrate": false,
+                              "interactionThreadID": 15,
+                              "latestPendingTime": 0,
+                              "latestPingedTime": 0,
+                              "latestSuspendedTime": 0,
+                              "memoizedInteractions": Set {},
+                              "nextExpirationTimeToWorkOn": 0,
+                              "nextScheduledRoot": null,
+                              "pendingChildren": null,
+                              "pendingCommitExpirationTime": 0,
+                              "pendingContext": null,
+                              "pendingInteractionMap": Map {},
+                              "pingCache": null,
+                              "timeoutHandle": -1,
+                            },
+                            "tag": 3,
+                            "treeBaseDuration": 0,
+                            "type": null,
+                            "updateQueue": Object {
+                              "baseState": null,
+                              "firstCapturedEffect": null,
+                              "firstCapturedUpdate": null,
+                              "firstEffect": null,
+                              "firstUpdate": Object {
+                                "callback": null,
+                                "expirationTime": 1073741823,
+                                "next": null,
+                                "nextEffect": null,
+                                "payload": Object {
+                                  "element": <WrapperComponent
+                                    Component={[Function]}
+                                    context={null}
+                                    props={
+                                      Object {
+                                        "children": <AuthenticatedRoute
+                                          authenticated={true}
+                                          component={[Function]}
+                                          path="/dashboard"
+                                        />,
+                                      }
+                                    }
+                                    wrappingComponentProps={null}
+                                  />,
+                                },
+                                "tag": 0,
+                              },
+                              "lastCapturedEffect": null,
+                              "lastCapturedUpdate": null,
+                              "lastEffect": null,
+                              "lastUpdate": Object {
+                                "callback": null,
+                                "expirationTime": 1073741823,
+                                "next": null,
+                                "nextEffect": null,
+                                "payload": Object {
+                                  "element": <WrapperComponent
+                                    Component={[Function]}
+                                    context={null}
+                                    props={
+                                      Object {
+                                        "children": <AuthenticatedRoute
+                                          authenticated={true}
+                                          component={[Function]}
+                                          path="/dashboard"
+                                        />,
+                                      }
+                                    }
+                                    wrappingComponentProps={null}
+                                  />,
+                                },
+                                "tag": 0,
+                              },
+                            },
+                          },
+                          "child": [Circular],
+                          "childExpirationTime": 0,
+                          "contextDependencies": null,
+                          "effectTag": 32,
+                          "elementType": null,
+                          "expirationTime": 0,
+                          "firstEffect": [Circular],
+                          "index": 0,
+                          "key": null,
+                          "lastEffect": [Circular],
+                          "memoizedProps": null,
+                          "memoizedState": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={
+                                Object {
+                                  "children": <AuthenticatedRoute
+                                    authenticated={true}
+                                    component={[Function]}
+                                    path="/dashboard"
+                                  />,
+                                }
+                              }
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "mode": 0,
+                          "nextEffect": null,
+                          "pendingProps": null,
+                          "ref": null,
+                          "return": null,
+                          "selfBaseDuration": 0,
+                          "sibling": null,
+                          "stateNode": Object {
+                            "containerInfo": <div />,
+                            "context": Object {},
+                            "current": [Circular],
+                            "didError": false,
+                            "earliestPendingTime": 0,
+                            "earliestSuspendedTime": 0,
+                            "expirationTime": 0,
+                            "finishedWork": null,
+                            "firstBatch": null,
+                            "hydrate": false,
+                            "interactionThreadID": 15,
+                            "latestPendingTime": 0,
+                            "latestPingedTime": 0,
+                            "latestSuspendedTime": 0,
+                            "memoizedInteractions": Set {},
+                            "nextExpirationTimeToWorkOn": 0,
+                            "nextScheduledRoot": null,
+                            "pendingChildren": null,
+                            "pendingCommitExpirationTime": 0,
+                            "pendingContext": null,
+                            "pendingInteractionMap": Map {},
+                            "pingCache": null,
+                            "timeoutHandle": -1,
+                          },
+                          "tag": 3,
+                          "treeBaseDuration": 0,
+                          "type": null,
+                          "updateQueue": Object {
+                            "baseState": Object {
+                              "element": <WrapperComponent
+                                Component={[Function]}
+                                context={null}
+                                props={
+                                  Object {
+                                    "children": <AuthenticatedRoute
+                                      authenticated={true}
+                                      component={[Function]}
+                                      path="/dashboard"
+                                    />,
+                                  }
+                                }
+                                wrappingComponentProps={null}
+                              />,
+                            },
+                            "firstCapturedEffect": null,
+                            "firstCapturedUpdate": null,
+                            "firstEffect": null,
+                            "firstUpdate": null,
+                            "lastCapturedEffect": null,
+                            "lastCapturedUpdate": null,
+                            "lastEffect": null,
+                            "lastUpdate": null,
+                          },
+                        },
+                        "pendingProps": Object {
+                          "Component": [Function],
+                          "context": null,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "ref": null,
+                        "return": FiberNode {
+                          "_debugHookTypes": null,
+                          "_debugID": 60,
+                          "_debugIsCurrentlyTiming": false,
+                          "_debugOwner": null,
+                          "_debugSource": null,
+                          "actualDuration": 0,
+                          "actualStartTime": -1,
+                          "alternate": FiberNode {
+                            "_debugHookTypes": null,
+                            "_debugID": 60,
+                            "_debugIsCurrentlyTiming": false,
+                            "_debugOwner": null,
+                            "_debugSource": null,
+                            "actualDuration": 0,
+                            "actualStartTime": -1,
+                            "alternate": [Circular],
+                            "child": null,
+                            "childExpirationTime": 0,
+                            "contextDependencies": null,
+                            "effectTag": 0,
+                            "elementType": null,
+                            "expirationTime": 1073741823,
+                            "firstEffect": null,
+                            "index": 0,
+                            "key": null,
+                            "lastEffect": null,
+                            "memoizedProps": null,
+                            "memoizedState": null,
+                            "mode": 0,
+                            "nextEffect": null,
+                            "pendingProps": null,
+                            "ref": null,
+                            "return": null,
+                            "selfBaseDuration": 0,
+                            "sibling": null,
+                            "stateNode": Object {
+                              "containerInfo": <div />,
+                              "context": Object {},
+                              "current": [Circular],
+                              "didError": false,
+                              "earliestPendingTime": 0,
+                              "earliestSuspendedTime": 0,
+                              "expirationTime": 0,
+                              "finishedWork": null,
+                              "firstBatch": null,
+                              "hydrate": false,
+                              "interactionThreadID": 15,
+                              "latestPendingTime": 0,
+                              "latestPingedTime": 0,
+                              "latestSuspendedTime": 0,
+                              "memoizedInteractions": Set {},
+                              "nextExpirationTimeToWorkOn": 0,
+                              "nextScheduledRoot": null,
+                              "pendingChildren": null,
+                              "pendingCommitExpirationTime": 0,
+                              "pendingContext": null,
+                              "pendingInteractionMap": Map {},
+                              "pingCache": null,
+                              "timeoutHandle": -1,
+                            },
+                            "tag": 3,
+                            "treeBaseDuration": 0,
+                            "type": null,
+                            "updateQueue": Object {
+                              "baseState": null,
+                              "firstCapturedEffect": null,
+                              "firstCapturedUpdate": null,
+                              "firstEffect": null,
+                              "firstUpdate": Object {
+                                "callback": null,
+                                "expirationTime": 1073741823,
+                                "next": null,
+                                "nextEffect": null,
+                                "payload": Object {
+                                  "element": <WrapperComponent
+                                    Component={[Function]}
+                                    context={null}
+                                    props={
+                                      Object {
+                                        "children": <AuthenticatedRoute
+                                          authenticated={true}
+                                          component={[Function]}
+                                          path="/dashboard"
+                                        />,
+                                      }
+                                    }
+                                    wrappingComponentProps={null}
+                                  />,
+                                },
+                                "tag": 0,
+                              },
+                              "lastCapturedEffect": null,
+                              "lastCapturedUpdate": null,
+                              "lastEffect": null,
+                              "lastUpdate": Object {
+                                "callback": null,
+                                "expirationTime": 1073741823,
+                                "next": null,
+                                "nextEffect": null,
+                                "payload": Object {
+                                  "element": <WrapperComponent
+                                    Component={[Function]}
+                                    context={null}
+                                    props={
+                                      Object {
+                                        "children": <AuthenticatedRoute
+                                          authenticated={true}
+                                          component={[Function]}
+                                          path="/dashboard"
+                                        />,
+                                      }
+                                    }
+                                    wrappingComponentProps={null}
+                                  />,
+                                },
+                                "tag": 0,
+                              },
+                            },
+                          },
+                          "child": [Circular],
+                          "childExpirationTime": 0,
+                          "contextDependencies": null,
+                          "effectTag": 32,
+                          "elementType": null,
+                          "expirationTime": 0,
+                          "firstEffect": [Circular],
+                          "index": 0,
+                          "key": null,
+                          "lastEffect": [Circular],
+                          "memoizedProps": null,
+                          "memoizedState": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={
+                                Object {
+                                  "children": <AuthenticatedRoute
+                                    authenticated={true}
+                                    component={[Function]}
+                                    path="/dashboard"
+                                  />,
+                                }
+                              }
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "mode": 0,
+                          "nextEffect": null,
+                          "pendingProps": null,
+                          "ref": null,
+                          "return": null,
+                          "selfBaseDuration": 0,
+                          "sibling": null,
+                          "stateNode": Object {
+                            "containerInfo": <div />,
+                            "context": Object {},
+                            "current": [Circular],
+                            "didError": false,
+                            "earliestPendingTime": 0,
+                            "earliestSuspendedTime": 0,
+                            "expirationTime": 0,
+                            "finishedWork": null,
+                            "firstBatch": null,
+                            "hydrate": false,
+                            "interactionThreadID": 15,
+                            "latestPendingTime": 0,
+                            "latestPingedTime": 0,
+                            "latestSuspendedTime": 0,
+                            "memoizedInteractions": Set {},
+                            "nextExpirationTimeToWorkOn": 0,
+                            "nextScheduledRoot": null,
+                            "pendingChildren": null,
+                            "pendingCommitExpirationTime": 0,
+                            "pendingContext": null,
+                            "pendingInteractionMap": Map {},
+                            "pingCache": null,
+                            "timeoutHandle": -1,
+                          },
+                          "tag": 3,
+                          "treeBaseDuration": 0,
+                          "type": null,
+                          "updateQueue": Object {
+                            "baseState": Object {
+                              "element": <WrapperComponent
+                                Component={[Function]}
+                                context={null}
+                                props={
+                                  Object {
+                                    "children": <AuthenticatedRoute
+                                      authenticated={true}
+                                      component={[Function]}
+                                      path="/dashboard"
+                                    />,
+                                  }
+                                }
+                                wrappingComponentProps={null}
+                              />,
+                            },
+                            "firstCapturedEffect": null,
+                            "firstCapturedUpdate": null,
+                            "firstEffect": null,
+                            "firstUpdate": null,
+                            "lastCapturedEffect": null,
+                            "lastCapturedUpdate": null,
+                            "lastEffect": null,
+                            "lastUpdate": null,
+                          },
+                        },
+                        "selfBaseDuration": 0,
+                        "sibling": null,
+                        "stateNode": WrapperComponent {
+                          "_reactInternalFiber": [Circular],
+                          "_reactInternalInstance": Object {},
+                          "context": Object {},
+                          "props": Object {
+                            "Component": [Function],
+                            "context": null,
+                            "props": Object {
+                              "children": <AuthenticatedRoute
+                                authenticated={true}
+                                component={[Function]}
+                                path="/dashboard"
+                              />,
+                            },
+                            "wrappingComponentProps": null,
+                          },
+                          "refs": Object {},
+                          "rootFinderInstance": null,
+                          "state": Object {
+                            "context": null,
+                            "mount": true,
+                            "props": Object {
+                              "children": <AuthenticatedRoute
+                                authenticated={true}
+                                component={[Function]}
+                                path="/dashboard"
+                              />,
+                            },
+                            "wrappingComponentProps": null,
+                          },
+                          "updater": Object {
+                            "enqueueForceUpdate": [Function],
+                            "enqueueReplaceState": [Function],
+                            "enqueueSetState": [Function],
+                            "isMounted": [Function],
+                          },
+                        },
+                        "tag": 1,
+                        "treeBaseDuration": 0,
+                        "type": [Function],
+                        "updateQueue": null,
+                      },
+                      "selfBaseDuration": 0,
+                      "sibling": null,
+                      "stateNode": BrowserRouter {
+                        "_reactInternalFiber": [Circular],
+                        "_reactInternalInstance": Object {},
+                        "context": Object {},
+                        "history": Object {
+                          "action": "POP",
+                          "block": [Function],
+                          "createHref": [Function],
+                          "go": [Function],
+                          "goBack": [Function],
+                          "goForward": [Function],
+                          "length": 1,
+                          "listen": [Function],
+                          "location": Object {
+                            "hash": "",
+                            "pathname": "/",
+                            "search": "",
+                            "state": undefined,
+                          },
+                          "push": [Function],
+                          "replace": [Function],
+                        },
+                        "props": Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        },
+                        "refs": Object {},
+                        "state": null,
+                        "updater": Object {
+                          "enqueueForceUpdate": [Function],
+                          "enqueueReplaceState": [Function],
+                          "enqueueSetState": [Function],
+                          "isMounted": [Function],
+                        },
+                      },
+                      "tag": 1,
+                      "treeBaseDuration": 0,
+                      "type": [Function],
+                      "updateQueue": null,
+                    },
+                    "_debugSource": null,
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": null,
+                    "child": [Circular],
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 1,
+                    "elementType": [Function],
+                    "expirationTime": 0,
+                    "firstEffect": null,
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": null,
+                    "memoizedProps": Object {
+                      "children": <AuthenticatedRoute
+                        authenticated={true}
+                        component={[Function]}
+                        path="/dashboard"
+                      />,
+                      "history": Object {
+                        "action": "POP",
+                        "block": [Function],
+                        "createHref": [Function],
+                        "go": [Function],
+                        "goBack": [Function],
+                        "goForward": [Function],
+                        "length": 1,
+                        "listen": [Function],
+                        "location": Object {
+                          "hash": "",
+                          "pathname": "/",
+                          "search": "",
+                          "state": undefined,
+                        },
+                        "push": [Function],
+                        "replace": [Function],
+                      },
+                    },
+                    "memoizedState": Object {
+                      "match": Object {
+                        "isExact": true,
+                        "params": Object {},
+                        "path": "/",
+                        "url": "/",
+                      },
+                    },
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": Object {
+                      "children": <AuthenticatedRoute
+                        authenticated={true}
+                        component={[Function]}
+                        path="/dashboard"
+                      />,
+                      "history": Object {
+                        "action": "POP",
+                        "block": [Function],
+                        "createHref": [Function],
+                        "go": [Function],
+                        "goBack": [Function],
+                        "goForward": [Function],
+                        "length": 1,
+                        "listen": [Function],
+                        "location": Object {
+                          "hash": "",
+                          "pathname": "/",
+                          "search": "",
+                          "state": undefined,
+                        },
+                        "push": [Function],
+                        "replace": [Function],
+                      },
+                    },
+                    "ref": null,
+                    "return": FiberNode {
+                      "_debugHookTypes": null,
+                      "_debugID": 63,
+                      "_debugIsCurrentlyTiming": false,
+                      "_debugOwner": FiberNode {
+                        "_debugHookTypes": null,
+                        "_debugID": 62,
+                        "_debugIsCurrentlyTiming": false,
+                        "_debugOwner": null,
+                        "_debugSource": null,
+                        "actualDuration": 0,
+                        "actualStartTime": -1,
+                        "alternate": null,
+                        "child": [Circular],
+                        "childExpirationTime": 0,
+                        "contextDependencies": null,
+                        "effectTag": 1,
+                        "elementType": [Function],
+                        "expirationTime": 0,
+                        "firstEffect": null,
+                        "index": 0,
+                        "key": null,
+                        "lastEffect": null,
+                        "memoizedProps": Object {
+                          "Component": [Function],
+                          "context": null,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "memoizedState": Object {
+                          "context": null,
+                          "mount": true,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "mode": 0,
+                        "nextEffect": FiberNode {
+                          "_debugHookTypes": null,
+                          "_debugID": 60,
+                          "_debugIsCurrentlyTiming": false,
+                          "_debugOwner": null,
+                          "_debugSource": null,
+                          "actualDuration": 0,
+                          "actualStartTime": -1,
+                          "alternate": FiberNode {
+                            "_debugHookTypes": null,
+                            "_debugID": 60,
+                            "_debugIsCurrentlyTiming": false,
+                            "_debugOwner": null,
+                            "_debugSource": null,
+                            "actualDuration": 0,
+                            "actualStartTime": -1,
+                            "alternate": [Circular],
+                            "child": null,
+                            "childExpirationTime": 0,
+                            "contextDependencies": null,
+                            "effectTag": 0,
+                            "elementType": null,
+                            "expirationTime": 1073741823,
+                            "firstEffect": null,
+                            "index": 0,
+                            "key": null,
+                            "lastEffect": null,
+                            "memoizedProps": null,
+                            "memoizedState": null,
+                            "mode": 0,
+                            "nextEffect": null,
+                            "pendingProps": null,
+                            "ref": null,
+                            "return": null,
+                            "selfBaseDuration": 0,
+                            "sibling": null,
+                            "stateNode": Object {
+                              "containerInfo": <div />,
+                              "context": Object {},
+                              "current": [Circular],
+                              "didError": false,
+                              "earliestPendingTime": 0,
+                              "earliestSuspendedTime": 0,
+                              "expirationTime": 0,
+                              "finishedWork": null,
+                              "firstBatch": null,
+                              "hydrate": false,
+                              "interactionThreadID": 15,
+                              "latestPendingTime": 0,
+                              "latestPingedTime": 0,
+                              "latestSuspendedTime": 0,
+                              "memoizedInteractions": Set {},
+                              "nextExpirationTimeToWorkOn": 0,
+                              "nextScheduledRoot": null,
+                              "pendingChildren": null,
+                              "pendingCommitExpirationTime": 0,
+                              "pendingContext": null,
+                              "pendingInteractionMap": Map {},
+                              "pingCache": null,
+                              "timeoutHandle": -1,
+                            },
+                            "tag": 3,
+                            "treeBaseDuration": 0,
+                            "type": null,
+                            "updateQueue": Object {
+                              "baseState": null,
+                              "firstCapturedEffect": null,
+                              "firstCapturedUpdate": null,
+                              "firstEffect": null,
+                              "firstUpdate": Object {
+                                "callback": null,
+                                "expirationTime": 1073741823,
+                                "next": null,
+                                "nextEffect": null,
+                                "payload": Object {
+                                  "element": <WrapperComponent
+                                    Component={[Function]}
+                                    context={null}
+                                    props={
+                                      Object {
+                                        "children": <AuthenticatedRoute
+                                          authenticated={true}
+                                          component={[Function]}
+                                          path="/dashboard"
+                                        />,
+                                      }
+                                    }
+                                    wrappingComponentProps={null}
+                                  />,
+                                },
+                                "tag": 0,
+                              },
+                              "lastCapturedEffect": null,
+                              "lastCapturedUpdate": null,
+                              "lastEffect": null,
+                              "lastUpdate": Object {
+                                "callback": null,
+                                "expirationTime": 1073741823,
+                                "next": null,
+                                "nextEffect": null,
+                                "payload": Object {
+                                  "element": <WrapperComponent
+                                    Component={[Function]}
+                                    context={null}
+                                    props={
+                                      Object {
+                                        "children": <AuthenticatedRoute
+                                          authenticated={true}
+                                          component={[Function]}
+                                          path="/dashboard"
+                                        />,
+                                      }
+                                    }
+                                    wrappingComponentProps={null}
+                                  />,
+                                },
+                                "tag": 0,
+                              },
+                            },
+                          },
+                          "child": [Circular],
+                          "childExpirationTime": 0,
+                          "contextDependencies": null,
+                          "effectTag": 32,
+                          "elementType": null,
+                          "expirationTime": 0,
+                          "firstEffect": [Circular],
+                          "index": 0,
+                          "key": null,
+                          "lastEffect": [Circular],
+                          "memoizedProps": null,
+                          "memoizedState": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={
+                                Object {
+                                  "children": <AuthenticatedRoute
+                                    authenticated={true}
+                                    component={[Function]}
+                                    path="/dashboard"
+                                  />,
+                                }
+                              }
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "mode": 0,
+                          "nextEffect": null,
+                          "pendingProps": null,
+                          "ref": null,
+                          "return": null,
+                          "selfBaseDuration": 0,
+                          "sibling": null,
+                          "stateNode": Object {
+                            "containerInfo": <div />,
+                            "context": Object {},
+                            "current": [Circular],
+                            "didError": false,
+                            "earliestPendingTime": 0,
+                            "earliestSuspendedTime": 0,
+                            "expirationTime": 0,
+                            "finishedWork": null,
+                            "firstBatch": null,
+                            "hydrate": false,
+                            "interactionThreadID": 15,
+                            "latestPendingTime": 0,
+                            "latestPingedTime": 0,
+                            "latestSuspendedTime": 0,
+                            "memoizedInteractions": Set {},
+                            "nextExpirationTimeToWorkOn": 0,
+                            "nextScheduledRoot": null,
+                            "pendingChildren": null,
+                            "pendingCommitExpirationTime": 0,
+                            "pendingContext": null,
+                            "pendingInteractionMap": Map {},
+                            "pingCache": null,
+                            "timeoutHandle": -1,
+                          },
+                          "tag": 3,
+                          "treeBaseDuration": 0,
+                          "type": null,
+                          "updateQueue": Object {
+                            "baseState": Object {
+                              "element": <WrapperComponent
+                                Component={[Function]}
+                                context={null}
+                                props={
+                                  Object {
+                                    "children": <AuthenticatedRoute
+                                      authenticated={true}
+                                      component={[Function]}
+                                      path="/dashboard"
+                                    />,
+                                  }
+                                }
+                                wrappingComponentProps={null}
+                              />,
+                            },
+                            "firstCapturedEffect": null,
+                            "firstCapturedUpdate": null,
+                            "firstEffect": null,
+                            "firstUpdate": null,
+                            "lastCapturedEffect": null,
+                            "lastCapturedUpdate": null,
+                            "lastEffect": null,
+                            "lastUpdate": null,
+                          },
+                        },
+                        "pendingProps": Object {
+                          "Component": [Function],
+                          "context": null,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "ref": null,
+                        "return": FiberNode {
+                          "_debugHookTypes": null,
+                          "_debugID": 60,
+                          "_debugIsCurrentlyTiming": false,
+                          "_debugOwner": null,
+                          "_debugSource": null,
+                          "actualDuration": 0,
+                          "actualStartTime": -1,
+                          "alternate": FiberNode {
+                            "_debugHookTypes": null,
+                            "_debugID": 60,
+                            "_debugIsCurrentlyTiming": false,
+                            "_debugOwner": null,
+                            "_debugSource": null,
+                            "actualDuration": 0,
+                            "actualStartTime": -1,
+                            "alternate": [Circular],
+                            "child": null,
+                            "childExpirationTime": 0,
+                            "contextDependencies": null,
+                            "effectTag": 0,
+                            "elementType": null,
+                            "expirationTime": 1073741823,
+                            "firstEffect": null,
+                            "index": 0,
+                            "key": null,
+                            "lastEffect": null,
+                            "memoizedProps": null,
+                            "memoizedState": null,
+                            "mode": 0,
+                            "nextEffect": null,
+                            "pendingProps": null,
+                            "ref": null,
+                            "return": null,
+                            "selfBaseDuration": 0,
+                            "sibling": null,
+                            "stateNode": Object {
+                              "containerInfo": <div />,
+                              "context": Object {},
+                              "current": [Circular],
+                              "didError": false,
+                              "earliestPendingTime": 0,
+                              "earliestSuspendedTime": 0,
+                              "expirationTime": 0,
+                              "finishedWork": null,
+                              "firstBatch": null,
+                              "hydrate": false,
+                              "interactionThreadID": 15,
+                              "latestPendingTime": 0,
+                              "latestPingedTime": 0,
+                              "latestSuspendedTime": 0,
+                              "memoizedInteractions": Set {},
+                              "nextExpirationTimeToWorkOn": 0,
+                              "nextScheduledRoot": null,
+                              "pendingChildren": null,
+                              "pendingCommitExpirationTime": 0,
+                              "pendingContext": null,
+                              "pendingInteractionMap": Map {},
+                              "pingCache": null,
+                              "timeoutHandle": -1,
+                            },
+                            "tag": 3,
+                            "treeBaseDuration": 0,
+                            "type": null,
+                            "updateQueue": Object {
+                              "baseState": null,
+                              "firstCapturedEffect": null,
+                              "firstCapturedUpdate": null,
+                              "firstEffect": null,
+                              "firstUpdate": Object {
+                                "callback": null,
+                                "expirationTime": 1073741823,
+                                "next": null,
+                                "nextEffect": null,
+                                "payload": Object {
+                                  "element": <WrapperComponent
+                                    Component={[Function]}
+                                    context={null}
+                                    props={
+                                      Object {
+                                        "children": <AuthenticatedRoute
+                                          authenticated={true}
+                                          component={[Function]}
+                                          path="/dashboard"
+                                        />,
+                                      }
+                                    }
+                                    wrappingComponentProps={null}
+                                  />,
+                                },
+                                "tag": 0,
+                              },
+                              "lastCapturedEffect": null,
+                              "lastCapturedUpdate": null,
+                              "lastEffect": null,
+                              "lastUpdate": Object {
+                                "callback": null,
+                                "expirationTime": 1073741823,
+                                "next": null,
+                                "nextEffect": null,
+                                "payload": Object {
+                                  "element": <WrapperComponent
+                                    Component={[Function]}
+                                    context={null}
+                                    props={
+                                      Object {
+                                        "children": <AuthenticatedRoute
+                                          authenticated={true}
+                                          component={[Function]}
+                                          path="/dashboard"
+                                        />,
+                                      }
+                                    }
+                                    wrappingComponentProps={null}
+                                  />,
+                                },
+                                "tag": 0,
+                              },
+                            },
+                          },
+                          "child": [Circular],
+                          "childExpirationTime": 0,
+                          "contextDependencies": null,
+                          "effectTag": 32,
+                          "elementType": null,
+                          "expirationTime": 0,
+                          "firstEffect": [Circular],
+                          "index": 0,
+                          "key": null,
+                          "lastEffect": [Circular],
+                          "memoizedProps": null,
+                          "memoizedState": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={
+                                Object {
+                                  "children": <AuthenticatedRoute
+                                    authenticated={true}
+                                    component={[Function]}
+                                    path="/dashboard"
+                                  />,
+                                }
+                              }
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "mode": 0,
+                          "nextEffect": null,
+                          "pendingProps": null,
+                          "ref": null,
+                          "return": null,
+                          "selfBaseDuration": 0,
+                          "sibling": null,
+                          "stateNode": Object {
+                            "containerInfo": <div />,
+                            "context": Object {},
+                            "current": [Circular],
+                            "didError": false,
+                            "earliestPendingTime": 0,
+                            "earliestSuspendedTime": 0,
+                            "expirationTime": 0,
+                            "finishedWork": null,
+                            "firstBatch": null,
+                            "hydrate": false,
+                            "interactionThreadID": 15,
+                            "latestPendingTime": 0,
+                            "latestPingedTime": 0,
+                            "latestSuspendedTime": 0,
+                            "memoizedInteractions": Set {},
+                            "nextExpirationTimeToWorkOn": 0,
+                            "nextScheduledRoot": null,
+                            "pendingChildren": null,
+                            "pendingCommitExpirationTime": 0,
+                            "pendingContext": null,
+                            "pendingInteractionMap": Map {},
+                            "pingCache": null,
+                            "timeoutHandle": -1,
+                          },
+                          "tag": 3,
+                          "treeBaseDuration": 0,
+                          "type": null,
+                          "updateQueue": Object {
+                            "baseState": Object {
+                              "element": <WrapperComponent
+                                Component={[Function]}
+                                context={null}
+                                props={
+                                  Object {
+                                    "children": <AuthenticatedRoute
+                                      authenticated={true}
+                                      component={[Function]}
+                                      path="/dashboard"
+                                    />,
+                                  }
+                                }
+                                wrappingComponentProps={null}
+                              />,
+                            },
+                            "firstCapturedEffect": null,
+                            "firstCapturedUpdate": null,
+                            "firstEffect": null,
+                            "firstUpdate": null,
+                            "lastCapturedEffect": null,
+                            "lastCapturedUpdate": null,
+                            "lastEffect": null,
+                            "lastUpdate": null,
+                          },
+                        },
+                        "selfBaseDuration": 0,
+                        "sibling": null,
+                        "stateNode": WrapperComponent {
+                          "_reactInternalFiber": [Circular],
+                          "_reactInternalInstance": Object {},
+                          "context": Object {},
+                          "props": Object {
+                            "Component": [Function],
+                            "context": null,
+                            "props": Object {
+                              "children": <AuthenticatedRoute
+                                authenticated={true}
+                                component={[Function]}
+                                path="/dashboard"
+                              />,
+                            },
+                            "wrappingComponentProps": null,
+                          },
+                          "refs": Object {},
+                          "rootFinderInstance": null,
+                          "state": Object {
+                            "context": null,
+                            "mount": true,
+                            "props": Object {
+                              "children": <AuthenticatedRoute
+                                authenticated={true}
+                                component={[Function]}
+                                path="/dashboard"
+                              />,
+                            },
+                            "wrappingComponentProps": null,
+                          },
+                          "updater": Object {
+                            "enqueueForceUpdate": [Function],
+                            "enqueueReplaceState": [Function],
+                            "enqueueSetState": [Function],
+                            "isMounted": [Function],
+                          },
+                        },
+                        "tag": 1,
+                        "treeBaseDuration": 0,
+                        "type": [Function],
+                        "updateQueue": null,
+                      },
+                      "_debugSource": null,
+                      "actualDuration": 0,
+                      "actualStartTime": -1,
+                      "alternate": null,
+                      "child": [Circular],
+                      "childExpirationTime": 0,
+                      "contextDependencies": null,
+                      "effectTag": 1,
+                      "elementType": [Function],
+                      "expirationTime": 0,
+                      "firstEffect": null,
+                      "index": 0,
+                      "key": null,
+                      "lastEffect": null,
+                      "memoizedProps": Object {
+                        "children": <AuthenticatedRoute
+                          authenticated={true}
+                          component={[Function]}
+                          path="/dashboard"
+                        />,
+                      },
+                      "memoizedState": null,
+                      "mode": 0,
+                      "nextEffect": null,
+                      "pendingProps": Object {
+                        "children": <AuthenticatedRoute
+                          authenticated={true}
+                          component={[Function]}
+                          path="/dashboard"
+                        />,
+                      },
+                      "ref": null,
+                      "return": FiberNode {
+                        "_debugHookTypes": null,
+                        "_debugID": 62,
+                        "_debugIsCurrentlyTiming": false,
+                        "_debugOwner": null,
+                        "_debugSource": null,
+                        "actualDuration": 0,
+                        "actualStartTime": -1,
+                        "alternate": null,
+                        "child": [Circular],
+                        "childExpirationTime": 0,
+                        "contextDependencies": null,
+                        "effectTag": 1,
+                        "elementType": [Function],
+                        "expirationTime": 0,
+                        "firstEffect": null,
+                        "index": 0,
+                        "key": null,
+                        "lastEffect": null,
+                        "memoizedProps": Object {
+                          "Component": [Function],
+                          "context": null,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "memoizedState": Object {
+                          "context": null,
+                          "mount": true,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "mode": 0,
+                        "nextEffect": FiberNode {
+                          "_debugHookTypes": null,
+                          "_debugID": 60,
+                          "_debugIsCurrentlyTiming": false,
+                          "_debugOwner": null,
+                          "_debugSource": null,
+                          "actualDuration": 0,
+                          "actualStartTime": -1,
+                          "alternate": FiberNode {
+                            "_debugHookTypes": null,
+                            "_debugID": 60,
+                            "_debugIsCurrentlyTiming": false,
+                            "_debugOwner": null,
+                            "_debugSource": null,
+                            "actualDuration": 0,
+                            "actualStartTime": -1,
+                            "alternate": [Circular],
+                            "child": null,
+                            "childExpirationTime": 0,
+                            "contextDependencies": null,
+                            "effectTag": 0,
+                            "elementType": null,
+                            "expirationTime": 1073741823,
+                            "firstEffect": null,
+                            "index": 0,
+                            "key": null,
+                            "lastEffect": null,
+                            "memoizedProps": null,
+                            "memoizedState": null,
+                            "mode": 0,
+                            "nextEffect": null,
+                            "pendingProps": null,
+                            "ref": null,
+                            "return": null,
+                            "selfBaseDuration": 0,
+                            "sibling": null,
+                            "stateNode": Object {
+                              "containerInfo": <div />,
+                              "context": Object {},
+                              "current": [Circular],
+                              "didError": false,
+                              "earliestPendingTime": 0,
+                              "earliestSuspendedTime": 0,
+                              "expirationTime": 0,
+                              "finishedWork": null,
+                              "firstBatch": null,
+                              "hydrate": false,
+                              "interactionThreadID": 15,
+                              "latestPendingTime": 0,
+                              "latestPingedTime": 0,
+                              "latestSuspendedTime": 0,
+                              "memoizedInteractions": Set {},
+                              "nextExpirationTimeToWorkOn": 0,
+                              "nextScheduledRoot": null,
+                              "pendingChildren": null,
+                              "pendingCommitExpirationTime": 0,
+                              "pendingContext": null,
+                              "pendingInteractionMap": Map {},
+                              "pingCache": null,
+                              "timeoutHandle": -1,
+                            },
+                            "tag": 3,
+                            "treeBaseDuration": 0,
+                            "type": null,
+                            "updateQueue": Object {
+                              "baseState": null,
+                              "firstCapturedEffect": null,
+                              "firstCapturedUpdate": null,
+                              "firstEffect": null,
+                              "firstUpdate": Object {
+                                "callback": null,
+                                "expirationTime": 1073741823,
+                                "next": null,
+                                "nextEffect": null,
+                                "payload": Object {
+                                  "element": <WrapperComponent
+                                    Component={[Function]}
+                                    context={null}
+                                    props={
+                                      Object {
+                                        "children": <AuthenticatedRoute
+                                          authenticated={true}
+                                          component={[Function]}
+                                          path="/dashboard"
+                                        />,
+                                      }
+                                    }
+                                    wrappingComponentProps={null}
+                                  />,
+                                },
+                                "tag": 0,
+                              },
+                              "lastCapturedEffect": null,
+                              "lastCapturedUpdate": null,
+                              "lastEffect": null,
+                              "lastUpdate": Object {
+                                "callback": null,
+                                "expirationTime": 1073741823,
+                                "next": null,
+                                "nextEffect": null,
+                                "payload": Object {
+                                  "element": <WrapperComponent
+                                    Component={[Function]}
+                                    context={null}
+                                    props={
+                                      Object {
+                                        "children": <AuthenticatedRoute
+                                          authenticated={true}
+                                          component={[Function]}
+                                          path="/dashboard"
+                                        />,
+                                      }
+                                    }
+                                    wrappingComponentProps={null}
+                                  />,
+                                },
+                                "tag": 0,
+                              },
+                            },
+                          },
+                          "child": [Circular],
+                          "childExpirationTime": 0,
+                          "contextDependencies": null,
+                          "effectTag": 32,
+                          "elementType": null,
+                          "expirationTime": 0,
+                          "firstEffect": [Circular],
+                          "index": 0,
+                          "key": null,
+                          "lastEffect": [Circular],
+                          "memoizedProps": null,
+                          "memoizedState": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={
+                                Object {
+                                  "children": <AuthenticatedRoute
+                                    authenticated={true}
+                                    component={[Function]}
+                                    path="/dashboard"
+                                  />,
+                                }
+                              }
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "mode": 0,
+                          "nextEffect": null,
+                          "pendingProps": null,
+                          "ref": null,
+                          "return": null,
+                          "selfBaseDuration": 0,
+                          "sibling": null,
+                          "stateNode": Object {
+                            "containerInfo": <div />,
+                            "context": Object {},
+                            "current": [Circular],
+                            "didError": false,
+                            "earliestPendingTime": 0,
+                            "earliestSuspendedTime": 0,
+                            "expirationTime": 0,
+                            "finishedWork": null,
+                            "firstBatch": null,
+                            "hydrate": false,
+                            "interactionThreadID": 15,
+                            "latestPendingTime": 0,
+                            "latestPingedTime": 0,
+                            "latestSuspendedTime": 0,
+                            "memoizedInteractions": Set {},
+                            "nextExpirationTimeToWorkOn": 0,
+                            "nextScheduledRoot": null,
+                            "pendingChildren": null,
+                            "pendingCommitExpirationTime": 0,
+                            "pendingContext": null,
+                            "pendingInteractionMap": Map {},
+                            "pingCache": null,
+                            "timeoutHandle": -1,
+                          },
+                          "tag": 3,
+                          "treeBaseDuration": 0,
+                          "type": null,
+                          "updateQueue": Object {
+                            "baseState": Object {
+                              "element": <WrapperComponent
+                                Component={[Function]}
+                                context={null}
+                                props={
+                                  Object {
+                                    "children": <AuthenticatedRoute
+                                      authenticated={true}
+                                      component={[Function]}
+                                      path="/dashboard"
+                                    />,
+                                  }
+                                }
+                                wrappingComponentProps={null}
+                              />,
+                            },
+                            "firstCapturedEffect": null,
+                            "firstCapturedUpdate": null,
+                            "firstEffect": null,
+                            "firstUpdate": null,
+                            "lastCapturedEffect": null,
+                            "lastCapturedUpdate": null,
+                            "lastEffect": null,
+                            "lastUpdate": null,
+                          },
+                        },
+                        "pendingProps": Object {
+                          "Component": [Function],
+                          "context": null,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "ref": null,
+                        "return": FiberNode {
+                          "_debugHookTypes": null,
+                          "_debugID": 60,
+                          "_debugIsCurrentlyTiming": false,
+                          "_debugOwner": null,
+                          "_debugSource": null,
+                          "actualDuration": 0,
+                          "actualStartTime": -1,
+                          "alternate": FiberNode {
+                            "_debugHookTypes": null,
+                            "_debugID": 60,
+                            "_debugIsCurrentlyTiming": false,
+                            "_debugOwner": null,
+                            "_debugSource": null,
+                            "actualDuration": 0,
+                            "actualStartTime": -1,
+                            "alternate": [Circular],
+                            "child": null,
+                            "childExpirationTime": 0,
+                            "contextDependencies": null,
+                            "effectTag": 0,
+                            "elementType": null,
+                            "expirationTime": 1073741823,
+                            "firstEffect": null,
+                            "index": 0,
+                            "key": null,
+                            "lastEffect": null,
+                            "memoizedProps": null,
+                            "memoizedState": null,
+                            "mode": 0,
+                            "nextEffect": null,
+                            "pendingProps": null,
+                            "ref": null,
+                            "return": null,
+                            "selfBaseDuration": 0,
+                            "sibling": null,
+                            "stateNode": Object {
+                              "containerInfo": <div />,
+                              "context": Object {},
+                              "current": [Circular],
+                              "didError": false,
+                              "earliestPendingTime": 0,
+                              "earliestSuspendedTime": 0,
+                              "expirationTime": 0,
+                              "finishedWork": null,
+                              "firstBatch": null,
+                              "hydrate": false,
+                              "interactionThreadID": 15,
+                              "latestPendingTime": 0,
+                              "latestPingedTime": 0,
+                              "latestSuspendedTime": 0,
+                              "memoizedInteractions": Set {},
+                              "nextExpirationTimeToWorkOn": 0,
+                              "nextScheduledRoot": null,
+                              "pendingChildren": null,
+                              "pendingCommitExpirationTime": 0,
+                              "pendingContext": null,
+                              "pendingInteractionMap": Map {},
+                              "pingCache": null,
+                              "timeoutHandle": -1,
+                            },
+                            "tag": 3,
+                            "treeBaseDuration": 0,
+                            "type": null,
+                            "updateQueue": Object {
+                              "baseState": null,
+                              "firstCapturedEffect": null,
+                              "firstCapturedUpdate": null,
+                              "firstEffect": null,
+                              "firstUpdate": Object {
+                                "callback": null,
+                                "expirationTime": 1073741823,
+                                "next": null,
+                                "nextEffect": null,
+                                "payload": Object {
+                                  "element": <WrapperComponent
+                                    Component={[Function]}
+                                    context={null}
+                                    props={
+                                      Object {
+                                        "children": <AuthenticatedRoute
+                                          authenticated={true}
+                                          component={[Function]}
+                                          path="/dashboard"
+                                        />,
+                                      }
+                                    }
+                                    wrappingComponentProps={null}
+                                  />,
+                                },
+                                "tag": 0,
+                              },
+                              "lastCapturedEffect": null,
+                              "lastCapturedUpdate": null,
+                              "lastEffect": null,
+                              "lastUpdate": Object {
+                                "callback": null,
+                                "expirationTime": 1073741823,
+                                "next": null,
+                                "nextEffect": null,
+                                "payload": Object {
+                                  "element": <WrapperComponent
+                                    Component={[Function]}
+                                    context={null}
+                                    props={
+                                      Object {
+                                        "children": <AuthenticatedRoute
+                                          authenticated={true}
+                                          component={[Function]}
+                                          path="/dashboard"
+                                        />,
+                                      }
+                                    }
+                                    wrappingComponentProps={null}
+                                  />,
+                                },
+                                "tag": 0,
+                              },
+                            },
+                          },
+                          "child": [Circular],
+                          "childExpirationTime": 0,
+                          "contextDependencies": null,
+                          "effectTag": 32,
+                          "elementType": null,
+                          "expirationTime": 0,
+                          "firstEffect": [Circular],
+                          "index": 0,
+                          "key": null,
+                          "lastEffect": [Circular],
+                          "memoizedProps": null,
+                          "memoizedState": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={
+                                Object {
+                                  "children": <AuthenticatedRoute
+                                    authenticated={true}
+                                    component={[Function]}
+                                    path="/dashboard"
+                                  />,
+                                }
+                              }
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "mode": 0,
+                          "nextEffect": null,
+                          "pendingProps": null,
+                          "ref": null,
+                          "return": null,
+                          "selfBaseDuration": 0,
+                          "sibling": null,
+                          "stateNode": Object {
+                            "containerInfo": <div />,
+                            "context": Object {},
+                            "current": [Circular],
+                            "didError": false,
+                            "earliestPendingTime": 0,
+                            "earliestSuspendedTime": 0,
+                            "expirationTime": 0,
+                            "finishedWork": null,
+                            "firstBatch": null,
+                            "hydrate": false,
+                            "interactionThreadID": 15,
+                            "latestPendingTime": 0,
+                            "latestPingedTime": 0,
+                            "latestSuspendedTime": 0,
+                            "memoizedInteractions": Set {},
+                            "nextExpirationTimeToWorkOn": 0,
+                            "nextScheduledRoot": null,
+                            "pendingChildren": null,
+                            "pendingCommitExpirationTime": 0,
+                            "pendingContext": null,
+                            "pendingInteractionMap": Map {},
+                            "pingCache": null,
+                            "timeoutHandle": -1,
+                          },
+                          "tag": 3,
+                          "treeBaseDuration": 0,
+                          "type": null,
+                          "updateQueue": Object {
+                            "baseState": Object {
+                              "element": <WrapperComponent
+                                Component={[Function]}
+                                context={null}
+                                props={
+                                  Object {
+                                    "children": <AuthenticatedRoute
+                                      authenticated={true}
+                                      component={[Function]}
+                                      path="/dashboard"
+                                    />,
+                                  }
+                                }
+                                wrappingComponentProps={null}
+                              />,
+                            },
+                            "firstCapturedEffect": null,
+                            "firstCapturedUpdate": null,
+                            "firstEffect": null,
+                            "firstUpdate": null,
+                            "lastCapturedEffect": null,
+                            "lastCapturedUpdate": null,
+                            "lastEffect": null,
+                            "lastUpdate": null,
+                          },
+                        },
+                        "selfBaseDuration": 0,
+                        "sibling": null,
+                        "stateNode": WrapperComponent {
+                          "_reactInternalFiber": [Circular],
+                          "_reactInternalInstance": Object {},
+                          "context": Object {},
+                          "props": Object {
+                            "Component": [Function],
+                            "context": null,
+                            "props": Object {
+                              "children": <AuthenticatedRoute
+                                authenticated={true}
+                                component={[Function]}
+                                path="/dashboard"
+                              />,
+                            },
+                            "wrappingComponentProps": null,
+                          },
+                          "refs": Object {},
+                          "rootFinderInstance": null,
+                          "state": Object {
+                            "context": null,
+                            "mount": true,
+                            "props": Object {
+                              "children": <AuthenticatedRoute
+                                authenticated={true}
+                                component={[Function]}
+                                path="/dashboard"
+                              />,
+                            },
+                            "wrappingComponentProps": null,
+                          },
+                          "updater": Object {
+                            "enqueueForceUpdate": [Function],
+                            "enqueueReplaceState": [Function],
+                            "enqueueSetState": [Function],
+                            "isMounted": [Function],
+                          },
+                        },
+                        "tag": 1,
+                        "treeBaseDuration": 0,
+                        "type": [Function],
+                        "updateQueue": null,
+                      },
+                      "selfBaseDuration": 0,
+                      "sibling": null,
+                      "stateNode": BrowserRouter {
+                        "_reactInternalFiber": [Circular],
+                        "_reactInternalInstance": Object {},
+                        "context": Object {},
+                        "history": Object {
+                          "action": "POP",
+                          "block": [Function],
+                          "createHref": [Function],
+                          "go": [Function],
+                          "goBack": [Function],
+                          "goForward": [Function],
+                          "length": 1,
+                          "listen": [Function],
+                          "location": Object {
+                            "hash": "",
+                            "pathname": "/",
+                            "search": "",
+                            "state": undefined,
+                          },
+                          "push": [Function],
+                          "replace": [Function],
+                        },
+                        "props": Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        },
+                        "refs": Object {},
+                        "state": null,
+                        "updater": Object {
+                          "enqueueForceUpdate": [Function],
+                          "enqueueReplaceState": [Function],
+                          "enqueueSetState": [Function],
+                          "isMounted": [Function],
+                        },
+                      },
+                      "tag": 1,
+                      "treeBaseDuration": 0,
+                      "type": [Function],
+                      "updateQueue": null,
+                    },
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": Router {
+                      "__reactInternalMemoizedMaskedChildContext": Object {
+                        "router": undefined,
+                      },
+                      "__reactInternalMemoizedMergedChildContext": Object {
+                        "router": Object {
+                          "history": Object {
+                            "action": "POP",
+                            "block": [Function],
+                            "createHref": [Function],
+                            "go": [Function],
+                            "goBack": [Function],
+                            "goForward": [Function],
+                            "length": 1,
+                            "listen": [Function],
+                            "location": Object {
+                              "hash": "",
+                              "pathname": "/",
+                              "search": "",
+                              "state": undefined,
+                            },
+                            "push": [Function],
+                            "replace": [Function],
+                          },
+                          "route": Object {
+                            "location": Object {
+                              "hash": "",
+                              "pathname": "/",
+                              "search": "",
+                              "state": undefined,
+                            },
+                            "match": Object {
+                              "isExact": true,
+                              "params": Object {},
+                              "path": "/",
+                              "url": "/",
+                            },
+                          },
+                        },
+                      },
+                      "__reactInternalMemoizedUnmaskedChildContext": Object {},
+                      "_reactInternalFiber": [Circular],
+                      "_reactInternalInstance": Object {},
+                      "context": Object {
+                        "router": undefined,
+                      },
+                      "props": Object {
+                        "children": <AuthenticatedRoute
+                          authenticated={true}
+                          component={[Function]}
+                          path="/dashboard"
+                        />,
+                        "history": Object {
+                          "action": "POP",
+                          "block": [Function],
+                          "createHref": [Function],
+                          "go": [Function],
+                          "goBack": [Function],
+                          "goForward": [Function],
+                          "length": 1,
+                          "listen": [Function],
+                          "location": Object {
+                            "hash": "",
+                            "pathname": "/",
+                            "search": "",
+                            "state": undefined,
+                          },
+                          "push": [Function],
+                          "replace": [Function],
+                        },
+                      },
+                      "refs": Object {},
+                      "state": Object {
+                        "match": Object {
+                          "isExact": true,
+                          "params": Object {},
+                          "path": "/",
+                          "url": "/",
+                        },
+                      },
+                      "unlisten": [Function],
+                      "updater": Object {
+                        "enqueueForceUpdate": [Function],
+                        "enqueueReplaceState": [Function],
+                        "enqueueSetState": [Function],
+                        "isMounted": [Function],
+                      },
+                    },
+                    "tag": 1,
+                    "treeBaseDuration": 0,
+                    "type": [Function],
+                    "updateQueue": null,
+                  },
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": null,
+                  "tag": 0,
+                  "treeBaseDuration": 0,
+                  "type": [Function],
+                  "updateQueue": null,
+                },
+                "selfBaseDuration": 0,
+                "sibling": null,
+                "stateNode": [Circular],
+                "tag": 1,
+                "treeBaseDuration": 0,
+                "type": [Function],
+                "updateQueue": null,
+              },
+              "_reactInternalInstance": Object {},
+              "context": Object {
+                "router": Object {
+                  "history": Object {
+                    "action": "POP",
+                    "block": [Function],
+                    "createHref": [Function],
+                    "go": [Function],
+                    "goBack": [Function],
+                    "goForward": [Function],
+                    "length": 1,
+                    "listen": [Function],
+                    "location": Object {
+                      "hash": "",
+                      "pathname": "/",
+                      "search": "",
+                      "state": undefined,
+                    },
+                    "push": [Function],
+                    "replace": [Function],
+                  },
+                  "route": Object {
+                    "location": Object {
+                      "hash": "",
+                      "pathname": "/",
+                      "search": "",
+                      "state": undefined,
+                    },
+                    "match": Object {
+                      "isExact": true,
+                      "params": Object {},
+                      "path": "/",
+                      "url": "/",
+                    },
+                  },
+                },
+              },
+              "props": Object {
+                "path": "/dashboard",
+                "render": [Function],
+              },
+              "refs": Object {},
+              "state": Object {
+                "match": null,
+              },
+              "updater": Object {
+                "enqueueForceUpdate": [Function],
+                "enqueueReplaceState": [Function],
+                "enqueueSetState": [Function],
+                "isMounted": [Function],
+              },
+            },
+            "key": undefined,
+            "nodeType": "class",
+            "props": Object {
+              "path": "/dashboard",
+              "render": [Function],
+            },
+            "ref": null,
+            "rendered": null,
+            "type": [Function],
+          },
+          "type": [Function],
+        },
+        "type": [Function],
+      },
+      "type": [Function],
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+        "legacyContextMode": "parent",
+        "lifecycles": Object {
+          "componentDidUpdate": Object {
+            "onSetState": true,
+          },
+          "getChildContext": Object {
+            "calledByRenderer": false,
+          },
+          "getDerivedStateFromError": true,
+          "getDerivedStateFromProps": Object {
+            "hasShouldComponentUpdateBug": false,
+          },
+          "getSnapshotBeforeUpdate": true,
+          "setState": Object {
+            "skipsComponentDidUpdateOnNullish": true,
+          },
+        },
+      },
+    },
+  },
+}
+`;

--- a/src/components/Dashboard/index.jsx
+++ b/src/components/Dashboard/index.jsx
@@ -117,22 +117,25 @@ class Dashboard extends React.Component {
           removeCurrentUser={removeCurrentUser}
           activeTab="dashboard"
         />
-        <Card
-          classes="engagement"
-          title="Engagement Trends"
-          component={() => {}}
-        />
-        <Card
-          classes="upSelling"
-          title="Upselling Partners"
-          component={this.renderUpsellingStats(partnerStats)}
-        />
-        <Card
-          classes="activity-feed-card"
-          component={() => ActivityFeed(this.state)}
-          title="Activity Feeds"
-        />
-        <PartnerStats />
+        <div className="dashboard-items">
+          <Card
+            classes="engagement"
+            title="Engagement Trends"
+            component={() => {}}
+          />
+          <Card
+            classes="upSelling"
+            title="Upselling Partners"
+            component={this.renderUpsellingStats(partnerStats)}
+          />
+          <Card
+            classes="activity-feed-card"
+            component={() => ActivityFeed(this.state)}
+            title="Activity Feeds"
+          />
+          <PartnerStats />
+
+        </div>
       </div>
     );
   }

--- a/src/components/Pagination/index.scss
+++ b/src/components/Pagination/index.scss
@@ -48,6 +48,7 @@
  .page-panel{
   display: flex;
   justify-content: center;
+  flex-direction: row;
   place-items: center;
   margin-left: 20px;
   margin-bottom: 6px;

--- a/src/components/Pagination/index.scss
+++ b/src/components/Pagination/index.scss
@@ -100,3 +100,58 @@
     margin-bottom: 0.5rem;
   }
 }
+
+@media only screen and (max-width: 600px) {
+  #header{
+    display: flex;
+    flex-direction: column;
+  }
+  .pills{
+    display: flex !important;
+    flex-direction: column ;
+    align-items: stretch;
+  }
+
+  #header .pills .nav-links {
+    margin-right: 1em;
+    margin-top: 0.5em;
+    padding-left: 50px;
+    padding-right: 50px;;
+    margin-top: 10px;
+}
+
+.user-info-container{
+  margin-top: 10px !important;
+}
+.user-name{
+  padding-left: 50px !important;
+}
+
+.dashboard-items{
+  display: flex;
+  flex-direction: column;
+}
+.partner-stats-container{
+  display: flex !important;
+  flex-direction: column;
+}
+.partner-stats-container .partner-stats {
+    margin-top: 10px;
+    width: 100% !important;
+}
+.dashboard-card{
+  width:90% !important;
+}
+.modal-body{
+  width: 100%;
+}
+.developer-info {
+    margin: 10px;
+}
+.fa, .fa-link{
+  display: none;
+}
+.channel-tabs-group, .channels-tab-background {
+    padding-right: 8.75rem;
+}
+}

--- a/src/components/developerCards/developerCard.scss
+++ b/src/components/developerCards/developerCard.scss
@@ -158,6 +158,33 @@
 }
 
 
+@media only screen and (max-width: 600px) {
+  .card {
+    min-width: 100%;
 
+  }
+  #list-icon, .view-button-active{
+    display: none;
+  }
+  .filter-box{
+    width:325px;
+    margin-right: 30px !important;
+  }
+  .stat-container{
+    background-color: #43A047;
+    width: 100% !important;
+    margin-bottom: 5%;
+  }
+  .pagination{
+    flex-direction: column-reverse;
+  }
+
+  .filter-container {
+    display: grid;
+    justify-self: right;
+    width: 0;
+    max-width: 90%;
+}
+}
 
 


### PR DESCRIPTION
#### What does this PR do?
Makes the dashboard mobile responsive.

#### Description of Task to be completed?
The Application is not responsive when used on small devices, so this task enables the app to be usable on mobile devices as well.

#### How should this be manually tested?
- Load app in any web browser.
- In the browser dev tools enable the responsive mode so that the dashboard can be tested across different mobile browsers.
- Select different mobile devices to check the responsive nature of the app on mobile applications.



#### Any background context you want to provide?
None


#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/167486117

#### Screenshots (If applicable)
<img width="605" alt="Screenshot 2019-09-12 at 16 34 25" src="https://user-images.githubusercontent.com/12638091/64788577-67c26e80-d57b-11e9-9c9d-6a9d800d3661.png">
<img width="527" alt="Screenshot 2019-09-12 at 16 35 00" src="https://user-images.githubusercontent.com/12638091/64788584-6b55f580-d57b-11e9-801d-7b76ad1ee7a8.png">
<img width="398" alt="Screenshot 2019-09-12 at 17 57 48" src="https://user-images.githubusercontent.com/12638091/64795598-06a09800-d587-11e9-8bc8-a40f7b1c0c05.png">
<img width="436" alt="Screenshot 2019-09-12 at 17 58 34" src="https://user-images.githubusercontent.com/12638091/64795608-0dc7a600-d587-11e9-8a72-f35d24304df9.png">
