### PR TITLE
#167486032: Fix styling of card modal table rows

### DIFF
--- a/src/__tests__/components/AutomationDetails.test.jsx
+++ b/src/__tests__/components/AutomationDetails.test.jsx
@@ -25,11 +25,13 @@ const props = {
       status: 'success',
       slackActivities: [
         {
+          id: 1,
           channelName: 'andela-int',
           type: 'Addition',
           status: 'success',
         },
         {
+          id: 2,
           channelName: 'andela',
           type: 'Removal',
           status: 'success',
@@ -40,6 +42,7 @@ const props = {
       status: 'failure',
       nokoActivities: [
         {
+          id: 1,
           status: 'failure',
           statusMessage: 'Request failed with status code 403',
           nokoUserId: null,
@@ -129,11 +132,13 @@ describe('Automation details', () => {
           status: 'success',
           slackActivities: [
             {
+              id: 1,
               channelName: 'andela-int',
               type: 'Addition',
               status: 'success',
             },
             {
+              id: 2,
               channelName: 'andela',
               type: 'Removal',
               status: 'success',
@@ -188,11 +193,13 @@ describe('Automation details', () => {
           status: 'success',
           slackActivities: [
             {
+              id: 1,
               channelName: 'andela-int',
               type: 'Addition',
               status: 'success',
             },
             {
+              id: 2,
               channelName: 'andela',
               type: 'Removal',
               status: 'success',

--- a/src/__tests__/components/Dashboard/activityFeed/ActivityFeed.test.jsx
+++ b/src/__tests__/components/Dashboard/activityFeed/ActivityFeed.test.jsx
@@ -7,6 +7,7 @@ describe('Activity Feed', () => {
   const props = {
     reportData: [
       {
+        id: 1,
         fellowName: 'Kitika, Kelvin',
         type: 'offboarding',
         updatedAt: '2019-05-15T13:47:04.608Z',

--- a/src/components/AutomationDetails/styles.scss
+++ b/src/components/AutomationDetails/styles.scss
@@ -210,7 +210,7 @@
         padding: 0 10px;
         border-bottom: 1px solid rgba(204,204,221,0.6);
         .content-row {
-            height: 48px;
+            height:100%;
             width: 184px;
             font-family: Arial;
             font-size: 14px;
@@ -228,7 +228,6 @@
                 text-align: center;
                 color: #889;
                 text-transform: uppercase;
-
             }
             &.subject{
                 text-align: center;

--- a/src/components/FilterComponent/index.jsx
+++ b/src/components/FilterComponent/index.jsx
@@ -117,7 +117,7 @@ class FilterComponent extends React.PureComponent {
 }
 
 FilterComponent.propTypes = {
-  filter: PropTypes.func.isRequired,
+  filter: PropTypes.object.isRequired,
 };
 
 export default FilterComponent;


### PR DESCRIPTION
#### What does this PR do?
- Fix styling of card modal table rows

#### Description of Task to be completed?
- Fix styling of card modal table rows

#### How should this be manually tested?
1. On browser, goto url ...
1. Check out to the branch `ch-styling-card-167486032`
2. On terminal, run command `yarn start` 

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
#167486032

#### Postman Documentation
N/A

#### Screenshots (If applicable)
<img width="1440" alt="Screen Shot 2019-08-19 at 3 03 06 PM" src="https://user-images.githubusercontent.com/9901086/63264107-f0a6fc80-c292-11e9-815c-ffb1b3c59347.png">
