### PR TITLE
#165876222: integrate partner stat cards

### DIFF
--- a/src/__tests__/components/Dashboard/activityFeed/__snapshots__/ActivityFeed.test.jsx.snap
+++ b/src/__tests__/components/Dashboard/activityFeed/__snapshots__/ActivityFeed.test.jsx.snap
@@ -77,7 +77,7 @@ ReactWrapper {
           <span
             class="feed-date"
           >
-            05/15/2019, 14:47
+            05/15/2019, 16:47
           </span>
         </div>
       </div>,
@@ -121,7 +121,7 @@ ReactWrapper {
             <span
               className="feed-date"
             >
-              05/15/2019, 14:47
+              05/15/2019, 16:47
             </span>
           </div>,
         ],
@@ -195,7 +195,7 @@ ReactWrapper {
             <span
               class="feed-date"
             >
-              05/15/2019, 14:47
+              05/15/2019, 16:47
             </span>
           </div>,
           "key": undefined,
@@ -228,7 +228,7 @@ ReactWrapper {
               <span
                 className="feed-date"
               >
-                05/15/2019, 14:47
+                05/15/2019, 16:47
               </span>,
             ],
             "className": "feeds-content",
@@ -376,17 +376,17 @@ ReactWrapper {
               "instance": <span
                 class="feed-date"
               >
-                05/15/2019, 14:47
+                05/15/2019, 16:47
               </span>,
               "key": undefined,
               "nodeType": "host",
               "props": Object {
-                "children": "05/15/2019, 14:47",
+                "children": "05/15/2019, 16:47",
                 "className": "feed-date",
               },
               "ref": null,
               "rendered": Array [
-                "05/15/2019, 14:47",
+                "05/15/2019, 16:47",
               ],
               "type": "span",
             },
@@ -453,7 +453,7 @@ ReactWrapper {
             <span
               class="feed-date"
             >
-              05/15/2019, 14:47
+              05/15/2019, 16:47
             </span>
           </div>
         </div>,
@@ -497,7 +497,7 @@ ReactWrapper {
               <span
                 className="feed-date"
               >
-                05/15/2019, 14:47
+                05/15/2019, 16:47
               </span>
             </div>,
           ],
@@ -571,7 +571,7 @@ ReactWrapper {
               <span
                 class="feed-date"
               >
-                05/15/2019, 14:47
+                05/15/2019, 16:47
               </span>
             </div>,
             "key": undefined,
@@ -604,7 +604,7 @@ ReactWrapper {
                 <span
                   className="feed-date"
                 >
-                  05/15/2019, 14:47
+                  05/15/2019, 16:47
                 </span>,
               ],
               "className": "feeds-content",
@@ -752,17 +752,17 @@ ReactWrapper {
                 "instance": <span
                   class="feed-date"
                 >
-                  05/15/2019, 14:47
+                  05/15/2019, 16:47
                 </span>,
                 "key": undefined,
                 "nodeType": "host",
                 "props": Object {
-                  "children": "05/15/2019, 14:47",
+                  "children": "05/15/2019, 16:47",
                   "className": "feed-date",
                 },
                 "ref": null,
                 "rendered": Array [
-                  "05/15/2019, 14:47",
+                  "05/15/2019, 16:47",
                 ],
                 "type": "span",
               },

--- a/src/__tests__/components/PartnerStatsCards/partnerStatsCard.test.jsx
+++ b/src/__tests__/components/PartnerStatsCards/partnerStatsCard.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import PartnerStats from '../../../components/PartnerStatsCard';
+import PartnerStats from '../../../components/Dashboard/PartnerStatsCard';
 
 describe('Partner Stats Card', () => {
   let wrapper;

--- a/src/components/Dashboard/ActivityFeed/activityfeed.scss
+++ b/src/components/Dashboard/ActivityFeed/activityfeed.scss
@@ -1,7 +1,9 @@
 .activity-feed-card {
   box-sizing: border-box;
+  float: left;
   height: 385px;
-  width: 812px;
+  width: 50%;
+  margin: 0 20px 20px 20px;
   border-radius: 5px;
   background-color: #FFF;
   border: 1px solid #EEF;

--- a/src/components/Dashboard/PartnerStatsCard/index.jsx
+++ b/src/components/Dashboard/PartnerStatsCard/index.jsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import Card from '../Dashboard/Card';
+import Card from '../Card';
 import './partnersStatsCard.scss';
 
 class PartnerStats extends Component {

--- a/src/components/Dashboard/PartnerStatsCard/partnersStatsCard.scss
+++ b/src/components/Dashboard/PartnerStatsCard/partnersStatsCard.scss
@@ -1,6 +1,6 @@
 .partner-stats-container {
   display: grid;
-  grid-template-columns: repeat(2, 297.5px);
+  grid-template-columns: repeat(2, 313px);
   grid-column-gap: 35px;
   grid-row-gap: 17px;
   margin: 20px;
@@ -8,7 +8,7 @@
   .partner-stats {
     box-sizing: border-box;
     height: 108px;
-    width: 297.5px;
+    width: 313px;
     border-radius: 5px;
     background-color: #FFF;
     border: 1px solid #EEF;

--- a/src/components/Dashboard/dashboard.scss
+++ b/src/components/Dashboard/dashboard.scss
@@ -12,3 +12,24 @@
   letter-spacing: -0.11px;
   font-size: 20px;
 }
+
+.engagement {
+  width: 60%;
+  float: left;
+  height: 350px;
+  border-radius: 5px;
+  background-color: #FFF;
+  border: 1px solid #EEF;
+  padding: 10px 10px;
+  margin: 20px;
+}
+
+.upselling {
+  width: 36%;
+  height: 350px;
+  border-radius: 5px;
+  background-color: #FFF;
+  border: 1px solid #EEF;
+  padding: 10px 10px;
+  margin: 20px;
+}

--- a/src/components/Dashboard/index.jsx
+++ b/src/components/Dashboard/index.jsx
@@ -7,6 +7,7 @@ import { fetchRealTimeReport } from '../../redux/actions/realTimeReport';
 import listenToSocketEvent from '../../realTime';
 import ActivityFeed from './ActivityFeed';
 import Header from '../Header';
+import PartnerStats from './PartnerStatsCard';
 
 class Dashboard extends React.Component {
   state = {
@@ -81,6 +82,7 @@ class Dashboard extends React.Component {
           component={() => ActivityFeed(this.state)}
           title="Activity Feeds"
         />
+        <PartnerStats />
       </div>
     );
   }


### PR DESCRIPTION
#### What does this PR do?
- Integrate partner stat cards to the dashboard
- Fix the dashboard UI layout

#### Description of Task to be completed?
-  Integrate Partner stats cards to the dashboard and fix how the dashboard is laid out
#### How should this be manually tested?

1. clone the repo, checkout to the `ft-165876222-intgrate-partner-stats` and install all the dependencies.
2. run the server using this command `yarn start`
3. head over to the browser and paste this url `http://localhost:3000/`
4. select dashboard in the navigation bar

#### Any background context you want to provide?
- N/A
#### What are the relevant pivotal tracker stories?
[165876222](https://www.pivotaltracker.com/story/show/165876222)

#### Screenshots (If applicable)
![image](https://user-images.githubusercontent.com/25249904/62277798-8e0acf80-b44f-11e9-91eb-79a257bec653.png)
