### PR TITLE
#167101210: Fix developer card component

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,15 +124,12 @@ workflows:
       - test_javascript_report:
           requires:
             - checkout_repo
-            - run_vulnerability_check
       - test_ui_flow:
           requires:
             - checkout_repo
-            - run_vulnerability_check
-            - test_javascript_report
       - deploy_staging:
           requires:
-            - checkout_repo
+            - run_vulnerability_check
             - test_javascript_report
-            # - test_ui_flow
+            - test_ui_flow
           <<: *filters

--- a/cypress/integration/filters.spec.js
+++ b/cypress/integration/filters.spec.js
@@ -7,7 +7,7 @@ import {
   stubbedPartnerOffboarding,
   stubbedDateFilter,
   onboardingFixtures,
-  offboardingFixtures
+  offboardingFixtures,
 } from '../stubs/filterStubs';
 
 
@@ -43,33 +43,33 @@ describe('Filter test', () => {
       cy.get('.filter-button')
         .click();
       cy.get('.automation-type-onboarding-label')
-        .click()
+        .click();
       cy.get('button.apply-filters')
         .click();
       cy.wait(2000);
-      cy.get('#0-id')
-        .click()
+      cy.get('#more-info-icon')
+        .click();
       cy.get('.automation-type')
         .contains('onboarding');
       cy.get('.modal-close-button-group')
         .click();
-    })
+    });
 
     it('filters data to get offboarding results only', () => {
       cy.get('.filter-button')
         .click();
       cy.get('.automation-type-offboarding-label')
-        .click()
+        .click();
       cy.get('button.apply-filters')
         .click();
       cy.wait(2000);
-      cy.get('#0-id')
-        .click()
+      cy.get('#more-info-icon')
+        .click();
       cy.get('.automation-type')
         .contains('offboarding');
       cy.get('.modal-close-button-group')
         .click();
-    })
+    });
 
     it('searches for a specified engineer name for onboarding activities ', () => {
       cy.get('input.search-input')
@@ -81,19 +81,19 @@ describe('Filter test', () => {
       cy.get('.search-by-fellow-label')
         .click();
       cy.get('.automation-type-onboarding-label')
-        .click()
+        .click();
       cy.get('button.apply-filters')
         .click();
       cy.wait(2000);
-      cy.get('#0-id')
-        .click()
+      cy.get('#more-info-icon')
+        .click();
       cy.get('.developer-name')
-        .contains('Kory')
+        .contains('Kory');
       cy.get('.automation-type')
         .contains('onboarding');
       cy.get('.modal-close-button-group')
         .click();
-    })
+    });
 
     it('searches for a specified engineer name for offboarding activities ', () => {
       cy.get('input.search-input')
@@ -105,19 +105,19 @@ describe('Filter test', () => {
       cy.get('.search-by-fellow-label')
         .click();
       cy.get('.automation-type-offboarding-label')
-        .click()
+        .click();
       cy.get('button.apply-filters')
         .click();
       cy.wait(2000);
-      cy.get('#0-id')
-        .click()
+      cy.get('#more-info-icon')
+        .click();
       cy.get('.developer-name')
-        .contains('Annabelle')
+        .contains('Annabelle');
       cy.get('.automation-type')
         .contains('offboarding');
       cy.get('.modal-close-button-group')
         .click();
-    })
+    });
 
     it('searches for a specified partner name for onboarding activities ', () => {
       cy.get('input.search-input')
@@ -129,19 +129,19 @@ describe('Filter test', () => {
       cy.get('.search-by-partner-label')
         .click();
       cy.get('.automation-type-onboarding-label')
-        .click()
+        .click();
       cy.get('button.apply-filters')
         .click();
       cy.wait(2000);
-      cy.get('#0-id')
-        .click()
+      cy.get('#more-info-icon')
+        .click();
       cy.get('.partner-name')
-        .contains('Fadel')
+        .contains('Fadel');
       cy.get('.automation-type')
         .contains('onboarding');
       cy.get('.modal-close-button-group')
         .click();
-    })
+    });
 
     it('searches for a specified partner name for offboarding activities ', () => {
       cy.get('input.search-input')
@@ -153,40 +153,40 @@ describe('Filter test', () => {
       cy.get('.search-by-partner-label')
         .click();
       cy.get('.automation-type-offboarding-label')
-        .click()
+        .click();
       cy.get('button.apply-filters')
         .click();
       cy.wait(2000);
-      cy.get('#0-id')
-        .click()
+      cy.get('#more-info-icon')
+        .click();
       cy.get('.partner-name')
-        .contains('Lincon')
+        .contains('Lincon');
       cy.get('.automation-type')
         .contains('offboarding');
       cy.get('.modal-close-button-group')
         .click();
-    })
+    });
 
     it('filters by automation date ', () => {
       cy.get('.filter-button')
         .click();
       cy.get('#from')
         .click()
-        .type('May 01, 2019')
+        .type('May 01, 2019');
       cy.get('#to')
         .click()
-        .type('May 01, 2019')
+        .type('May 01, 2019');
       cy.get('.filter-dropdown-parent')
         .click();
       cy.get('button.apply-filters')
         .click();
       cy.wait(2000);
-      cy.get('#0-id')
-        .click()
+      cy.get('#more-info-icon')
+        .click();
       cy.get('.automation-date')
-        .contains('5/1/2019')
+        .contains('5/1/2019');
       cy.get('.modal-close-button-group')
         .click();
-    })
-  });  
+    });
+  });
 });

--- a/src/components/AutomationDetails/index.jsx
+++ b/src/components/AutomationDetails/index.jsx
@@ -31,7 +31,7 @@ class AutomationDetails extends PureComponent {
     const nokoStatus = !!(nokoAutomations && nokoAutomations.slackActivities === 'success');
     const name = _.split(modalContent.fellowName, ',');
     const firstInitial = (modalContent.fellowName && name[0].charAt(0)) || '';
-    const secondInitial = (modalContent.fellowName && name[1].charAt(1)) || '';
+    const secondInitial = (modalContent.fellowName && name[1] && name[1].charAt(1)) || '';
     return (
       <div className="developer-info">
         <div className="devPicture">
@@ -165,7 +165,7 @@ class AutomationDetails extends PureComponent {
   ) => {
     const automations = modalContent[automationType];
     const appActivities = (automations && automations[automationActivities]) || [];
-    return appActivities.map((content, index )=> (
+    return appActivities.map((content, index) => (
       <div key={index}>
         <div className="automation-content">
           <div className="content-row name">{content[contentData]}</div>

--- a/src/components/developerCards/index.jsx
+++ b/src/components/developerCards/index.jsx
@@ -81,7 +81,7 @@ class DeveloperCard extends Component {
     const name = card.fellowName;
     const newName = _.split(name, ',');
     const firstInitials = newName[0].charAt(0);
-    const secondInitials = newName[1].charAt(1);
+    const secondInitials = newName[1] && newName[1].charAt(1);
     return (
       <div className="card" key={card.id}>
         <div className="info-cont">

--- a/src/fixtures/fixtures.js
+++ b/src/fixtures/fixtures.js
@@ -1,4 +1,4 @@
-import moment from "moment";
+import moment from 'moment';
 
 const sampleReports = {
   data: [
@@ -23,7 +23,7 @@ const sampleReports = {
         status: 'success',
         emailActivities: [10],
       },
-      updatedAt: moment("2017-09-29", "YYYY-MM-DD"),
+      updatedAt: moment('2017-09-29', 'YYYY-MM-DD'),
     },
     {
       id: 8631,


### PR DESCRIPTION
#### What does this PR do?
This PR fixes the `developerCard` Component
     - each (visual) card should be a developer-card component
     - details in the modal should match the details of the automation being viewed
     - Fix failing crash when a user navigates to the last record using the application pagination buttons
     - Fix failing end to end tests
     - Modify the workflow setup in circleci configuration script to reduce build time

#### Description of Task to be completed?
#####  Current behaviour
- There is only one developer-card component ever in the cards view, which then renders each automation as a div within itself.
- After viewing the details of automation, subsequent automation details get mixed up with previously viewed automation details
##### Expected
- Each (visual) card should be a developer-card component
- The details in the modal should match the details of the automation being viewed
#### How should this be manually tested?
##### First 
- Run `yarn` in the frontend to install new dependencies
- Log in to the application and click on the card view
- Inspect and go to react developer tools
- Search for `DeveloperCard` component and you will realize that there are individual `developerCard` components for each card.
##### second
- Click on info icon for different cards and you will realize that details in the modal match the details of the automation being viewed.
#### Any background context you want to provide?
- The PR works with this [backend PR](https://github.com/andela/bp-esa-backend/pull/118)
- Change the value of the Id- that is being searched for when the end to end tests are running

#### What are the relevant pivotal tracker stories?
[167101210](https://www.pivotaltracker.com/story/show/167101210)
#### Postman Documentation
- N/A

#### Screenshots (If applicable)
<img width="1440" alt="Screen Shot 2019-07-16 at 12 11 26" src="https://user-images.githubusercontent.com/29975767/61281788-e640a100-a7c2-11e9-97b7-b1290b0294ba.png">


<img width="499" alt="Screenshot 2019-08-02 at 17 17 03" src="https://user-images.githubusercontent.com/21138053/62377961-6c434280-b54c-11e9-8fb9-3517a791416a.png">


<img width="989" alt="Screenshot 2019-08-02 at 17 20 12" src="https://user-images.githubusercontent.com/21138053/62377963-6c434280-b54c-11e9-86aa-b211f57b1867.png">
