### PR TITLE
#162751892: Engagement trend visualisation

### DIFF
--- a/cypress/integration/dashboard.spec.js
+++ b/cypress/integration/dashboard.spec.js
@@ -18,6 +18,8 @@ describe('pill navigation', () => {
       .get(':nth-child(1) > .developers')
       .should('be.visible')
       .get(':nth-child(1) > .partner-name')
+      .should('be.visible')
+      .get('.svgDiv')
       .should('be.visible');
   });
 });

--- a/src/__tests__/components/Dashboard/__snapshots__/Card.test.jsx.snap
+++ b/src/__tests__/components/Dashboard/__snapshots__/Card.test.jsx.snap
@@ -2,23 +2,6 @@
 
 exports[`Dashboard card renders appropriately 1`] = `
 ReactWrapper {
-  Symbol(enzyme.__unrendered__): <Card
-    classes="class"
-    component={
-      [MockFunction] {
-        "calls": Array [
-          Array [],
-        ],
-        "results": Array [
-          Object {
-            "isThrow": false,
-            "value": undefined,
-          },
-        ],
-      }
-    }
-    title="Title Card"
-  />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
     "getNode": [Function],
@@ -33,12 +16,14 @@ ReactWrapper {
     "instance": Card {
       "_reactInternalFiber": FiberNode {
         "_debugHookTypes": null,
-        "_debugID": 63,
+        "_debugID": 123,
         "_debugIsCurrentlyTiming": false,
+        "_debugNeedsRemount": false,
         "_debugOwner": FiberNode {
           "_debugHookTypes": null,
-          "_debugID": 62,
+          "_debugID": 121,
           "_debugIsCurrentlyTiming": false,
+          "_debugNeedsRemount": false,
           "_debugOwner": null,
           "_debugSource": null,
           "actualDuration": 0,
@@ -46,7 +31,7 @@ ReactWrapper {
           "alternate": null,
           "child": [Circular],
           "childExpirationTime": 0,
-          "contextDependencies": null,
+          "dependencies": null,
           "effectTag": 1,
           "elementType": [Function],
           "expirationTime": 0,
@@ -95,267 +80,7 @@ ReactWrapper {
             "wrappingComponentProps": null,
           },
           "mode": 0,
-          "nextEffect": FiberNode {
-            "_debugHookTypes": null,
-            "_debugID": 60,
-            "_debugIsCurrentlyTiming": false,
-            "_debugOwner": null,
-            "_debugSource": null,
-            "actualDuration": 0,
-            "actualStartTime": -1,
-            "alternate": FiberNode {
-              "_debugHookTypes": null,
-              "_debugID": 60,
-              "_debugIsCurrentlyTiming": false,
-              "_debugOwner": null,
-              "_debugSource": null,
-              "actualDuration": 0,
-              "actualStartTime": -1,
-              "alternate": [Circular],
-              "child": null,
-              "childExpirationTime": 0,
-              "contextDependencies": null,
-              "effectTag": 0,
-              "elementType": null,
-              "expirationTime": 1073741823,
-              "firstEffect": null,
-              "index": 0,
-              "key": null,
-              "lastEffect": null,
-              "memoizedProps": null,
-              "memoizedState": null,
-              "mode": 0,
-              "nextEffect": null,
-              "pendingProps": null,
-              "ref": null,
-              "return": null,
-              "selfBaseDuration": 0,
-              "sibling": null,
-              "stateNode": Object {
-                "containerInfo": <div>
-                  <div
-                    class="dashboard-card class"
-                  >
-                    <div
-                      class="title"
-                    >
-                      Title Card
-                    </div>
-                  </div>
-                </div>,
-                "context": Object {},
-                "current": [Circular],
-                "didError": false,
-                "earliestPendingTime": 0,
-                "earliestSuspendedTime": 0,
-                "expirationTime": 0,
-                "finishedWork": null,
-                "firstBatch": null,
-                "hydrate": false,
-                "interactionThreadID": 15,
-                "latestPendingTime": 0,
-                "latestPingedTime": 0,
-                "latestSuspendedTime": 0,
-                "memoizedInteractions": Set {},
-                "nextExpirationTimeToWorkOn": 0,
-                "nextScheduledRoot": null,
-                "pendingChildren": null,
-                "pendingCommitExpirationTime": 0,
-                "pendingContext": null,
-                "pendingInteractionMap": Map {},
-                "pingCache": null,
-                "timeoutHandle": -1,
-              },
-              "tag": 3,
-              "treeBaseDuration": 0,
-              "type": null,
-              "updateQueue": Object {
-                "baseState": null,
-                "firstCapturedEffect": null,
-                "firstCapturedUpdate": null,
-                "firstEffect": null,
-                "firstUpdate": Object {
-                  "callback": null,
-                  "expirationTime": 1073741823,
-                  "next": null,
-                  "nextEffect": null,
-                  "payload": Object {
-                    "element": <WrapperComponent
-                      Component={[Function]}
-                      context={null}
-                      props={
-                        Object {
-                          "classes": "class",
-                          "component": [MockFunction] {
-                            "calls": Array [
-                              Array [],
-                            ],
-                            "results": Array [
-                              Object {
-                                "isThrow": false,
-                                "value": undefined,
-                              },
-                            ],
-                          },
-                          "title": "Title Card",
-                        }
-                      }
-                      wrappingComponentProps={null}
-                    />,
-                  },
-                  "tag": 0,
-                },
-                "lastCapturedEffect": null,
-                "lastCapturedUpdate": null,
-                "lastEffect": null,
-                "lastUpdate": Object {
-                  "callback": null,
-                  "expirationTime": 1073741823,
-                  "next": null,
-                  "nextEffect": null,
-                  "payload": Object {
-                    "element": <WrapperComponent
-                      Component={[Function]}
-                      context={null}
-                      props={
-                        Object {
-                          "classes": "class",
-                          "component": [MockFunction] {
-                            "calls": Array [
-                              Array [],
-                            ],
-                            "results": Array [
-                              Object {
-                                "isThrow": false,
-                                "value": undefined,
-                              },
-                            ],
-                          },
-                          "title": "Title Card",
-                        }
-                      }
-                      wrappingComponentProps={null}
-                    />,
-                  },
-                  "tag": 0,
-                },
-              },
-            },
-            "child": [Circular],
-            "childExpirationTime": 0,
-            "contextDependencies": null,
-            "effectTag": 32,
-            "elementType": null,
-            "expirationTime": 0,
-            "firstEffect": [Circular],
-            "index": 0,
-            "key": null,
-            "lastEffect": [Circular],
-            "memoizedProps": null,
-            "memoizedState": Object {
-              "element": <WrapperComponent
-                Component={[Function]}
-                context={null}
-                props={
-                  Object {
-                    "classes": "class",
-                    "component": [MockFunction] {
-                      "calls": Array [
-                        Array [],
-                      ],
-                      "results": Array [
-                        Object {
-                          "isThrow": false,
-                          "value": undefined,
-                        },
-                      ],
-                    },
-                    "title": "Title Card",
-                  }
-                }
-                wrappingComponentProps={null}
-              />,
-            },
-            "mode": 0,
-            "nextEffect": null,
-            "pendingProps": null,
-            "ref": null,
-            "return": null,
-            "selfBaseDuration": 0,
-            "sibling": null,
-            "stateNode": Object {
-              "containerInfo": <div>
-                <div
-                  class="dashboard-card class"
-                >
-                  <div
-                    class="title"
-                  >
-                    Title Card
-                  </div>
-                </div>
-              </div>,
-              "context": Object {},
-              "current": [Circular],
-              "didError": false,
-              "earliestPendingTime": 0,
-              "earliestSuspendedTime": 0,
-              "expirationTime": 0,
-              "finishedWork": null,
-              "firstBatch": null,
-              "hydrate": false,
-              "interactionThreadID": 15,
-              "latestPendingTime": 0,
-              "latestPingedTime": 0,
-              "latestSuspendedTime": 0,
-              "memoizedInteractions": Set {},
-              "nextExpirationTimeToWorkOn": 0,
-              "nextScheduledRoot": null,
-              "pendingChildren": null,
-              "pendingCommitExpirationTime": 0,
-              "pendingContext": null,
-              "pendingInteractionMap": Map {},
-              "pingCache": null,
-              "timeoutHandle": -1,
-            },
-            "tag": 3,
-            "treeBaseDuration": 0,
-            "type": null,
-            "updateQueue": Object {
-              "baseState": Object {
-                "element": <WrapperComponent
-                  Component={[Function]}
-                  context={null}
-                  props={
-                    Object {
-                      "classes": "class",
-                      "component": [MockFunction] {
-                        "calls": Array [
-                          Array [],
-                        ],
-                        "results": Array [
-                          Object {
-                            "isThrow": false,
-                            "value": undefined,
-                          },
-                        ],
-                      },
-                      "title": "Title Card",
-                    }
-                  }
-                  wrappingComponentProps={null}
-                />,
-              },
-              "firstCapturedEffect": null,
-              "firstCapturedUpdate": null,
-              "firstEffect": null,
-              "firstUpdate": null,
-              "lastCapturedEffect": null,
-              "lastCapturedUpdate": null,
-              "lastEffect": null,
-              "lastUpdate": null,
-            },
-          },
+          "nextEffect": null,
           "pendingProps": Object {
             "Component": [Function],
             "context": null,
@@ -379,16 +104,18 @@ ReactWrapper {
           "ref": null,
           "return": FiberNode {
             "_debugHookTypes": null,
-            "_debugID": 60,
+            "_debugID": 118,
             "_debugIsCurrentlyTiming": false,
+            "_debugNeedsRemount": false,
             "_debugOwner": null,
             "_debugSource": null,
             "actualDuration": 0,
             "actualStartTime": -1,
             "alternate": FiberNode {
               "_debugHookTypes": null,
-              "_debugID": 60,
+              "_debugID": 118,
               "_debugIsCurrentlyTiming": false,
+              "_debugNeedsRemount": false,
               "_debugOwner": null,
               "_debugSource": null,
               "actualDuration": 0,
@@ -396,7 +123,7 @@ ReactWrapper {
               "alternate": [Circular],
               "child": null,
               "childExpirationTime": 0,
-              "contextDependencies": null,
+              "dependencies": null,
               "effectTag": 0,
               "elementType": null,
               "expirationTime": 1073741823,
@@ -413,7 +140,9 @@ ReactWrapper {
               "return": null,
               "selfBaseDuration": 0,
               "sibling": null,
-              "stateNode": Object {
+              "stateNode": FiberRootNode {
+                "callbackExpirationTime": 0,
+                "callbackNode": null,
                 "containerInfo": <div>
                   <div
                     class="dashboard-card class"
@@ -427,25 +156,20 @@ ReactWrapper {
                 </div>,
                 "context": Object {},
                 "current": [Circular],
-                "didError": false,
-                "earliestPendingTime": 0,
-                "earliestSuspendedTime": 0,
-                "expirationTime": 0,
+                "finishedExpirationTime": 0,
                 "finishedWork": null,
                 "firstBatch": null,
+                "firstPendingTime": 0,
                 "hydrate": false,
-                "interactionThreadID": 15,
-                "latestPendingTime": 0,
-                "latestPingedTime": 0,
-                "latestSuspendedTime": 0,
+                "interactionThreadID": 16,
+                "lastPendingTime": 0,
                 "memoizedInteractions": Set {},
-                "nextExpirationTimeToWorkOn": 0,
-                "nextScheduledRoot": null,
                 "pendingChildren": null,
-                "pendingCommitExpirationTime": 0,
                 "pendingContext": null,
                 "pendingInteractionMap": Map {},
                 "pingCache": null,
+                "pingTime": 0,
+                "tag": 0,
                 "timeoutHandle": -1,
               },
               "tag": 3,
@@ -485,6 +209,8 @@ ReactWrapper {
                       wrappingComponentProps={null}
                     />,
                   },
+                  "priority": 97,
+                  "suspenseConfig": null,
                   "tag": 0,
                 },
                 "lastCapturedEffect": null,
@@ -519,14 +245,16 @@ ReactWrapper {
                       wrappingComponentProps={null}
                     />,
                   },
+                  "priority": 97,
+                  "suspenseConfig": null,
                   "tag": 0,
                 },
               },
             },
             "child": [Circular],
             "childExpirationTime": 0,
-            "contextDependencies": null,
-            "effectTag": 32,
+            "dependencies": null,
+            "effectTag": 0,
             "elementType": null,
             "expirationTime": 0,
             "firstEffect": [Circular],
@@ -565,7 +293,9 @@ ReactWrapper {
             "return": null,
             "selfBaseDuration": 0,
             "sibling": null,
-            "stateNode": Object {
+            "stateNode": FiberRootNode {
+              "callbackExpirationTime": 0,
+              "callbackNode": null,
               "containerInfo": <div>
                 <div
                   class="dashboard-card class"
@@ -579,25 +309,20 @@ ReactWrapper {
               </div>,
               "context": Object {},
               "current": [Circular],
-              "didError": false,
-              "earliestPendingTime": 0,
-              "earliestSuspendedTime": 0,
-              "expirationTime": 0,
+              "finishedExpirationTime": 0,
               "finishedWork": null,
               "firstBatch": null,
+              "firstPendingTime": 0,
               "hydrate": false,
-              "interactionThreadID": 15,
-              "latestPendingTime": 0,
-              "latestPingedTime": 0,
-              "latestSuspendedTime": 0,
+              "interactionThreadID": 16,
+              "lastPendingTime": 0,
               "memoizedInteractions": Set {},
-              "nextExpirationTimeToWorkOn": 0,
-              "nextScheduledRoot": null,
               "pendingChildren": null,
-              "pendingCommitExpirationTime": 0,
               "pendingContext": null,
               "pendingInteractionMap": Map {},
               "pingCache": null,
+              "pingTime": 0,
+              "tag": 0,
               "timeoutHandle": -1,
             },
             "tag": 3,
@@ -704,8 +429,9 @@ ReactWrapper {
         "alternate": null,
         "child": FiberNode {
           "_debugHookTypes": null,
-          "_debugID": 64,
+          "_debugID": 125,
           "_debugIsCurrentlyTiming": false,
+          "_debugNeedsRemount": false,
           "_debugOwner": [Circular],
           "_debugSource": Object {
             "fileName": "/Users/arnold/Andela-Project/bp-esa-frontend/src/components/Dashboard/Card.jsx",
@@ -716,8 +442,9 @@ ReactWrapper {
           "alternate": null,
           "child": FiberNode {
             "_debugHookTypes": null,
-            "_debugID": 65,
+            "_debugID": 127,
             "_debugIsCurrentlyTiming": false,
+            "_debugNeedsRemount": false,
             "_debugOwner": [Circular],
             "_debugSource": Object {
               "fileName": "/Users/arnold/Andela-Project/bp-esa-frontend/src/components/Dashboard/Card.jsx",
@@ -728,7 +455,7 @@ ReactWrapper {
             "alternate": null,
             "child": null,
             "childExpirationTime": 0,
-            "contextDependencies": null,
+            "dependencies": null,
             "effectTag": 0,
             "elementType": "div",
             "expirationTime": 0,
@@ -762,7 +489,7 @@ ReactWrapper {
             "updateQueue": null,
           },
           "childExpirationTime": 0,
-          "contextDependencies": null,
+          "dependencies": null,
           "effectTag": 0,
           "elementType": "div",
           "expirationTime": 0,
@@ -814,7 +541,7 @@ ReactWrapper {
           "updateQueue": null,
         },
         "childExpirationTime": 0,
-        "contextDependencies": null,
+        "dependencies": null,
         "effectTag": 1,
         "elementType": [Function],
         "expirationTime": 0,
@@ -858,8 +585,9 @@ ReactWrapper {
         "ref": null,
         "return": FiberNode {
           "_debugHookTypes": null,
-          "_debugID": 62,
+          "_debugID": 121,
           "_debugIsCurrentlyTiming": false,
+          "_debugNeedsRemount": false,
           "_debugOwner": null,
           "_debugSource": null,
           "actualDuration": 0,
@@ -867,7 +595,7 @@ ReactWrapper {
           "alternate": null,
           "child": [Circular],
           "childExpirationTime": 0,
-          "contextDependencies": null,
+          "dependencies": null,
           "effectTag": 1,
           "elementType": [Function],
           "expirationTime": 0,
@@ -916,267 +644,7 @@ ReactWrapper {
             "wrappingComponentProps": null,
           },
           "mode": 0,
-          "nextEffect": FiberNode {
-            "_debugHookTypes": null,
-            "_debugID": 60,
-            "_debugIsCurrentlyTiming": false,
-            "_debugOwner": null,
-            "_debugSource": null,
-            "actualDuration": 0,
-            "actualStartTime": -1,
-            "alternate": FiberNode {
-              "_debugHookTypes": null,
-              "_debugID": 60,
-              "_debugIsCurrentlyTiming": false,
-              "_debugOwner": null,
-              "_debugSource": null,
-              "actualDuration": 0,
-              "actualStartTime": -1,
-              "alternate": [Circular],
-              "child": null,
-              "childExpirationTime": 0,
-              "contextDependencies": null,
-              "effectTag": 0,
-              "elementType": null,
-              "expirationTime": 1073741823,
-              "firstEffect": null,
-              "index": 0,
-              "key": null,
-              "lastEffect": null,
-              "memoizedProps": null,
-              "memoizedState": null,
-              "mode": 0,
-              "nextEffect": null,
-              "pendingProps": null,
-              "ref": null,
-              "return": null,
-              "selfBaseDuration": 0,
-              "sibling": null,
-              "stateNode": Object {
-                "containerInfo": <div>
-                  <div
-                    class="dashboard-card class"
-                  >
-                    <div
-                      class="title"
-                    >
-                      Title Card
-                    </div>
-                  </div>
-                </div>,
-                "context": Object {},
-                "current": [Circular],
-                "didError": false,
-                "earliestPendingTime": 0,
-                "earliestSuspendedTime": 0,
-                "expirationTime": 0,
-                "finishedWork": null,
-                "firstBatch": null,
-                "hydrate": false,
-                "interactionThreadID": 15,
-                "latestPendingTime": 0,
-                "latestPingedTime": 0,
-                "latestSuspendedTime": 0,
-                "memoizedInteractions": Set {},
-                "nextExpirationTimeToWorkOn": 0,
-                "nextScheduledRoot": null,
-                "pendingChildren": null,
-                "pendingCommitExpirationTime": 0,
-                "pendingContext": null,
-                "pendingInteractionMap": Map {},
-                "pingCache": null,
-                "timeoutHandle": -1,
-              },
-              "tag": 3,
-              "treeBaseDuration": 0,
-              "type": null,
-              "updateQueue": Object {
-                "baseState": null,
-                "firstCapturedEffect": null,
-                "firstCapturedUpdate": null,
-                "firstEffect": null,
-                "firstUpdate": Object {
-                  "callback": null,
-                  "expirationTime": 1073741823,
-                  "next": null,
-                  "nextEffect": null,
-                  "payload": Object {
-                    "element": <WrapperComponent
-                      Component={[Function]}
-                      context={null}
-                      props={
-                        Object {
-                          "classes": "class",
-                          "component": [MockFunction] {
-                            "calls": Array [
-                              Array [],
-                            ],
-                            "results": Array [
-                              Object {
-                                "isThrow": false,
-                                "value": undefined,
-                              },
-                            ],
-                          },
-                          "title": "Title Card",
-                        }
-                      }
-                      wrappingComponentProps={null}
-                    />,
-                  },
-                  "tag": 0,
-                },
-                "lastCapturedEffect": null,
-                "lastCapturedUpdate": null,
-                "lastEffect": null,
-                "lastUpdate": Object {
-                  "callback": null,
-                  "expirationTime": 1073741823,
-                  "next": null,
-                  "nextEffect": null,
-                  "payload": Object {
-                    "element": <WrapperComponent
-                      Component={[Function]}
-                      context={null}
-                      props={
-                        Object {
-                          "classes": "class",
-                          "component": [MockFunction] {
-                            "calls": Array [
-                              Array [],
-                            ],
-                            "results": Array [
-                              Object {
-                                "isThrow": false,
-                                "value": undefined,
-                              },
-                            ],
-                          },
-                          "title": "Title Card",
-                        }
-                      }
-                      wrappingComponentProps={null}
-                    />,
-                  },
-                  "tag": 0,
-                },
-              },
-            },
-            "child": [Circular],
-            "childExpirationTime": 0,
-            "contextDependencies": null,
-            "effectTag": 32,
-            "elementType": null,
-            "expirationTime": 0,
-            "firstEffect": [Circular],
-            "index": 0,
-            "key": null,
-            "lastEffect": [Circular],
-            "memoizedProps": null,
-            "memoizedState": Object {
-              "element": <WrapperComponent
-                Component={[Function]}
-                context={null}
-                props={
-                  Object {
-                    "classes": "class",
-                    "component": [MockFunction] {
-                      "calls": Array [
-                        Array [],
-                      ],
-                      "results": Array [
-                        Object {
-                          "isThrow": false,
-                          "value": undefined,
-                        },
-                      ],
-                    },
-                    "title": "Title Card",
-                  }
-                }
-                wrappingComponentProps={null}
-              />,
-            },
-            "mode": 0,
-            "nextEffect": null,
-            "pendingProps": null,
-            "ref": null,
-            "return": null,
-            "selfBaseDuration": 0,
-            "sibling": null,
-            "stateNode": Object {
-              "containerInfo": <div>
-                <div
-                  class="dashboard-card class"
-                >
-                  <div
-                    class="title"
-                  >
-                    Title Card
-                  </div>
-                </div>
-              </div>,
-              "context": Object {},
-              "current": [Circular],
-              "didError": false,
-              "earliestPendingTime": 0,
-              "earliestSuspendedTime": 0,
-              "expirationTime": 0,
-              "finishedWork": null,
-              "firstBatch": null,
-              "hydrate": false,
-              "interactionThreadID": 15,
-              "latestPendingTime": 0,
-              "latestPingedTime": 0,
-              "latestSuspendedTime": 0,
-              "memoizedInteractions": Set {},
-              "nextExpirationTimeToWorkOn": 0,
-              "nextScheduledRoot": null,
-              "pendingChildren": null,
-              "pendingCommitExpirationTime": 0,
-              "pendingContext": null,
-              "pendingInteractionMap": Map {},
-              "pingCache": null,
-              "timeoutHandle": -1,
-            },
-            "tag": 3,
-            "treeBaseDuration": 0,
-            "type": null,
-            "updateQueue": Object {
-              "baseState": Object {
-                "element": <WrapperComponent
-                  Component={[Function]}
-                  context={null}
-                  props={
-                    Object {
-                      "classes": "class",
-                      "component": [MockFunction] {
-                        "calls": Array [
-                          Array [],
-                        ],
-                        "results": Array [
-                          Object {
-                            "isThrow": false,
-                            "value": undefined,
-                          },
-                        ],
-                      },
-                      "title": "Title Card",
-                    }
-                  }
-                  wrappingComponentProps={null}
-                />,
-              },
-              "firstCapturedEffect": null,
-              "firstCapturedUpdate": null,
-              "firstEffect": null,
-              "firstUpdate": null,
-              "lastCapturedEffect": null,
-              "lastCapturedUpdate": null,
-              "lastEffect": null,
-              "lastUpdate": null,
-            },
-          },
+          "nextEffect": null,
           "pendingProps": Object {
             "Component": [Function],
             "context": null,
@@ -1200,16 +668,18 @@ ReactWrapper {
           "ref": null,
           "return": FiberNode {
             "_debugHookTypes": null,
-            "_debugID": 60,
+            "_debugID": 118,
             "_debugIsCurrentlyTiming": false,
+            "_debugNeedsRemount": false,
             "_debugOwner": null,
             "_debugSource": null,
             "actualDuration": 0,
             "actualStartTime": -1,
             "alternate": FiberNode {
               "_debugHookTypes": null,
-              "_debugID": 60,
+              "_debugID": 118,
               "_debugIsCurrentlyTiming": false,
+              "_debugNeedsRemount": false,
               "_debugOwner": null,
               "_debugSource": null,
               "actualDuration": 0,
@@ -1217,7 +687,7 @@ ReactWrapper {
               "alternate": [Circular],
               "child": null,
               "childExpirationTime": 0,
-              "contextDependencies": null,
+              "dependencies": null,
               "effectTag": 0,
               "elementType": null,
               "expirationTime": 1073741823,
@@ -1234,7 +704,9 @@ ReactWrapper {
               "return": null,
               "selfBaseDuration": 0,
               "sibling": null,
-              "stateNode": Object {
+              "stateNode": FiberRootNode {
+                "callbackExpirationTime": 0,
+                "callbackNode": null,
                 "containerInfo": <div>
                   <div
                     class="dashboard-card class"
@@ -1248,25 +720,20 @@ ReactWrapper {
                 </div>,
                 "context": Object {},
                 "current": [Circular],
-                "didError": false,
-                "earliestPendingTime": 0,
-                "earliestSuspendedTime": 0,
-                "expirationTime": 0,
+                "finishedExpirationTime": 0,
                 "finishedWork": null,
                 "firstBatch": null,
+                "firstPendingTime": 0,
                 "hydrate": false,
-                "interactionThreadID": 15,
-                "latestPendingTime": 0,
-                "latestPingedTime": 0,
-                "latestSuspendedTime": 0,
+                "interactionThreadID": 16,
+                "lastPendingTime": 0,
                 "memoizedInteractions": Set {},
-                "nextExpirationTimeToWorkOn": 0,
-                "nextScheduledRoot": null,
                 "pendingChildren": null,
-                "pendingCommitExpirationTime": 0,
                 "pendingContext": null,
                 "pendingInteractionMap": Map {},
                 "pingCache": null,
+                "pingTime": 0,
+                "tag": 0,
                 "timeoutHandle": -1,
               },
               "tag": 3,
@@ -1306,6 +773,8 @@ ReactWrapper {
                       wrappingComponentProps={null}
                     />,
                   },
+                  "priority": 97,
+                  "suspenseConfig": null,
                   "tag": 0,
                 },
                 "lastCapturedEffect": null,
@@ -1340,14 +809,16 @@ ReactWrapper {
                       wrappingComponentProps={null}
                     />,
                   },
+                  "priority": 97,
+                  "suspenseConfig": null,
                   "tag": 0,
                 },
               },
             },
             "child": [Circular],
             "childExpirationTime": 0,
-            "contextDependencies": null,
-            "effectTag": 32,
+            "dependencies": null,
+            "effectTag": 0,
             "elementType": null,
             "expirationTime": 0,
             "firstEffect": [Circular],
@@ -1386,7 +857,9 @@ ReactWrapper {
             "return": null,
             "selfBaseDuration": 0,
             "sibling": null,
-            "stateNode": Object {
+            "stateNode": FiberRootNode {
+              "callbackExpirationTime": 0,
+              "callbackNode": null,
               "containerInfo": <div>
                 <div
                   class="dashboard-card class"
@@ -1400,25 +873,20 @@ ReactWrapper {
               </div>,
               "context": Object {},
               "current": [Circular],
-              "didError": false,
-              "earliestPendingTime": 0,
-              "earliestSuspendedTime": 0,
-              "expirationTime": 0,
+              "finishedExpirationTime": 0,
               "finishedWork": null,
               "firstBatch": null,
+              "firstPendingTime": 0,
               "hydrate": false,
-              "interactionThreadID": 15,
-              "latestPendingTime": 0,
-              "latestPingedTime": 0,
-              "latestSuspendedTime": 0,
+              "interactionThreadID": 16,
+              "lastPendingTime": 0,
               "memoizedInteractions": Set {},
-              "nextExpirationTimeToWorkOn": 0,
-              "nextScheduledRoot": null,
               "pendingChildren": null,
-              "pendingCommitExpirationTime": 0,
               "pendingContext": null,
               "pendingInteractionMap": Map {},
               "pingCache": null,
+              "pingTime": 0,
+              "tag": 0,
               "timeoutHandle": -1,
             },
             "tag": 3,
@@ -1624,12 +1092,14 @@ ReactWrapper {
       "instance": Card {
         "_reactInternalFiber": FiberNode {
           "_debugHookTypes": null,
-          "_debugID": 63,
+          "_debugID": 123,
           "_debugIsCurrentlyTiming": false,
+          "_debugNeedsRemount": false,
           "_debugOwner": FiberNode {
             "_debugHookTypes": null,
-            "_debugID": 62,
+            "_debugID": 121,
             "_debugIsCurrentlyTiming": false,
+            "_debugNeedsRemount": false,
             "_debugOwner": null,
             "_debugSource": null,
             "actualDuration": 0,
@@ -1637,7 +1107,7 @@ ReactWrapper {
             "alternate": null,
             "child": [Circular],
             "childExpirationTime": 0,
-            "contextDependencies": null,
+            "dependencies": null,
             "effectTag": 1,
             "elementType": [Function],
             "expirationTime": 0,
@@ -1686,267 +1156,7 @@ ReactWrapper {
               "wrappingComponentProps": null,
             },
             "mode": 0,
-            "nextEffect": FiberNode {
-              "_debugHookTypes": null,
-              "_debugID": 60,
-              "_debugIsCurrentlyTiming": false,
-              "_debugOwner": null,
-              "_debugSource": null,
-              "actualDuration": 0,
-              "actualStartTime": -1,
-              "alternate": FiberNode {
-                "_debugHookTypes": null,
-                "_debugID": 60,
-                "_debugIsCurrentlyTiming": false,
-                "_debugOwner": null,
-                "_debugSource": null,
-                "actualDuration": 0,
-                "actualStartTime": -1,
-                "alternate": [Circular],
-                "child": null,
-                "childExpirationTime": 0,
-                "contextDependencies": null,
-                "effectTag": 0,
-                "elementType": null,
-                "expirationTime": 1073741823,
-                "firstEffect": null,
-                "index": 0,
-                "key": null,
-                "lastEffect": null,
-                "memoizedProps": null,
-                "memoizedState": null,
-                "mode": 0,
-                "nextEffect": null,
-                "pendingProps": null,
-                "ref": null,
-                "return": null,
-                "selfBaseDuration": 0,
-                "sibling": null,
-                "stateNode": Object {
-                  "containerInfo": <div>
-                    <div
-                      class="dashboard-card class"
-                    >
-                      <div
-                        class="title"
-                      >
-                        Title Card
-                      </div>
-                    </div>
-                  </div>,
-                  "context": Object {},
-                  "current": [Circular],
-                  "didError": false,
-                  "earliestPendingTime": 0,
-                  "earliestSuspendedTime": 0,
-                  "expirationTime": 0,
-                  "finishedWork": null,
-                  "firstBatch": null,
-                  "hydrate": false,
-                  "interactionThreadID": 15,
-                  "latestPendingTime": 0,
-                  "latestPingedTime": 0,
-                  "latestSuspendedTime": 0,
-                  "memoizedInteractions": Set {},
-                  "nextExpirationTimeToWorkOn": 0,
-                  "nextScheduledRoot": null,
-                  "pendingChildren": null,
-                  "pendingCommitExpirationTime": 0,
-                  "pendingContext": null,
-                  "pendingInteractionMap": Map {},
-                  "pingCache": null,
-                  "timeoutHandle": -1,
-                },
-                "tag": 3,
-                "treeBaseDuration": 0,
-                "type": null,
-                "updateQueue": Object {
-                  "baseState": null,
-                  "firstCapturedEffect": null,
-                  "firstCapturedUpdate": null,
-                  "firstEffect": null,
-                  "firstUpdate": Object {
-                    "callback": null,
-                    "expirationTime": 1073741823,
-                    "next": null,
-                    "nextEffect": null,
-                    "payload": Object {
-                      "element": <WrapperComponent
-                        Component={[Function]}
-                        context={null}
-                        props={
-                          Object {
-                            "classes": "class",
-                            "component": [MockFunction] {
-                              "calls": Array [
-                                Array [],
-                              ],
-                              "results": Array [
-                                Object {
-                                  "isThrow": false,
-                                  "value": undefined,
-                                },
-                              ],
-                            },
-                            "title": "Title Card",
-                          }
-                        }
-                        wrappingComponentProps={null}
-                      />,
-                    },
-                    "tag": 0,
-                  },
-                  "lastCapturedEffect": null,
-                  "lastCapturedUpdate": null,
-                  "lastEffect": null,
-                  "lastUpdate": Object {
-                    "callback": null,
-                    "expirationTime": 1073741823,
-                    "next": null,
-                    "nextEffect": null,
-                    "payload": Object {
-                      "element": <WrapperComponent
-                        Component={[Function]}
-                        context={null}
-                        props={
-                          Object {
-                            "classes": "class",
-                            "component": [MockFunction] {
-                              "calls": Array [
-                                Array [],
-                              ],
-                              "results": Array [
-                                Object {
-                                  "isThrow": false,
-                                  "value": undefined,
-                                },
-                              ],
-                            },
-                            "title": "Title Card",
-                          }
-                        }
-                        wrappingComponentProps={null}
-                      />,
-                    },
-                    "tag": 0,
-                  },
-                },
-              },
-              "child": [Circular],
-              "childExpirationTime": 0,
-              "contextDependencies": null,
-              "effectTag": 32,
-              "elementType": null,
-              "expirationTime": 0,
-              "firstEffect": [Circular],
-              "index": 0,
-              "key": null,
-              "lastEffect": [Circular],
-              "memoizedProps": null,
-              "memoizedState": Object {
-                "element": <WrapperComponent
-                  Component={[Function]}
-                  context={null}
-                  props={
-                    Object {
-                      "classes": "class",
-                      "component": [MockFunction] {
-                        "calls": Array [
-                          Array [],
-                        ],
-                        "results": Array [
-                          Object {
-                            "isThrow": false,
-                            "value": undefined,
-                          },
-                        ],
-                      },
-                      "title": "Title Card",
-                    }
-                  }
-                  wrappingComponentProps={null}
-                />,
-              },
-              "mode": 0,
-              "nextEffect": null,
-              "pendingProps": null,
-              "ref": null,
-              "return": null,
-              "selfBaseDuration": 0,
-              "sibling": null,
-              "stateNode": Object {
-                "containerInfo": <div>
-                  <div
-                    class="dashboard-card class"
-                  >
-                    <div
-                      class="title"
-                    >
-                      Title Card
-                    </div>
-                  </div>
-                </div>,
-                "context": Object {},
-                "current": [Circular],
-                "didError": false,
-                "earliestPendingTime": 0,
-                "earliestSuspendedTime": 0,
-                "expirationTime": 0,
-                "finishedWork": null,
-                "firstBatch": null,
-                "hydrate": false,
-                "interactionThreadID": 15,
-                "latestPendingTime": 0,
-                "latestPingedTime": 0,
-                "latestSuspendedTime": 0,
-                "memoizedInteractions": Set {},
-                "nextExpirationTimeToWorkOn": 0,
-                "nextScheduledRoot": null,
-                "pendingChildren": null,
-                "pendingCommitExpirationTime": 0,
-                "pendingContext": null,
-                "pendingInteractionMap": Map {},
-                "pingCache": null,
-                "timeoutHandle": -1,
-              },
-              "tag": 3,
-              "treeBaseDuration": 0,
-              "type": null,
-              "updateQueue": Object {
-                "baseState": Object {
-                  "element": <WrapperComponent
-                    Component={[Function]}
-                    context={null}
-                    props={
-                      Object {
-                        "classes": "class",
-                        "component": [MockFunction] {
-                          "calls": Array [
-                            Array [],
-                          ],
-                          "results": Array [
-                            Object {
-                              "isThrow": false,
-                              "value": undefined,
-                            },
-                          ],
-                        },
-                        "title": "Title Card",
-                      }
-                    }
-                    wrappingComponentProps={null}
-                  />,
-                },
-                "firstCapturedEffect": null,
-                "firstCapturedUpdate": null,
-                "firstEffect": null,
-                "firstUpdate": null,
-                "lastCapturedEffect": null,
-                "lastCapturedUpdate": null,
-                "lastEffect": null,
-                "lastUpdate": null,
-              },
-            },
+            "nextEffect": null,
             "pendingProps": Object {
               "Component": [Function],
               "context": null,
@@ -1970,16 +1180,18 @@ ReactWrapper {
             "ref": null,
             "return": FiberNode {
               "_debugHookTypes": null,
-              "_debugID": 60,
+              "_debugID": 118,
               "_debugIsCurrentlyTiming": false,
+              "_debugNeedsRemount": false,
               "_debugOwner": null,
               "_debugSource": null,
               "actualDuration": 0,
               "actualStartTime": -1,
               "alternate": FiberNode {
                 "_debugHookTypes": null,
-                "_debugID": 60,
+                "_debugID": 118,
                 "_debugIsCurrentlyTiming": false,
+                "_debugNeedsRemount": false,
                 "_debugOwner": null,
                 "_debugSource": null,
                 "actualDuration": 0,
@@ -1987,7 +1199,7 @@ ReactWrapper {
                 "alternate": [Circular],
                 "child": null,
                 "childExpirationTime": 0,
-                "contextDependencies": null,
+                "dependencies": null,
                 "effectTag": 0,
                 "elementType": null,
                 "expirationTime": 1073741823,
@@ -2004,7 +1216,9 @@ ReactWrapper {
                 "return": null,
                 "selfBaseDuration": 0,
                 "sibling": null,
-                "stateNode": Object {
+                "stateNode": FiberRootNode {
+                  "callbackExpirationTime": 0,
+                  "callbackNode": null,
                   "containerInfo": <div>
                     <div
                       class="dashboard-card class"
@@ -2018,25 +1232,20 @@ ReactWrapper {
                   </div>,
                   "context": Object {},
                   "current": [Circular],
-                  "didError": false,
-                  "earliestPendingTime": 0,
-                  "earliestSuspendedTime": 0,
-                  "expirationTime": 0,
+                  "finishedExpirationTime": 0,
                   "finishedWork": null,
                   "firstBatch": null,
+                  "firstPendingTime": 0,
                   "hydrate": false,
-                  "interactionThreadID": 15,
-                  "latestPendingTime": 0,
-                  "latestPingedTime": 0,
-                  "latestSuspendedTime": 0,
+                  "interactionThreadID": 16,
+                  "lastPendingTime": 0,
                   "memoizedInteractions": Set {},
-                  "nextExpirationTimeToWorkOn": 0,
-                  "nextScheduledRoot": null,
                   "pendingChildren": null,
-                  "pendingCommitExpirationTime": 0,
                   "pendingContext": null,
                   "pendingInteractionMap": Map {},
                   "pingCache": null,
+                  "pingTime": 0,
+                  "tag": 0,
                   "timeoutHandle": -1,
                 },
                 "tag": 3,
@@ -2076,6 +1285,8 @@ ReactWrapper {
                         wrappingComponentProps={null}
                       />,
                     },
+                    "priority": 97,
+                    "suspenseConfig": null,
                     "tag": 0,
                   },
                   "lastCapturedEffect": null,
@@ -2110,14 +1321,16 @@ ReactWrapper {
                         wrappingComponentProps={null}
                       />,
                     },
+                    "priority": 97,
+                    "suspenseConfig": null,
                     "tag": 0,
                   },
                 },
               },
               "child": [Circular],
               "childExpirationTime": 0,
-              "contextDependencies": null,
-              "effectTag": 32,
+              "dependencies": null,
+              "effectTag": 0,
               "elementType": null,
               "expirationTime": 0,
               "firstEffect": [Circular],
@@ -2156,7 +1369,9 @@ ReactWrapper {
               "return": null,
               "selfBaseDuration": 0,
               "sibling": null,
-              "stateNode": Object {
+              "stateNode": FiberRootNode {
+                "callbackExpirationTime": 0,
+                "callbackNode": null,
                 "containerInfo": <div>
                   <div
                     class="dashboard-card class"
@@ -2170,25 +1385,20 @@ ReactWrapper {
                 </div>,
                 "context": Object {},
                 "current": [Circular],
-                "didError": false,
-                "earliestPendingTime": 0,
-                "earliestSuspendedTime": 0,
-                "expirationTime": 0,
+                "finishedExpirationTime": 0,
                 "finishedWork": null,
                 "firstBatch": null,
+                "firstPendingTime": 0,
                 "hydrate": false,
-                "interactionThreadID": 15,
-                "latestPendingTime": 0,
-                "latestPingedTime": 0,
-                "latestSuspendedTime": 0,
+                "interactionThreadID": 16,
+                "lastPendingTime": 0,
                 "memoizedInteractions": Set {},
-                "nextExpirationTimeToWorkOn": 0,
-                "nextScheduledRoot": null,
                 "pendingChildren": null,
-                "pendingCommitExpirationTime": 0,
                 "pendingContext": null,
                 "pendingInteractionMap": Map {},
                 "pingCache": null,
+                "pingTime": 0,
+                "tag": 0,
                 "timeoutHandle": -1,
               },
               "tag": 3,
@@ -2295,8 +1505,9 @@ ReactWrapper {
           "alternate": null,
           "child": FiberNode {
             "_debugHookTypes": null,
-            "_debugID": 64,
+            "_debugID": 125,
             "_debugIsCurrentlyTiming": false,
+            "_debugNeedsRemount": false,
             "_debugOwner": [Circular],
             "_debugSource": Object {
               "fileName": "/Users/arnold/Andela-Project/bp-esa-frontend/src/components/Dashboard/Card.jsx",
@@ -2307,8 +1518,9 @@ ReactWrapper {
             "alternate": null,
             "child": FiberNode {
               "_debugHookTypes": null,
-              "_debugID": 65,
+              "_debugID": 127,
               "_debugIsCurrentlyTiming": false,
+              "_debugNeedsRemount": false,
               "_debugOwner": [Circular],
               "_debugSource": Object {
                 "fileName": "/Users/arnold/Andela-Project/bp-esa-frontend/src/components/Dashboard/Card.jsx",
@@ -2319,7 +1531,7 @@ ReactWrapper {
               "alternate": null,
               "child": null,
               "childExpirationTime": 0,
-              "contextDependencies": null,
+              "dependencies": null,
               "effectTag": 0,
               "elementType": "div",
               "expirationTime": 0,
@@ -2353,7 +1565,7 @@ ReactWrapper {
               "updateQueue": null,
             },
             "childExpirationTime": 0,
-            "contextDependencies": null,
+            "dependencies": null,
             "effectTag": 0,
             "elementType": "div",
             "expirationTime": 0,
@@ -2405,7 +1617,7 @@ ReactWrapper {
             "updateQueue": null,
           },
           "childExpirationTime": 0,
-          "contextDependencies": null,
+          "dependencies": null,
           "effectTag": 1,
           "elementType": [Function],
           "expirationTime": 0,
@@ -2449,8 +1661,9 @@ ReactWrapper {
           "ref": null,
           "return": FiberNode {
             "_debugHookTypes": null,
-            "_debugID": 62,
+            "_debugID": 121,
             "_debugIsCurrentlyTiming": false,
+            "_debugNeedsRemount": false,
             "_debugOwner": null,
             "_debugSource": null,
             "actualDuration": 0,
@@ -2458,7 +1671,7 @@ ReactWrapper {
             "alternate": null,
             "child": [Circular],
             "childExpirationTime": 0,
-            "contextDependencies": null,
+            "dependencies": null,
             "effectTag": 1,
             "elementType": [Function],
             "expirationTime": 0,
@@ -2507,267 +1720,7 @@ ReactWrapper {
               "wrappingComponentProps": null,
             },
             "mode": 0,
-            "nextEffect": FiberNode {
-              "_debugHookTypes": null,
-              "_debugID": 60,
-              "_debugIsCurrentlyTiming": false,
-              "_debugOwner": null,
-              "_debugSource": null,
-              "actualDuration": 0,
-              "actualStartTime": -1,
-              "alternate": FiberNode {
-                "_debugHookTypes": null,
-                "_debugID": 60,
-                "_debugIsCurrentlyTiming": false,
-                "_debugOwner": null,
-                "_debugSource": null,
-                "actualDuration": 0,
-                "actualStartTime": -1,
-                "alternate": [Circular],
-                "child": null,
-                "childExpirationTime": 0,
-                "contextDependencies": null,
-                "effectTag": 0,
-                "elementType": null,
-                "expirationTime": 1073741823,
-                "firstEffect": null,
-                "index": 0,
-                "key": null,
-                "lastEffect": null,
-                "memoizedProps": null,
-                "memoizedState": null,
-                "mode": 0,
-                "nextEffect": null,
-                "pendingProps": null,
-                "ref": null,
-                "return": null,
-                "selfBaseDuration": 0,
-                "sibling": null,
-                "stateNode": Object {
-                  "containerInfo": <div>
-                    <div
-                      class="dashboard-card class"
-                    >
-                      <div
-                        class="title"
-                      >
-                        Title Card
-                      </div>
-                    </div>
-                  </div>,
-                  "context": Object {},
-                  "current": [Circular],
-                  "didError": false,
-                  "earliestPendingTime": 0,
-                  "earliestSuspendedTime": 0,
-                  "expirationTime": 0,
-                  "finishedWork": null,
-                  "firstBatch": null,
-                  "hydrate": false,
-                  "interactionThreadID": 15,
-                  "latestPendingTime": 0,
-                  "latestPingedTime": 0,
-                  "latestSuspendedTime": 0,
-                  "memoizedInteractions": Set {},
-                  "nextExpirationTimeToWorkOn": 0,
-                  "nextScheduledRoot": null,
-                  "pendingChildren": null,
-                  "pendingCommitExpirationTime": 0,
-                  "pendingContext": null,
-                  "pendingInteractionMap": Map {},
-                  "pingCache": null,
-                  "timeoutHandle": -1,
-                },
-                "tag": 3,
-                "treeBaseDuration": 0,
-                "type": null,
-                "updateQueue": Object {
-                  "baseState": null,
-                  "firstCapturedEffect": null,
-                  "firstCapturedUpdate": null,
-                  "firstEffect": null,
-                  "firstUpdate": Object {
-                    "callback": null,
-                    "expirationTime": 1073741823,
-                    "next": null,
-                    "nextEffect": null,
-                    "payload": Object {
-                      "element": <WrapperComponent
-                        Component={[Function]}
-                        context={null}
-                        props={
-                          Object {
-                            "classes": "class",
-                            "component": [MockFunction] {
-                              "calls": Array [
-                                Array [],
-                              ],
-                              "results": Array [
-                                Object {
-                                  "isThrow": false,
-                                  "value": undefined,
-                                },
-                              ],
-                            },
-                            "title": "Title Card",
-                          }
-                        }
-                        wrappingComponentProps={null}
-                      />,
-                    },
-                    "tag": 0,
-                  },
-                  "lastCapturedEffect": null,
-                  "lastCapturedUpdate": null,
-                  "lastEffect": null,
-                  "lastUpdate": Object {
-                    "callback": null,
-                    "expirationTime": 1073741823,
-                    "next": null,
-                    "nextEffect": null,
-                    "payload": Object {
-                      "element": <WrapperComponent
-                        Component={[Function]}
-                        context={null}
-                        props={
-                          Object {
-                            "classes": "class",
-                            "component": [MockFunction] {
-                              "calls": Array [
-                                Array [],
-                              ],
-                              "results": Array [
-                                Object {
-                                  "isThrow": false,
-                                  "value": undefined,
-                                },
-                              ],
-                            },
-                            "title": "Title Card",
-                          }
-                        }
-                        wrappingComponentProps={null}
-                      />,
-                    },
-                    "tag": 0,
-                  },
-                },
-              },
-              "child": [Circular],
-              "childExpirationTime": 0,
-              "contextDependencies": null,
-              "effectTag": 32,
-              "elementType": null,
-              "expirationTime": 0,
-              "firstEffect": [Circular],
-              "index": 0,
-              "key": null,
-              "lastEffect": [Circular],
-              "memoizedProps": null,
-              "memoizedState": Object {
-                "element": <WrapperComponent
-                  Component={[Function]}
-                  context={null}
-                  props={
-                    Object {
-                      "classes": "class",
-                      "component": [MockFunction] {
-                        "calls": Array [
-                          Array [],
-                        ],
-                        "results": Array [
-                          Object {
-                            "isThrow": false,
-                            "value": undefined,
-                          },
-                        ],
-                      },
-                      "title": "Title Card",
-                    }
-                  }
-                  wrappingComponentProps={null}
-                />,
-              },
-              "mode": 0,
-              "nextEffect": null,
-              "pendingProps": null,
-              "ref": null,
-              "return": null,
-              "selfBaseDuration": 0,
-              "sibling": null,
-              "stateNode": Object {
-                "containerInfo": <div>
-                  <div
-                    class="dashboard-card class"
-                  >
-                    <div
-                      class="title"
-                    >
-                      Title Card
-                    </div>
-                  </div>
-                </div>,
-                "context": Object {},
-                "current": [Circular],
-                "didError": false,
-                "earliestPendingTime": 0,
-                "earliestSuspendedTime": 0,
-                "expirationTime": 0,
-                "finishedWork": null,
-                "firstBatch": null,
-                "hydrate": false,
-                "interactionThreadID": 15,
-                "latestPendingTime": 0,
-                "latestPingedTime": 0,
-                "latestSuspendedTime": 0,
-                "memoizedInteractions": Set {},
-                "nextExpirationTimeToWorkOn": 0,
-                "nextScheduledRoot": null,
-                "pendingChildren": null,
-                "pendingCommitExpirationTime": 0,
-                "pendingContext": null,
-                "pendingInteractionMap": Map {},
-                "pingCache": null,
-                "timeoutHandle": -1,
-              },
-              "tag": 3,
-              "treeBaseDuration": 0,
-              "type": null,
-              "updateQueue": Object {
-                "baseState": Object {
-                  "element": <WrapperComponent
-                    Component={[Function]}
-                    context={null}
-                    props={
-                      Object {
-                        "classes": "class",
-                        "component": [MockFunction] {
-                          "calls": Array [
-                            Array [],
-                          ],
-                          "results": Array [
-                            Object {
-                              "isThrow": false,
-                              "value": undefined,
-                            },
-                          ],
-                        },
-                        "title": "Title Card",
-                      }
-                    }
-                    wrappingComponentProps={null}
-                  />,
-                },
-                "firstCapturedEffect": null,
-                "firstCapturedUpdate": null,
-                "firstEffect": null,
-                "firstUpdate": null,
-                "lastCapturedEffect": null,
-                "lastCapturedUpdate": null,
-                "lastEffect": null,
-                "lastUpdate": null,
-              },
-            },
+            "nextEffect": null,
             "pendingProps": Object {
               "Component": [Function],
               "context": null,
@@ -2791,16 +1744,18 @@ ReactWrapper {
             "ref": null,
             "return": FiberNode {
               "_debugHookTypes": null,
-              "_debugID": 60,
+              "_debugID": 118,
               "_debugIsCurrentlyTiming": false,
+              "_debugNeedsRemount": false,
               "_debugOwner": null,
               "_debugSource": null,
               "actualDuration": 0,
               "actualStartTime": -1,
               "alternate": FiberNode {
                 "_debugHookTypes": null,
-                "_debugID": 60,
+                "_debugID": 118,
                 "_debugIsCurrentlyTiming": false,
+                "_debugNeedsRemount": false,
                 "_debugOwner": null,
                 "_debugSource": null,
                 "actualDuration": 0,
@@ -2808,7 +1763,7 @@ ReactWrapper {
                 "alternate": [Circular],
                 "child": null,
                 "childExpirationTime": 0,
-                "contextDependencies": null,
+                "dependencies": null,
                 "effectTag": 0,
                 "elementType": null,
                 "expirationTime": 1073741823,
@@ -2825,7 +1780,9 @@ ReactWrapper {
                 "return": null,
                 "selfBaseDuration": 0,
                 "sibling": null,
-                "stateNode": Object {
+                "stateNode": FiberRootNode {
+                  "callbackExpirationTime": 0,
+                  "callbackNode": null,
                   "containerInfo": <div>
                     <div
                       class="dashboard-card class"
@@ -2839,25 +1796,20 @@ ReactWrapper {
                   </div>,
                   "context": Object {},
                   "current": [Circular],
-                  "didError": false,
-                  "earliestPendingTime": 0,
-                  "earliestSuspendedTime": 0,
-                  "expirationTime": 0,
+                  "finishedExpirationTime": 0,
                   "finishedWork": null,
                   "firstBatch": null,
+                  "firstPendingTime": 0,
                   "hydrate": false,
-                  "interactionThreadID": 15,
-                  "latestPendingTime": 0,
-                  "latestPingedTime": 0,
-                  "latestSuspendedTime": 0,
+                  "interactionThreadID": 16,
+                  "lastPendingTime": 0,
                   "memoizedInteractions": Set {},
-                  "nextExpirationTimeToWorkOn": 0,
-                  "nextScheduledRoot": null,
                   "pendingChildren": null,
-                  "pendingCommitExpirationTime": 0,
                   "pendingContext": null,
                   "pendingInteractionMap": Map {},
                   "pingCache": null,
+                  "pingTime": 0,
+                  "tag": 0,
                   "timeoutHandle": -1,
                 },
                 "tag": 3,
@@ -2897,6 +1849,8 @@ ReactWrapper {
                         wrappingComponentProps={null}
                       />,
                     },
+                    "priority": 97,
+                    "suspenseConfig": null,
                     "tag": 0,
                   },
                   "lastCapturedEffect": null,
@@ -2931,14 +1885,16 @@ ReactWrapper {
                         wrappingComponentProps={null}
                       />,
                     },
+                    "priority": 97,
+                    "suspenseConfig": null,
                     "tag": 0,
                   },
                 },
               },
               "child": [Circular],
               "childExpirationTime": 0,
-              "contextDependencies": null,
-              "effectTag": 32,
+              "dependencies": null,
+              "effectTag": 0,
               "elementType": null,
               "expirationTime": 0,
               "firstEffect": [Circular],
@@ -2977,7 +1933,9 @@ ReactWrapper {
               "return": null,
               "selfBaseDuration": 0,
               "sibling": null,
-              "stateNode": Object {
+              "stateNode": FiberRootNode {
+                "callbackExpirationTime": 0,
+                "callbackNode": null,
                 "containerInfo": <div>
                   <div
                     class="dashboard-card class"
@@ -2991,25 +1949,20 @@ ReactWrapper {
                 </div>,
                 "context": Object {},
                 "current": [Circular],
-                "didError": false,
-                "earliestPendingTime": 0,
-                "earliestSuspendedTime": 0,
-                "expirationTime": 0,
+                "finishedExpirationTime": 0,
                 "finishedWork": null,
                 "firstBatch": null,
+                "firstPendingTime": 0,
                 "hydrate": false,
-                "interactionThreadID": 15,
-                "latestPendingTime": 0,
-                "latestPingedTime": 0,
-                "latestSuspendedTime": 0,
+                "interactionThreadID": 16,
+                "lastPendingTime": 0,
                 "memoizedInteractions": Set {},
-                "nextExpirationTimeToWorkOn": 0,
-                "nextScheduledRoot": null,
                 "pendingChildren": null,
-                "pendingCommitExpirationTime": 0,
                 "pendingContext": null,
                 "pendingInteractionMap": Map {},
                 "pingCache": null,
+                "pingTime": 0,
+                "tag": 0,
                 "timeoutHandle": -1,
               },
               "tag": 3,
@@ -3235,5 +2188,24 @@ ReactWrapper {
       },
     },
   },
+  Symbol(enzyme.__linkedRoots__): Array [],
+  Symbol(enzyme.__unrendered__): <Card
+    classes="class"
+    component={
+      [MockFunction] {
+        "calls": Array [
+          Array [],
+        ],
+        "results": Array [
+          Object {
+            "isThrow": false,
+            "value": undefined,
+          },
+        ],
+      }
+    }
+    title="Title Card"
+  />,
+  Symbol(enzyme.__updatedBy__): null,
 }
 `;

--- a/src/__tests__/components/Dashboard/activityFeed/__snapshots__/ActivityFeed.test.jsx.snap
+++ b/src/__tests__/components/Dashboard/activityFeed/__snapshots__/ActivityFeed.test.jsx.snap
@@ -802,5 +802,18 @@ ReactWrapper {
       },
     },
   },
+  Symbol(enzyme.__linkedRoots__): Array [],
+  Symbol(enzyme.__unrendered__): <ActivityFeed
+    reportData={
+      Array [
+        Object {
+          "fellowName": "Kitika, Kelvin",
+          "type": "offboarding",
+          "updatedAt": "2019-05-15T13:47:04.608Z",
+        },
+      ]
+    }
+  />,
+  Symbol(enzyme.__updatedBy__): null,
 }
 `;

--- a/src/__tests__/components/Dashboard/index.test.jsx
+++ b/src/__tests__/components/Dashboard/index.test.jsx
@@ -3,7 +3,7 @@ import configureStore from 'redux-mock-store';
 import ReactRouterEnzymeContext from 'react-router-enzyme-context';
 import { Provider } from 'react-redux';
 import { mount } from 'enzyme';
-import Dashboard from '../../../components/Dashboard';
+import Dashboard, { mapDispatchToProps } from '../../../components/Dashboard';
 
 const options = new ReactRouterEnzymeContext();
 
@@ -39,5 +39,12 @@ describe('test dashboard', () => {
     const upsellingCard = wrapper.find('.upSelling');
     const title = upsellingCard.find('.title');
     expect(title.text()).toEqual('Upselling Partners');
+  });
+
+  it('Test mapDispatch to props', () => {
+    const dispatch = jest.fn();
+    const expectedProps = mapDispatchToProps(dispatch);
+    expectedProps.fetchUpdates();
+    expect(dispatch).toHaveBeenCalled();
   });
 });

--- a/src/__tests__/components/FilterComponent/__snapshots__/Snapshots.test.jsx.snap
+++ b/src/__tests__/components/FilterComponent/__snapshots__/Snapshots.test.jsx.snap
@@ -98,7 +98,9 @@ ShallowWrapper {
         },
       },
     },
+    Symbol(enzyme.__providerValues__): undefined,
   },
+  Symbol(enzyme.__providerValues__): Map {},
 }
 `;
 
@@ -164,7 +166,9 @@ ShallowWrapper {
         },
       },
     },
+    Symbol(enzyme.__providerValues__): undefined,
   },
+  Symbol(enzyme.__providerValues__): Map {},
 }
 `;
 
@@ -290,7 +294,9 @@ ShallowWrapper {
         },
       },
     },
+    Symbol(enzyme.__providerValues__): undefined,
   },
+  Symbol(enzyme.__providerValues__): Map {},
 }
 `;
 
@@ -564,7 +570,9 @@ ShallowWrapper {
         },
       },
     },
+    Symbol(enzyme.__providerValues__): undefined,
   },
+  Symbol(enzyme.__providerValues__): Map {},
   Symbol(enzyme.__childContext__): null,
 }
 `;
@@ -1266,6 +1274,8 @@ ShallowWrapper {
         },
       },
     },
+    Symbol(enzyme.__providerValues__): undefined,
   },
+  Symbol(enzyme.__providerValues__): Map {},
 }
 `;

--- a/src/__tests__/components/ReportNavBar/__snapshots__/ReportNavBar.test.jsx.snap
+++ b/src/__tests__/components/ReportNavBar/__snapshots__/ReportNavBar.test.jsx.snap
@@ -155,6 +155,8 @@ ShallowWrapper {
         },
       },
     },
+    Symbol(enzyme.__providerValues__): undefined,
   },
+  Symbol(enzyme.__providerValues__): Map {},
 }
 `;

--- a/src/__tests__/components/Spinner/__snapshots__/Spinner.test.jsx.snap
+++ b/src/__tests__/components/Spinner/__snapshots__/Spinner.test.jsx.snap
@@ -62,6 +62,8 @@ ShallowWrapper {
         },
       },
     },
+    Symbol(enzyme.__providerValues__): undefined,
   },
+  Symbol(enzyme.__providerValues__): Map {},
 }
 `;

--- a/src/__tests__/components/StatsCard/__snapshots__/Dropdown.test.jsx.snap
+++ b/src/__tests__/components/StatsCard/__snapshots__/Dropdown.test.jsx.snap
@@ -4,12 +4,14 @@ exports[`Dropdown should render as expected 1`] = `
 Dropdown {
   "_reactInternalFiber": FiberNode {
     "_debugHookTypes": null,
-    "_debugID": 63,
+    "_debugID": 123,
     "_debugIsCurrentlyTiming": false,
+    "_debugNeedsRemount": false,
     "_debugOwner": FiberNode {
       "_debugHookTypes": null,
-      "_debugID": 62,
+      "_debugID": 121,
       "_debugIsCurrentlyTiming": false,
+      "_debugNeedsRemount": false,
       "_debugOwner": null,
       "_debugSource": null,
       "actualDuration": 0,
@@ -17,7 +19,7 @@ Dropdown {
       "alternate": null,
       "child": [Circular],
       "childExpirationTime": 0,
-      "contextDependencies": null,
+      "dependencies": null,
       "effectTag": 1,
       "elementType": [Function],
       "expirationTime": 0,
@@ -42,229 +44,7 @@ Dropdown {
         "wrappingComponentProps": null,
       },
       "mode": 0,
-      "nextEffect": FiberNode {
-        "_debugHookTypes": null,
-        "_debugID": 60,
-        "_debugIsCurrentlyTiming": false,
-        "_debugOwner": null,
-        "_debugSource": null,
-        "actualDuration": 0,
-        "actualStartTime": -1,
-        "alternate": FiberNode {
-          "_debugHookTypes": null,
-          "_debugID": 60,
-          "_debugIsCurrentlyTiming": false,
-          "_debugOwner": null,
-          "_debugSource": null,
-          "actualDuration": 0,
-          "actualStartTime": -1,
-          "alternate": [Circular],
-          "child": null,
-          "childExpirationTime": 0,
-          "contextDependencies": null,
-          "effectTag": 0,
-          "elementType": null,
-          "expirationTime": 1073741823,
-          "firstEffect": null,
-          "index": 0,
-          "key": null,
-          "lastEffect": null,
-          "memoizedProps": null,
-          "memoizedState": null,
-          "mode": 0,
-          "nextEffect": null,
-          "pendingProps": null,
-          "ref": null,
-          "return": null,
-          "selfBaseDuration": 0,
-          "sibling": null,
-          "stateNode": Object {
-            "containerInfo": <div>
-              <div
-                class="stat-dropdown-container"
-              >
-                Automations stats for
-                <span
-                  class="stat-dropdown-caret"
-                >
-                   today
-                  <img
-                    alt="down"
-                    src="/drop-down.png"
-                  />
-                </span>
-              </div>
-            </div>,
-            "context": Object {},
-            "current": [Circular],
-            "didError": false,
-            "earliestPendingTime": 0,
-            "earliestSuspendedTime": 0,
-            "expirationTime": 0,
-            "finishedWork": null,
-            "firstBatch": null,
-            "hydrate": false,
-            "interactionThreadID": 15,
-            "latestPendingTime": 0,
-            "latestPingedTime": 0,
-            "latestSuspendedTime": 0,
-            "memoizedInteractions": Set {},
-            "nextExpirationTimeToWorkOn": 0,
-            "nextScheduledRoot": null,
-            "pendingChildren": null,
-            "pendingCommitExpirationTime": 0,
-            "pendingContext": null,
-            "pendingInteractionMap": Map {},
-            "pingCache": null,
-            "timeoutHandle": -1,
-          },
-          "tag": 3,
-          "treeBaseDuration": 0,
-          "type": null,
-          "updateQueue": Object {
-            "baseState": null,
-            "firstCapturedEffect": null,
-            "firstCapturedUpdate": null,
-            "firstEffect": null,
-            "firstUpdate": Object {
-              "callback": null,
-              "expirationTime": 1073741823,
-              "next": null,
-              "nextEffect": null,
-              "payload": Object {
-                "element": <WrapperComponent
-                  Component={[Function]}
-                  context={null}
-                  props={
-                    Object {
-                      "fetchStat": [MockFunction],
-                    }
-                  }
-                  wrappingComponentProps={null}
-                />,
-              },
-              "tag": 0,
-            },
-            "lastCapturedEffect": null,
-            "lastCapturedUpdate": null,
-            "lastEffect": null,
-            "lastUpdate": Object {
-              "callback": null,
-              "expirationTime": 1073741823,
-              "next": null,
-              "nextEffect": null,
-              "payload": Object {
-                "element": <WrapperComponent
-                  Component={[Function]}
-                  context={null}
-                  props={
-                    Object {
-                      "fetchStat": [MockFunction],
-                    }
-                  }
-                  wrappingComponentProps={null}
-                />,
-              },
-              "tag": 0,
-            },
-          },
-        },
-        "child": [Circular],
-        "childExpirationTime": 0,
-        "contextDependencies": null,
-        "effectTag": 32,
-        "elementType": null,
-        "expirationTime": 0,
-        "firstEffect": [Circular],
-        "index": 0,
-        "key": null,
-        "lastEffect": [Circular],
-        "memoizedProps": null,
-        "memoizedState": Object {
-          "element": <WrapperComponent
-            Component={[Function]}
-            context={null}
-            props={
-              Object {
-                "fetchStat": [MockFunction],
-              }
-            }
-            wrappingComponentProps={null}
-          />,
-        },
-        "mode": 0,
-        "nextEffect": null,
-        "pendingProps": null,
-        "ref": null,
-        "return": null,
-        "selfBaseDuration": 0,
-        "sibling": null,
-        "stateNode": Object {
-          "containerInfo": <div>
-            <div
-              class="stat-dropdown-container"
-            >
-              Automations stats for
-              <span
-                class="stat-dropdown-caret"
-              >
-                 today
-                <img
-                  alt="down"
-                  src="/drop-down.png"
-                />
-              </span>
-            </div>
-          </div>,
-          "context": Object {},
-          "current": [Circular],
-          "didError": false,
-          "earliestPendingTime": 0,
-          "earliestSuspendedTime": 0,
-          "expirationTime": 0,
-          "finishedWork": null,
-          "firstBatch": null,
-          "hydrate": false,
-          "interactionThreadID": 15,
-          "latestPendingTime": 0,
-          "latestPingedTime": 0,
-          "latestSuspendedTime": 0,
-          "memoizedInteractions": Set {},
-          "nextExpirationTimeToWorkOn": 0,
-          "nextScheduledRoot": null,
-          "pendingChildren": null,
-          "pendingCommitExpirationTime": 0,
-          "pendingContext": null,
-          "pendingInteractionMap": Map {},
-          "pingCache": null,
-          "timeoutHandle": -1,
-        },
-        "tag": 3,
-        "treeBaseDuration": 0,
-        "type": null,
-        "updateQueue": Object {
-          "baseState": Object {
-            "element": <WrapperComponent
-              Component={[Function]}
-              context={null}
-              props={
-                Object {
-                  "fetchStat": [MockFunction],
-                }
-              }
-              wrappingComponentProps={null}
-            />,
-          },
-          "firstCapturedEffect": null,
-          "firstCapturedUpdate": null,
-          "firstEffect": null,
-          "firstUpdate": null,
-          "lastCapturedEffect": null,
-          "lastCapturedUpdate": null,
-          "lastEffect": null,
-          "lastUpdate": null,
-        },
-      },
+      "nextEffect": null,
       "pendingProps": Object {
         "Component": [Function],
         "context": null,
@@ -276,16 +56,18 @@ Dropdown {
       "ref": null,
       "return": FiberNode {
         "_debugHookTypes": null,
-        "_debugID": 60,
+        "_debugID": 118,
         "_debugIsCurrentlyTiming": false,
+        "_debugNeedsRemount": false,
         "_debugOwner": null,
         "_debugSource": null,
         "actualDuration": 0,
         "actualStartTime": -1,
         "alternate": FiberNode {
           "_debugHookTypes": null,
-          "_debugID": 60,
+          "_debugID": 118,
           "_debugIsCurrentlyTiming": false,
+          "_debugNeedsRemount": false,
           "_debugOwner": null,
           "_debugSource": null,
           "actualDuration": 0,
@@ -293,7 +75,7 @@ Dropdown {
           "alternate": [Circular],
           "child": null,
           "childExpirationTime": 0,
-          "contextDependencies": null,
+          "dependencies": null,
           "effectTag": 0,
           "elementType": null,
           "expirationTime": 1073741823,
@@ -310,7 +92,9 @@ Dropdown {
           "return": null,
           "selfBaseDuration": 0,
           "sibling": null,
-          "stateNode": Object {
+          "stateNode": FiberRootNode {
+            "callbackExpirationTime": 0,
+            "callbackNode": null,
             "containerInfo": <div>
               <div
                 class="stat-dropdown-container"
@@ -329,25 +113,20 @@ Dropdown {
             </div>,
             "context": Object {},
             "current": [Circular],
-            "didError": false,
-            "earliestPendingTime": 0,
-            "earliestSuspendedTime": 0,
-            "expirationTime": 0,
+            "finishedExpirationTime": 0,
             "finishedWork": null,
             "firstBatch": null,
+            "firstPendingTime": 0,
             "hydrate": false,
-            "interactionThreadID": 15,
-            "latestPendingTime": 0,
-            "latestPingedTime": 0,
-            "latestSuspendedTime": 0,
+            "interactionThreadID": 16,
+            "lastPendingTime": 0,
             "memoizedInteractions": Set {},
-            "nextExpirationTimeToWorkOn": 0,
-            "nextScheduledRoot": null,
             "pendingChildren": null,
-            "pendingCommitExpirationTime": 0,
             "pendingContext": null,
             "pendingInteractionMap": Map {},
             "pingCache": null,
+            "pingTime": 0,
+            "tag": 0,
             "timeoutHandle": -1,
           },
           "tag": 3,
@@ -375,6 +154,8 @@ Dropdown {
                   wrappingComponentProps={null}
                 />,
               },
+              "priority": 97,
+              "suspenseConfig": null,
               "tag": 0,
             },
             "lastCapturedEffect": null,
@@ -397,14 +178,16 @@ Dropdown {
                   wrappingComponentProps={null}
                 />,
               },
+              "priority": 97,
+              "suspenseConfig": null,
               "tag": 0,
             },
           },
         },
         "child": [Circular],
         "childExpirationTime": 0,
-        "contextDependencies": null,
-        "effectTag": 32,
+        "dependencies": null,
+        "effectTag": 0,
         "elementType": null,
         "expirationTime": 0,
         "firstEffect": [Circular],
@@ -431,7 +214,9 @@ Dropdown {
         "return": null,
         "selfBaseDuration": 0,
         "sibling": null,
-        "stateNode": Object {
+        "stateNode": FiberRootNode {
+          "callbackExpirationTime": 0,
+          "callbackNode": null,
           "containerInfo": <div>
             <div
               class="stat-dropdown-container"
@@ -450,25 +235,20 @@ Dropdown {
           </div>,
           "context": Object {},
           "current": [Circular],
-          "didError": false,
-          "earliestPendingTime": 0,
-          "earliestSuspendedTime": 0,
-          "expirationTime": 0,
+          "finishedExpirationTime": 0,
           "finishedWork": null,
           "firstBatch": null,
+          "firstPendingTime": 0,
           "hydrate": false,
-          "interactionThreadID": 15,
-          "latestPendingTime": 0,
-          "latestPingedTime": 0,
-          "latestSuspendedTime": 0,
+          "interactionThreadID": 16,
+          "lastPendingTime": 0,
           "memoizedInteractions": Set {},
-          "nextExpirationTimeToWorkOn": 0,
-          "nextScheduledRoot": null,
           "pendingChildren": null,
-          "pendingCommitExpirationTime": 0,
           "pendingContext": null,
           "pendingInteractionMap": Map {},
           "pingCache": null,
+          "pingTime": 0,
+          "tag": 0,
           "timeoutHandle": -1,
         },
         "tag": 3,
@@ -539,8 +319,9 @@ Dropdown {
     "alternate": null,
     "child": FiberNode {
       "_debugHookTypes": null,
-      "_debugID": 64,
+      "_debugID": 125,
       "_debugIsCurrentlyTiming": false,
+      "_debugNeedsRemount": false,
       "_debugOwner": [Circular],
       "_debugSource": Object {
         "fileName": "/Users/arnold/Andela-Project/bp-esa-frontend/src/components/StatsCard/Dropdown.jsx",
@@ -551,8 +332,9 @@ Dropdown {
       "alternate": null,
       "child": FiberNode {
         "_debugHookTypes": null,
-        "_debugID": 65,
+        "_debugID": 127,
         "_debugIsCurrentlyTiming": false,
+        "_debugNeedsRemount": false,
         "_debugOwner": null,
         "_debugSource": null,
         "actualDuration": 0,
@@ -560,7 +342,7 @@ Dropdown {
         "alternate": null,
         "child": null,
         "childExpirationTime": 0,
-        "contextDependencies": null,
+        "dependencies": null,
         "effectTag": 0,
         "elementType": null,
         "expirationTime": 0,
@@ -578,8 +360,9 @@ Dropdown {
         "selfBaseDuration": 0,
         "sibling": FiberNode {
           "_debugHookTypes": null,
-          "_debugID": 66,
+          "_debugID": 128,
           "_debugIsCurrentlyTiming": false,
+          "_debugNeedsRemount": false,
           "_debugOwner": [Circular],
           "_debugSource": Object {
             "fileName": "/Users/arnold/Andela-Project/bp-esa-frontend/src/components/StatsCard/Dropdown.jsx",
@@ -590,8 +373,9 @@ Dropdown {
           "alternate": null,
           "child": FiberNode {
             "_debugHookTypes": null,
-            "_debugID": 67,
+            "_debugID": 131,
             "_debugIsCurrentlyTiming": false,
+            "_debugNeedsRemount": false,
             "_debugOwner": null,
             "_debugSource": null,
             "actualDuration": 0,
@@ -599,7 +383,7 @@ Dropdown {
             "alternate": null,
             "child": null,
             "childExpirationTime": 0,
-            "contextDependencies": null,
+            "dependencies": null,
             "effectTag": 0,
             "elementType": null,
             "expirationTime": 0,
@@ -617,8 +401,9 @@ Dropdown {
             "selfBaseDuration": 0,
             "sibling": FiberNode {
               "_debugHookTypes": null,
-              "_debugID": 68,
+              "_debugID": 132,
               "_debugIsCurrentlyTiming": false,
+              "_debugNeedsRemount": false,
               "_debugOwner": [Circular],
               "_debugSource": Object {
                 "fileName": "/Users/arnold/Andela-Project/bp-esa-frontend/src/components/StatsCard/Dropdown.jsx",
@@ -629,7 +414,7 @@ Dropdown {
               "alternate": null,
               "child": null,
               "childExpirationTime": 0,
-              "contextDependencies": null,
+              "dependencies": null,
               "effectTag": 0,
               "elementType": "img",
               "expirationTime": 0,
@@ -668,7 +453,7 @@ Dropdown {
             "updateQueue": null,
           },
           "childExpirationTime": 0,
-          "contextDependencies": null,
+          "dependencies": null,
           "effectTag": 0,
           "elementType": "span",
           "expirationTime": 0,
@@ -726,7 +511,7 @@ Dropdown {
         "updateQueue": null,
       },
       "childExpirationTime": 0,
-      "contextDependencies": null,
+      "dependencies": null,
       "effectTag": 0,
       "elementType": "div",
       "expirationTime": 0,
@@ -795,7 +580,7 @@ Dropdown {
       "updateQueue": null,
     },
     "childExpirationTime": 0,
-    "contextDependencies": null,
+    "dependencies": null,
     "effectTag": 1,
     "elementType": [Function],
     "expirationTime": 0,
@@ -818,8 +603,9 @@ Dropdown {
     "ref": null,
     "return": FiberNode {
       "_debugHookTypes": null,
-      "_debugID": 62,
+      "_debugID": 121,
       "_debugIsCurrentlyTiming": false,
+      "_debugNeedsRemount": false,
       "_debugOwner": null,
       "_debugSource": null,
       "actualDuration": 0,
@@ -827,7 +613,7 @@ Dropdown {
       "alternate": null,
       "child": [Circular],
       "childExpirationTime": 0,
-      "contextDependencies": null,
+      "dependencies": null,
       "effectTag": 1,
       "elementType": [Function],
       "expirationTime": 0,
@@ -852,229 +638,7 @@ Dropdown {
         "wrappingComponentProps": null,
       },
       "mode": 0,
-      "nextEffect": FiberNode {
-        "_debugHookTypes": null,
-        "_debugID": 60,
-        "_debugIsCurrentlyTiming": false,
-        "_debugOwner": null,
-        "_debugSource": null,
-        "actualDuration": 0,
-        "actualStartTime": -1,
-        "alternate": FiberNode {
-          "_debugHookTypes": null,
-          "_debugID": 60,
-          "_debugIsCurrentlyTiming": false,
-          "_debugOwner": null,
-          "_debugSource": null,
-          "actualDuration": 0,
-          "actualStartTime": -1,
-          "alternate": [Circular],
-          "child": null,
-          "childExpirationTime": 0,
-          "contextDependencies": null,
-          "effectTag": 0,
-          "elementType": null,
-          "expirationTime": 1073741823,
-          "firstEffect": null,
-          "index": 0,
-          "key": null,
-          "lastEffect": null,
-          "memoizedProps": null,
-          "memoizedState": null,
-          "mode": 0,
-          "nextEffect": null,
-          "pendingProps": null,
-          "ref": null,
-          "return": null,
-          "selfBaseDuration": 0,
-          "sibling": null,
-          "stateNode": Object {
-            "containerInfo": <div>
-              <div
-                class="stat-dropdown-container"
-              >
-                Automations stats for
-                <span
-                  class="stat-dropdown-caret"
-                >
-                   today
-                  <img
-                    alt="down"
-                    src="/drop-down.png"
-                  />
-                </span>
-              </div>
-            </div>,
-            "context": Object {},
-            "current": [Circular],
-            "didError": false,
-            "earliestPendingTime": 0,
-            "earliestSuspendedTime": 0,
-            "expirationTime": 0,
-            "finishedWork": null,
-            "firstBatch": null,
-            "hydrate": false,
-            "interactionThreadID": 15,
-            "latestPendingTime": 0,
-            "latestPingedTime": 0,
-            "latestSuspendedTime": 0,
-            "memoizedInteractions": Set {},
-            "nextExpirationTimeToWorkOn": 0,
-            "nextScheduledRoot": null,
-            "pendingChildren": null,
-            "pendingCommitExpirationTime": 0,
-            "pendingContext": null,
-            "pendingInteractionMap": Map {},
-            "pingCache": null,
-            "timeoutHandle": -1,
-          },
-          "tag": 3,
-          "treeBaseDuration": 0,
-          "type": null,
-          "updateQueue": Object {
-            "baseState": null,
-            "firstCapturedEffect": null,
-            "firstCapturedUpdate": null,
-            "firstEffect": null,
-            "firstUpdate": Object {
-              "callback": null,
-              "expirationTime": 1073741823,
-              "next": null,
-              "nextEffect": null,
-              "payload": Object {
-                "element": <WrapperComponent
-                  Component={[Function]}
-                  context={null}
-                  props={
-                    Object {
-                      "fetchStat": [MockFunction],
-                    }
-                  }
-                  wrappingComponentProps={null}
-                />,
-              },
-              "tag": 0,
-            },
-            "lastCapturedEffect": null,
-            "lastCapturedUpdate": null,
-            "lastEffect": null,
-            "lastUpdate": Object {
-              "callback": null,
-              "expirationTime": 1073741823,
-              "next": null,
-              "nextEffect": null,
-              "payload": Object {
-                "element": <WrapperComponent
-                  Component={[Function]}
-                  context={null}
-                  props={
-                    Object {
-                      "fetchStat": [MockFunction],
-                    }
-                  }
-                  wrappingComponentProps={null}
-                />,
-              },
-              "tag": 0,
-            },
-          },
-        },
-        "child": [Circular],
-        "childExpirationTime": 0,
-        "contextDependencies": null,
-        "effectTag": 32,
-        "elementType": null,
-        "expirationTime": 0,
-        "firstEffect": [Circular],
-        "index": 0,
-        "key": null,
-        "lastEffect": [Circular],
-        "memoizedProps": null,
-        "memoizedState": Object {
-          "element": <WrapperComponent
-            Component={[Function]}
-            context={null}
-            props={
-              Object {
-                "fetchStat": [MockFunction],
-              }
-            }
-            wrappingComponentProps={null}
-          />,
-        },
-        "mode": 0,
-        "nextEffect": null,
-        "pendingProps": null,
-        "ref": null,
-        "return": null,
-        "selfBaseDuration": 0,
-        "sibling": null,
-        "stateNode": Object {
-          "containerInfo": <div>
-            <div
-              class="stat-dropdown-container"
-            >
-              Automations stats for
-              <span
-                class="stat-dropdown-caret"
-              >
-                 today
-                <img
-                  alt="down"
-                  src="/drop-down.png"
-                />
-              </span>
-            </div>
-          </div>,
-          "context": Object {},
-          "current": [Circular],
-          "didError": false,
-          "earliestPendingTime": 0,
-          "earliestSuspendedTime": 0,
-          "expirationTime": 0,
-          "finishedWork": null,
-          "firstBatch": null,
-          "hydrate": false,
-          "interactionThreadID": 15,
-          "latestPendingTime": 0,
-          "latestPingedTime": 0,
-          "latestSuspendedTime": 0,
-          "memoizedInteractions": Set {},
-          "nextExpirationTimeToWorkOn": 0,
-          "nextScheduledRoot": null,
-          "pendingChildren": null,
-          "pendingCommitExpirationTime": 0,
-          "pendingContext": null,
-          "pendingInteractionMap": Map {},
-          "pingCache": null,
-          "timeoutHandle": -1,
-        },
-        "tag": 3,
-        "treeBaseDuration": 0,
-        "type": null,
-        "updateQueue": Object {
-          "baseState": Object {
-            "element": <WrapperComponent
-              Component={[Function]}
-              context={null}
-              props={
-                Object {
-                  "fetchStat": [MockFunction],
-                }
-              }
-              wrappingComponentProps={null}
-            />,
-          },
-          "firstCapturedEffect": null,
-          "firstCapturedUpdate": null,
-          "firstEffect": null,
-          "firstUpdate": null,
-          "lastCapturedEffect": null,
-          "lastCapturedUpdate": null,
-          "lastEffect": null,
-          "lastUpdate": null,
-        },
-      },
+      "nextEffect": null,
       "pendingProps": Object {
         "Component": [Function],
         "context": null,
@@ -1086,16 +650,18 @@ Dropdown {
       "ref": null,
       "return": FiberNode {
         "_debugHookTypes": null,
-        "_debugID": 60,
+        "_debugID": 118,
         "_debugIsCurrentlyTiming": false,
+        "_debugNeedsRemount": false,
         "_debugOwner": null,
         "_debugSource": null,
         "actualDuration": 0,
         "actualStartTime": -1,
         "alternate": FiberNode {
           "_debugHookTypes": null,
-          "_debugID": 60,
+          "_debugID": 118,
           "_debugIsCurrentlyTiming": false,
+          "_debugNeedsRemount": false,
           "_debugOwner": null,
           "_debugSource": null,
           "actualDuration": 0,
@@ -1103,7 +669,7 @@ Dropdown {
           "alternate": [Circular],
           "child": null,
           "childExpirationTime": 0,
-          "contextDependencies": null,
+          "dependencies": null,
           "effectTag": 0,
           "elementType": null,
           "expirationTime": 1073741823,
@@ -1120,7 +686,9 @@ Dropdown {
           "return": null,
           "selfBaseDuration": 0,
           "sibling": null,
-          "stateNode": Object {
+          "stateNode": FiberRootNode {
+            "callbackExpirationTime": 0,
+            "callbackNode": null,
             "containerInfo": <div>
               <div
                 class="stat-dropdown-container"
@@ -1139,25 +707,20 @@ Dropdown {
             </div>,
             "context": Object {},
             "current": [Circular],
-            "didError": false,
-            "earliestPendingTime": 0,
-            "earliestSuspendedTime": 0,
-            "expirationTime": 0,
+            "finishedExpirationTime": 0,
             "finishedWork": null,
             "firstBatch": null,
+            "firstPendingTime": 0,
             "hydrate": false,
-            "interactionThreadID": 15,
-            "latestPendingTime": 0,
-            "latestPingedTime": 0,
-            "latestSuspendedTime": 0,
+            "interactionThreadID": 16,
+            "lastPendingTime": 0,
             "memoizedInteractions": Set {},
-            "nextExpirationTimeToWorkOn": 0,
-            "nextScheduledRoot": null,
             "pendingChildren": null,
-            "pendingCommitExpirationTime": 0,
             "pendingContext": null,
             "pendingInteractionMap": Map {},
             "pingCache": null,
+            "pingTime": 0,
+            "tag": 0,
             "timeoutHandle": -1,
           },
           "tag": 3,
@@ -1185,6 +748,8 @@ Dropdown {
                   wrappingComponentProps={null}
                 />,
               },
+              "priority": 97,
+              "suspenseConfig": null,
               "tag": 0,
             },
             "lastCapturedEffect": null,
@@ -1207,14 +772,16 @@ Dropdown {
                   wrappingComponentProps={null}
                 />,
               },
+              "priority": 97,
+              "suspenseConfig": null,
               "tag": 0,
             },
           },
         },
         "child": [Circular],
         "childExpirationTime": 0,
-        "contextDependencies": null,
-        "effectTag": 32,
+        "dependencies": null,
+        "effectTag": 0,
         "elementType": null,
         "expirationTime": 0,
         "firstEffect": [Circular],
@@ -1241,7 +808,9 @@ Dropdown {
         "return": null,
         "selfBaseDuration": 0,
         "sibling": null,
-        "stateNode": Object {
+        "stateNode": FiberRootNode {
+          "callbackExpirationTime": 0,
+          "callbackNode": null,
           "containerInfo": <div>
             <div
               class="stat-dropdown-container"
@@ -1260,25 +829,20 @@ Dropdown {
           </div>,
           "context": Object {},
           "current": [Circular],
-          "didError": false,
-          "earliestPendingTime": 0,
-          "earliestSuspendedTime": 0,
-          "expirationTime": 0,
+          "finishedExpirationTime": 0,
           "finishedWork": null,
           "firstBatch": null,
+          "firstPendingTime": 0,
           "hydrate": false,
-          "interactionThreadID": 15,
-          "latestPendingTime": 0,
-          "latestPingedTime": 0,
-          "latestSuspendedTime": 0,
+          "interactionThreadID": 16,
+          "lastPendingTime": 0,
           "memoizedInteractions": Set {},
-          "nextExpirationTimeToWorkOn": 0,
-          "nextScheduledRoot": null,
           "pendingChildren": null,
-          "pendingCommitExpirationTime": 0,
           "pendingContext": null,
           "pendingInteractionMap": Map {},
           "pingCache": null,
+          "pingTime": 0,
+          "tag": 0,
           "timeoutHandle": -1,
         },
         "tag": 3,

--- a/src/__tests__/components/StatsCard/__snapshots__/StatsCard.test.jsx.snap
+++ b/src/__tests__/components/StatsCard/__snapshots__/StatsCard.test.jsx.snap
@@ -216,7 +216,9 @@ ShallowWrapper {
         },
       },
     },
+    Symbol(enzyme.__providerValues__): undefined,
   },
+  Symbol(enzyme.__providerValues__): Map {},
   Symbol(enzyme.__childContext__): null,
 }
 `;

--- a/src/__tests__/components/__snapshots__/Header.test.jsx.snap
+++ b/src/__tests__/components/__snapshots__/Header.test.jsx.snap
@@ -1373,7 +1373,9 @@ ShallowWrapper {
         },
       },
     },
+    Symbol(enzyme.__providerValues__): undefined,
   },
+  Symbol(enzyme.__providerValues__): Map {},
   Symbol(enzyme.__childContext__): null,
 }
 `;
@@ -2727,7 +2729,9 @@ ShallowWrapper {
         },
       },
     },
+    Symbol(enzyme.__providerValues__): undefined,
   },
+  Symbol(enzyme.__providerValues__): Map {},
   Symbol(enzyme.__childContext__): null,
 }
 `;

--- a/src/__tests__/components/__snapshots__/Pagination.test.jsx.snap
+++ b/src/__tests__/components/__snapshots__/Pagination.test.jsx.snap
@@ -2,21 +2,6 @@
 
 exports[`Pagination Component renders the pagination component 1`] = `
 ReactWrapper {
-  Symbol(enzyme.__unrendered__): <Pagination
-    currentPage={2}
-    handlePagination={[MockFunction]}
-    limit={10}
-    onChangeRowCount={[MockFunction]}
-    onPageChange={[MockFunction]}
-    pageNumber={1}
-    pagination={
-      Object {
-        "currentPage": 1,
-        "numberOfPages": 1120,
-      }
-    }
-    tempCurrentPage={false}
-  />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
     "getNode": [Function],
@@ -1707,5 +1692,22 @@ ReactWrapper {
       },
     },
   },
+  Symbol(enzyme.__linkedRoots__): Array [],
+  Symbol(enzyme.__unrendered__): <Pagination
+    currentPage={2}
+    handlePagination={[MockFunction]}
+    limit={10}
+    onChangeRowCount={[MockFunction]}
+    onPageChange={[MockFunction]}
+    pageNumber={1}
+    pagination={
+      Object {
+        "currentPage": 1,
+        "numberOfPages": 1120,
+      }
+    }
+    tempCurrentPage={false}
+  />,
+  Symbol(enzyme.__updatedBy__): null,
 }
 `;

--- a/src/__tests__/components/__snapshots__/ProgressBar.test.jsx.snap
+++ b/src/__tests__/components/__snapshots__/ProgressBar.test.jsx.snap
@@ -86,7 +86,9 @@ ShallowWrapper {
         },
       },
     },
+    Symbol(enzyme.__providerValues__): undefined,
   },
+  Symbol(enzyme.__providerValues__): Map {},
 }
 `;
 
@@ -176,7 +178,9 @@ ShallowWrapper {
         },
       },
     },
+    Symbol(enzyme.__providerValues__): undefined,
   },
+  Symbol(enzyme.__providerValues__): Map {},
 }
 `;
 
@@ -266,6 +270,8 @@ ShallowWrapper {
         },
       },
     },
+    Symbol(enzyme.__providerValues__): undefined,
   },
+  Symbol(enzyme.__providerValues__): Map {},
 }
 `;

--- a/src/__tests__/components/__snapshots__/UpdateTabe.test.jsx.snap
+++ b/src/__tests__/components/__snapshots__/UpdateTabe.test.jsx.snap
@@ -122,6 +122,8 @@ ShallowWrapper {
         },
       },
     },
+    Symbol(enzyme.__providerValues__): undefined,
   },
+  Symbol(enzyme.__providerValues__): Map {},
 }
 `;

--- a/src/__tests__/components/__snapshots__/login.test.jsx.snap
+++ b/src/__tests__/components/__snapshots__/login.test.jsx.snap
@@ -818,7 +818,9 @@ ShallowWrapper {
         },
       },
     },
+    Symbol(enzyme.__providerValues__): undefined,
   },
+  Symbol(enzyme.__providerValues__): Map {},
   Symbol(enzyme.__childContext__): null,
 }
 `;

--- a/src/components/Dashboard/EngagementTrends/engagementTrends.scss
+++ b/src/components/Dashboard/EngagementTrends/engagementTrends.scss
@@ -1,0 +1,54 @@
+
+text{
+    font-family: sans-serif
+}
+
+.tick text{
+    font-size: .8em;
+    fill: #635F5D
+}
+
+.tick line{
+    stroke: black
+}
+
+.on-boarding-label{
+    font-size: .7em;
+    fill: black
+}
+
+.off-boarding-label{
+    font-size: .7em;
+    fill: black
+}
+
+.area-path{
+    stroke: none;
+}
+
+// add position of xAxis ticks
+
+.x11{
+    transform: translate(0, 0);
+}
+.x12{
+    transform: translate(117.5px, 0);
+}
+.x13{
+    transform: translate(235px, 0);
+}
+.x14{
+    transform: translate(352.5px, 0);
+}
+.x15{
+    transform: translate(470px, 0);
+}
+.x16{
+    transform: translate(587.5px, 0);
+}
+.x17{
+    transform: translate(705px, 0);
+}
+.x18{
+    transform: translate(822.5px, 0);
+}

--- a/src/components/Dashboard/EngagementTrends/index.jsx
+++ b/src/components/Dashboard/EngagementTrends/index.jsx
@@ -1,0 +1,226 @@
+import React from 'react';
+import {
+  select,
+  scaleLinear,
+  scaleOrdinal,
+  scaleBand,
+  max,
+  axisLeft,
+  axisBottom,
+  area,
+  line,
+  curveMonotoneX,
+  nest,
+  selectAll,
+} from 'd3';
+import './engagementTrends.scss';
+
+export const EngagementTrends = () => (
+  <div>
+    <svg className="svgDiv" />
+  </div>
+);
+
+// constants
+const svgWidth = '1000';
+const svgHeight = '300';
+const margin = {
+  top: 100, left: 50, bottom: 50, right: 10,
+};
+const innerWidth = svgWidth - margin.left - margin.right;
+const innerHeight = svgHeight - margin.top - margin.bottom;
+const circleRadius = 2;
+const onBoardingLabel = 'onBoarding';
+const offBoardingLabel = 'offBoarding';
+const xValue = d => d.finalDate;
+const yValue = d => d.totalNumber;
+const colorValue = d => d.automationType;
+
+// generate color for area graph
+const areaColorScale = scaleOrdinal()
+  .domain(['onBoarding', 'offboarding'])
+  .range(['rgb(216,200,186)', 'rgba(221,234,219)']);
+
+// generate color for line graph
+const lineColorScale = scaleOrdinal()
+  .domain(['onBoarding', 'offboarding'])
+  .range(['#c33e37', '#9DB68C']);
+
+// line and area graph
+const renderAreaGraph = (g, classType, nested, dataValues, colorValues) => {
+  const element = g.selectAll(classType)
+    .data(nested)
+    .enter()
+    .append('path')
+    .attr('class', classType)
+    .attr('d', dataValues)
+    .attr('fill', classType === '.area-path' ? colorValues : 'none')
+    .attr('stroke', classType === '.line-path' ? colorValues : 'none');
+  return element;
+};
+
+// circles
+const renderCircles = (g, elementType, data, yPosition, xPosition, circleColor) => {
+  const circleElements = g.selectAll(elementType)
+    .data(data)
+    .enter()
+    .append(elementType)
+    .attr('cy', yPosition)
+    .attr('cx', xPosition)
+    .attr('r', circleRadius)
+    .style('fill', circleColor);
+  return circleElements;
+};
+
+// render xAxisGroup
+const renderXAxisGroup = (g, xAxis) => {
+  // xAxis group
+  const xAxisGroup = g.append('g')
+    .call(xAxis)
+    .attr('class', 'x-axis-group')
+    .attr('transform', `translate(0, ${innerHeight})`);
+
+  // Add x Axis onBoarding Label
+  xAxisGroup.append('text')
+    .attr('class', 'on-boarding-label')
+    .attr('y', 30)
+    .attr('x', innerWidth - 510)
+    .text(onBoardingLabel)
+    .attr('fill', 'black');
+
+  // Add x Axis offBoarding Label
+  xAxisGroup.append('text')
+    .attr('class', 'off-boarding-label')
+    .attr('y', 30)
+    .attr('x', innerWidth - 450)
+    .text(offBoardingLabel)
+    .attr('fill', 'black');
+
+  // Add x Axis offBoarding Label rectangle
+  xAxisGroup.append('rect')
+    .attr('x', 460)
+    .attr('y', 24)
+    .attr('width', 7)
+    .attr('height', 7)
+    .attr('fill', '#c33e37');
+
+  // Add x Axis onBoarding Label rectangle
+  xAxisGroup.append('rect')
+    .attr('x', 400)
+    .attr('y', 24)
+    .attr('width', 7)
+    .attr('height', 7)
+    .attr('fill', '#5d9d52');
+
+  return xAxisGroup;
+};
+
+// Defining the renderGraph function
+const renderGraph = (data, g) => {
+  // make x Scale using scaleBand
+  const xScale = scaleBand()
+    .domain(data.map(xValue))
+    .range([0, innerWidth]);
+
+  // make y Scale using scaleLinear
+  const yScale = scaleLinear()
+    .domain([0, max(data, yValue)])
+    .range([innerHeight, 0])
+    .nice();
+
+  // call axisLeft and axisBottom to make x and y axis
+  const xAxis = axisBottom(xScale)
+    .tickPadding(2);
+
+  const yAxis = axisLeft(yScale);
+  g.append('g')
+    .call(yAxis);
+
+  // render renderXAxisGroup
+  renderXAxisGroup(g, xAxis);
+
+  // reduce on the length of the xAxis domain line
+  g.select('.x-axis-group .domain')
+    .attr('d', 'M0.5,6V0.5H860.5V6');
+
+  // add classes to the different ticks of xAxis
+  const ticks = selectAll('.tick');
+  ticks.attr('class', (d, i) => `x${i}`);
+
+  // generate area graph data
+  const areaGenerator = area()
+    .x(d => xScale(xValue(d)))
+    .y0(innerHeight)
+    .y1(d => yScale(yValue(d)))
+    .curve(curveMonotoneX);
+
+  // generate line graph data
+  const lineGenerator = line()
+    .x(d => xScale(xValue(d)))
+    .y(d => yScale(yValue(d)))
+    .curve(curveMonotoneX);
+
+  // nest for multiple lines/area
+  const nested = nest()
+    .key(colorValue)
+    .entries(data);
+
+  // Add area graph domain
+  areaColorScale.domain(nested.map(d => d.key));
+
+  // Add line graph domain
+  lineColorScale.domain(nested.map(d => d.key));
+
+  const areaValues = d => areaGenerator(d.values);
+  const areaColors = d => areaColorScale(d.key);
+
+  const lineValues = d => lineGenerator(d.values);
+  const lineColors = d => lineColorScale(d.key);
+
+  // Add area graph
+  renderAreaGraph(g, '.area-path', nested, areaValues, areaColors);
+
+  // Add line graph
+  renderAreaGraph(g, '.line-path', nested, lineValues, lineColors);
+
+  // Add circles
+  renderCircles(
+    g,
+    'circle',
+    data,
+    d => yScale(yValue(d)),
+    d => xScale(xValue(d)),
+    d => (d.automationType === 'onBoarding' ? '#5d9d52' : '#c33e37'),
+  );
+};
+
+export const createEngagementTrend = (trendData) => {
+  // selecting the svg element from DOM and adding attributes to it
+  const svg = select('svg')
+    .attr('width', +svgWidth)
+    .attr('height', +svgHeight);
+
+  // Add a group element to group the elements
+  const g = svg.append('g')
+    .attr('transform', `translate(${margin.left}, ${margin.top})`);
+
+  const automationData = trendData.map((d) => {
+    const automationDate = new Date(d.createdAt);
+    const month = automationDate.toLocaleString('default', { month: 'short' });
+    const day = automationDate.toLocaleString('default', { weekday: 'short' });
+    const date = automationDate.getDate();
+    const year = automationDate.getFullYear();
+    const finalDate = `${day} ${month} ${date} ${year}`;
+    const totalNumber = +d.number;
+    const automationType = d.type;
+    const data = {
+      finalDate,
+      totalNumber,
+      automationType,
+    };
+    return data;
+  });
+
+  // return render function to display the data
+  return renderGraph(automationData, g, areaColorScale, lineColorScale);
+};

--- a/src/components/Dashboard/dummyData.js
+++ b/src/components/Dashboard/dummyData.js
@@ -1,0 +1,84 @@
+const dummyData = [
+  {
+    type: 'offBoarding',
+    number: 15,
+    createdAt: '2019-08-01T08:55:10.359Z',
+  },
+  {
+    type: 'offBoarding',
+    number: 10,
+    createdAt: '2019-08-02T08:55:10.353Z',
+  },
+  {
+    type: 'offBoarding',
+    number: 16,
+    createdAt: '2019-08-03T08:54:50.682Z',
+  },
+  {
+    type: 'offBoarding',
+    number: 11,
+    createdAt: '2019-08-04T08:54:50.647Z',
+  },
+  {
+    type: 'offBoarding',
+    number: 20,
+    createdAt: '2019-08-05T08:53:33.798Z',
+  },
+  {
+    type: 'offBoarding',
+    number: 9,
+    createdAt: '2019-08-06T08:53:33.724Z',
+  },
+  {
+    type: 'offBoarding',
+    number: 10,
+    createdAt: '2019-08-07T08:52:51.878Z',
+  },
+  {
+    type: 'offBoarding',
+    number: 2,
+    createdAt: '2019-08-08T08:52:51.863Z',
+  },
+  {
+    type: 'onBoarding',
+    number: 1,
+    createdAt: '2019-08-01T08:55:10.359Z',
+  },
+  {
+    type: 'onBoarding',
+    number: 10,
+    createdAt: '2019-08-02T08:55:10.353Z',
+  },
+  {
+    type: 'onBoarding',
+    number: 4,
+    createdAt: '2019-08-03T08:54:50.682Z',
+  },
+  {
+    type: 'onBoarding',
+    number: 9,
+    createdAt: '2019-08-04T08:54:50.647Z',
+  },
+  {
+    type: 'onBoarding',
+    number: 20,
+    createdAt: '2019-08-05T08:53:33.798Z',
+  },
+  {
+    type: 'onBoarding',
+    number: 0,
+    createdAt: '2019-08-06T08:53:33.724Z',
+  },
+  {
+    type: 'onBoarding',
+    number: 8,
+    createdAt: '2019-08-07T08:52:51.878Z',
+  },
+  {
+    type: 'onBoarding',
+    number: 7,
+    createdAt: '2019-08-08T08:52:51.863Z',
+  },
+];
+
+export default dummyData;

--- a/src/components/Dashboard/index.jsx
+++ b/src/components/Dashboard/index.jsx
@@ -6,9 +6,11 @@ import Card from './Card';
 import { fetchRealTimeReport } from '../../redux/actions/realTimeReport';
 import listenToSocketEvent from '../../realTime';
 import ActivityFeed from './ActivityFeed';
+import { EngagementTrends, createEngagementTrend } from './EngagementTrends';
 import Header from '../Header';
 import PartnerStats from './PartnerStatsCard';
 import ProgressBar from './UpSellingPartners/index';
+import dummyData from './dummyData';
 
 class Dashboard extends React.Component {
   state = {
@@ -33,6 +35,7 @@ class Dashboard extends React.Component {
         expectedDevNum: 30,
       },
     ],
+    trendData: dummyData,
   };
 
   upSellData = (partnerStats) => {
@@ -50,6 +53,8 @@ class Dashboard extends React.Component {
   componentDidMount = () => {
     // triggers event to fetch data from the API
     this.connectToSocket('newAutomation');
+    const { trendData } = this.state;
+    createEngagementTrend(trendData);
   };
 
   connectToSocket = (event) => {
@@ -120,7 +125,7 @@ class Dashboard extends React.Component {
         <Card
           classes="engagement"
           title="Engagement Trends"
-          component={() => {}}
+          component={() => EngagementTrends()}
         />
         <Card
           classes="upSelling"
@@ -153,7 +158,7 @@ const mapStateToProps = state => ({
   automation: state.automation,
 });
 
-const mapDispatchToProps = dispatch => ({
+export const mapDispatchToProps = dispatch => ({
   fetchUpdates: () => dispatch(fetchRealTimeReport()),
 });
 


### PR DESCRIPTION
#### What does this PR do?
- Displays engagement trend (onBoarding and offBoarding) on a graph

#### Description of Task to be completed?
- Displays engagement trend (onBoarding and offBoarding) on a graph

#### How should this be manually tested?
- Clone the frontend repo and the backend repo
- Run both frontend and backend repo
- log in to the frontend and click on dashboard
- you will be able to see a graph for onBoarding and offBoarding
#### Any background context you want to provide?
- This PR uses dummyData
#### What are the relevant pivotal tracker stories?
[162751892](https://www.pivotaltracker.com/story/show/162751892)
#### Postman Documentation
- N/A
#### Screenshots (If applicable)
<img width="954" alt="Screenshot 2019-09-05 at 11 27 01" src="https://user-images.githubusercontent.com/29975767/64325068-27d61700-cfd0-11e9-9778-e9862bc68b80.png">
