### PR TITLE
#165876481: Upselling partners

### DIFF
--- a/cypress/integration/dashboard.spec.js
+++ b/cypress/integration/dashboard.spec.js
@@ -1,0 +1,23 @@
+describe('pill navigation', () => {
+  beforeEach(() => {
+    cy.authenticateUser();
+  });
+
+  it('should display dashboard', () => {
+    cy.visit('/')
+      .get('.nav-links:first')
+      .click()
+      .url()
+      .should('include', '/dashboard')
+      .get('.upSelling')
+      .should('be.visible')
+      .get('.upSelling > .title')
+      .contains('Upselling Partners')
+      .get(':nth-child(1) > .progress > .filler')
+      .should('be.visible')
+      .get(':nth-child(1) > .developers')
+      .should('be.visible')
+      .get(':nth-child(1) > .partner-name')
+      .should('be.visible');
+  });
+});

--- a/src/__tests__/components/Dashboard/index.test.jsx
+++ b/src/__tests__/components/Dashboard/index.test.jsx
@@ -25,14 +25,20 @@ describe('test dashboard', () => {
   };
   const mockStore = configureStore();
   const store = mockStore(state);
+
+  const wrapper = mount(
+    <Provider store={store}>
+      <Dashboard {...props} />
+    </Provider>,
+    options.get(),
+  );
   it('renders a header', () => {
-    const wrapper = mount(
-      // eslint-disable-next-line react/jsx-filename-extension
-      <Provider store={store}>
-        <Dashboard {...props} />
-      </Provider>,
-      options.get(),
-    );
     expect(wrapper.find('#header').length).toEqual(1);
+  });
+
+  it('should render the partners upselling card', () => {
+    const upsellingCard = wrapper.find('.upSelling');
+    const title = upsellingCard.find('.title');
+    expect(title.text()).toEqual('Upselling Partners');
   });
 });

--- a/src/__tests__/components/ProgressBar.test.jsx
+++ b/src/__tests__/components/ProgressBar.test.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import ProgressBar from '../../components/Dashboard/UpSellingPartners';
+
+describe('The Progress Bar', () => {
+  function renderProgressBar(args) {
+    const defaultProps = {
+      upselledDevs: 10,
+    };
+
+    const props = { ...defaultProps, ...args };
+    return shallow(<ProgressBar {...props} />);
+  }
+
+  it('renders correctly', () => {
+    const wrapper = renderProgressBar();
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should render with a width of 30% with 30 upselled Developers', () => {
+    const wrapper = renderProgressBar({ upselledDevs: 30 });
+    const width = wrapper.find('.progress').prop('style');
+    expect(width).toHaveProperty('width', '30%');
+    expect(wrapper).toMatchSnapshot();
+  });
+
+  it('should render with a width of 60% with 60 upselled Developers', () => {
+    const wrapper = renderProgressBar({ upselledDevs: 60 });
+    const width = wrapper.find('.progress').prop('style');
+    expect(width).toHaveProperty('width', '60%');
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/src/components/Dashboard/UpSellingPartners/ProgressBar.scss
+++ b/src/components/Dashboard/UpSellingPartners/ProgressBar.scss
@@ -1,0 +1,14 @@
+// styling for container thats holds the filler bar;
+.progress {
+  height: 3px;
+  margin-top: 6px;
+};
+
+// styling for the filler that shows progress
+.filler {
+  background-color: #3359DF;
+  height: 100%;
+  width: 100%;
+  border-radius: inherit;
+  transition: width .2s ease-in; 
+};

--- a/src/components/Dashboard/UpSellingPartners/index.jsx
+++ b/src/components/Dashboard/UpSellingPartners/index.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import './ProgressBar.scss';
+import PropTypes from 'prop-types';
+
+// The filler component to indicate progress
+const Filler = () => <div className="filler" />;
+
+// The parent Div that houses the filler bar
+const ProgressBar = ({ upselledDevs }) => (
+  <div className="progress" style={{ width: `${upselledDevs}%` }}>
+    <Filler />
+  </div>
+);
+
+ProgressBar.propTypes = {
+  upselledDevs: PropTypes.number.isRequired,
+};
+
+export default ProgressBar;

--- a/src/components/Dashboard/dashboard.scss
+++ b/src/components/Dashboard/dashboard.scss
@@ -1,3 +1,5 @@
+
+
 .dashboard-card {
   background-color: white;
   padding: 16px;
@@ -5,8 +7,8 @@
 }
 .title {
   color: #667;
-  font-family: DinPro;
-  font-weight: normal;
+  font-family: Din Pro;
+  font-weight: 501;
   text-align: left;
   line-height: 24px;
   letter-spacing: -0.11px;
@@ -14,7 +16,7 @@
 }
 
 .engagement {
-  width: 60%;
+  width: 66%;
   float: left;
   height: 350px;
   border-radius: 5px;
@@ -24,8 +26,8 @@
   margin: 20px;
 }
 
-.upselling {
-  width: 36%;
+.upSelling {
+  width: 30%;
   height: 350px;
   border-radius: 5px;
   background-color: #FFF;
@@ -33,3 +35,40 @@
   padding: 10px 10px;
   margin: 20px;
 }
+
+ul {
+  padding: 10px;
+  box-sizing: border-box;
+
+   li {
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-start;
+    flex-wrap: wrap;
+    background:rgba(255, 255, 255, .1);
+    padding: 5px 5px;
+    color: black;
+    transition: .5s;
+  };
+};
+
+ .partner-name {
+  width: 68%;
+  color: #667;
+  font-family: "DIN Pro";
+  font-size: 18px;
+  font-weight: 200;
+  letter-spacing: -0.1px;
+  line-height: 22px;
+  height: 22px;
+};
+.developers {
+  width: 30%;
+  color: #667;
+  font-family: "DIN Pro";
+  font-size: 18px;
+  font-weight: 500;
+  letter-spacing: -0.1px;
+  line-height: 22px;
+  text-align: right;
+};

--- a/src/components/Dashboard/index.jsx
+++ b/src/components/Dashboard/index.jsx
@@ -8,11 +8,44 @@ import listenToSocketEvent from '../../realTime';
 import ActivityFeed from './ActivityFeed';
 import Header from '../Header';
 import PartnerStats from './PartnerStatsCard';
+import ProgressBar from './UpSellingPartners/index';
 
 class Dashboard extends React.Component {
   state = {
     reportData: [],
+    partnerStats: [
+      {
+        id: 1,
+        name: 'Git Prime Git Prime',
+        devNum: 30,
+        expectedDevNum: 30,
+      },
+      {
+        id: 2,
+        name: 'Medeable, inc',
+        devNum: 20,
+        expectedDevNum: 40,
+      },
+      {
+        id: 3,
+        name: 'Building Robotics inc',
+        devNum: 10,
+        expectedDevNum: 30,
+      },
+    ],
   };
+
+  upSellData = (partnerStats) => {
+    const devs = partnerStats.map((dev) => {
+      const finalDev = (dev.devNum / dev.expectedDevNum) * 100;
+      const devStats = {
+        upSellPercentage: finalDev,
+        ...dev,
+      };
+      return devStats;
+    });
+    return devs;
+  }
 
   componentDidMount = () => {
     // triggers event to fetch data from the API
@@ -53,14 +86,31 @@ class Dashboard extends React.Component {
     return newArr;
   };
 
+  renderUpsellingStats = partnerStats => () => {
+    const result = this.upSellData(partnerStats);
+    return (
+      <ul className="upSellList">
+        { result.map(stat => (
+          <li key={stat.id}>
+            <span className="partner-name">{stat.name}</span>
+            <span className="developers">{stat.devNum}</span>
+            <ProgressBar upselledDevs={stat.upSellPercentage} />
+          </li>
+        ))}
+      </ul>
+    );
+  };
+
+
   render() {
     const {
       currentUser,
       removeCurrentUser,
       history,
     } = this.props;
+    const { partnerStats } = this.state;
     return (
-      <div className="dashboard">
+      <div className="dashboard-content">
         <Header
           currentUser={currentUser}
           history={history}
@@ -73,9 +123,9 @@ class Dashboard extends React.Component {
           component={() => {}}
         />
         <Card
-          classes="upselling"
+          classes="upSelling"
           title="Upselling Partners"
-          component={() => {}}
+          component={this.renderUpsellingStats(partnerStats)}
         />
         <Card
           classes="activity-feed-card"


### PR DESCRIPTION
#### What does this PR do?
Finishes the Upselling partners visualization task that was created earlier.

#### Description of Task to be completed?

- Displays a card for Upselling partners

#### How should this be manually tested?
-  Log into ESA and click on dashboard
- You will see the Upsell partner card as shown in the screen below.
#### Any background context you want to provide?
- The card uses dummy data.
- The feature is a continuation of this [PR](https://github.com/andela/bp-esa-frontend/pull/84) that was closed

#### What are the relevant pivotal tracker stories?
[#165876481](https://www.pivotaltracker.com/story/show/165876481)

#### Postman Documentation

-N/A
#### Screenshots (If applicable)
<img width="443" alt="Screen Shot 2019-08-07 at 13 03 59" src="https://user-images.githubusercontent.com/29975767/62614338-df193880-b913-11e9-98a1-6d41c03b87fe.png">
