### PR TITLE
A user should be able to migrate placement-information from allocations into a spreadsheet

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "enzyme-adapter-react-16": "^1.1.1",
     "eslint-plugin-cypress": "^2.2.1",
     "file-loader": "1.1.5",
+    "file-saver": "^2.0.2",
     "firebase": "^5.8.2",
     "fs-extra": "3.0.1",
     "jquery": "^1.9.1",

--- a/src/__snapshots__/App.test.jsx.snap
+++ b/src/__snapshots__/App.test.jsx.snap
@@ -1,0 +1,18793 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Authenticate route should run the authenticated route component 1`] = `
+ReactWrapper {
+  Symbol(enzyme.__unrendered__): <BrowserRouter>
+    <AuthenticatedRoute
+      authenticated={true}
+      component={[Function]}
+      path="/dashboard"
+    />
+  </BrowserRouter>,
+  Symbol(enzyme.__renderer__): Object {
+    "batchedUpdates": [Function],
+    "getNode": [Function],
+    "getWrappingComponentRenderer": [Function],
+    "render": [Function],
+    "simulateError": [Function],
+    "simulateEvent": [Function],
+    "unmount": [Function],
+  },
+  Symbol(enzyme.__root__): [Circular],
+  Symbol(enzyme.__node__): Object {
+    "instance": BrowserRouter {
+      "_reactInternalFiber": FiberNode {
+        "_debugHookTypes": null,
+        "_debugID": 63,
+        "_debugIsCurrentlyTiming": false,
+        "_debugOwner": FiberNode {
+          "_debugHookTypes": null,
+          "_debugID": 62,
+          "_debugIsCurrentlyTiming": false,
+          "_debugOwner": null,
+          "_debugSource": null,
+          "actualDuration": 0,
+          "actualStartTime": -1,
+          "alternate": null,
+          "child": [Circular],
+          "childExpirationTime": 0,
+          "contextDependencies": null,
+          "effectTag": 1,
+          "elementType": [Function],
+          "expirationTime": 0,
+          "firstEffect": null,
+          "index": 0,
+          "key": null,
+          "lastEffect": null,
+          "memoizedProps": Object {
+            "Component": [Function],
+            "context": null,
+            "props": Object {
+              "children": <AuthenticatedRoute
+                authenticated={true}
+                component={[Function]}
+                path="/dashboard"
+              />,
+            },
+            "wrappingComponentProps": null,
+          },
+          "memoizedState": Object {
+            "context": null,
+            "mount": true,
+            "props": Object {
+              "children": <AuthenticatedRoute
+                authenticated={true}
+                component={[Function]}
+                path="/dashboard"
+              />,
+            },
+            "wrappingComponentProps": null,
+          },
+          "mode": 0,
+          "nextEffect": FiberNode {
+            "_debugHookTypes": null,
+            "_debugID": 60,
+            "_debugIsCurrentlyTiming": false,
+            "_debugOwner": null,
+            "_debugSource": null,
+            "actualDuration": 0,
+            "actualStartTime": -1,
+            "alternate": FiberNode {
+              "_debugHookTypes": null,
+              "_debugID": 60,
+              "_debugIsCurrentlyTiming": false,
+              "_debugOwner": null,
+              "_debugSource": null,
+              "actualDuration": 0,
+              "actualStartTime": -1,
+              "alternate": [Circular],
+              "child": null,
+              "childExpirationTime": 0,
+              "contextDependencies": null,
+              "effectTag": 0,
+              "elementType": null,
+              "expirationTime": 1073741823,
+              "firstEffect": null,
+              "index": 0,
+              "key": null,
+              "lastEffect": null,
+              "memoizedProps": null,
+              "memoizedState": null,
+              "mode": 0,
+              "nextEffect": null,
+              "pendingProps": null,
+              "ref": null,
+              "return": null,
+              "selfBaseDuration": 0,
+              "sibling": null,
+              "stateNode": Object {
+                "containerInfo": <div />,
+                "context": Object {},
+                "current": [Circular],
+                "didError": false,
+                "earliestPendingTime": 0,
+                "earliestSuspendedTime": 0,
+                "expirationTime": 0,
+                "finishedWork": null,
+                "firstBatch": null,
+                "hydrate": false,
+                "interactionThreadID": 15,
+                "latestPendingTime": 0,
+                "latestPingedTime": 0,
+                "latestSuspendedTime": 0,
+                "memoizedInteractions": Set {},
+                "nextExpirationTimeToWorkOn": 0,
+                "nextScheduledRoot": null,
+                "pendingChildren": null,
+                "pendingCommitExpirationTime": 0,
+                "pendingContext": null,
+                "pendingInteractionMap": Map {},
+                "pingCache": null,
+                "timeoutHandle": -1,
+              },
+              "tag": 3,
+              "treeBaseDuration": 0,
+              "type": null,
+              "updateQueue": Object {
+                "baseState": null,
+                "firstCapturedEffect": null,
+                "firstCapturedUpdate": null,
+                "firstEffect": null,
+                "firstUpdate": Object {
+                  "callback": null,
+                  "expirationTime": 1073741823,
+                  "next": null,
+                  "nextEffect": null,
+                  "payload": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={
+                        Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        }
+                      }
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "tag": 0,
+                },
+                "lastCapturedEffect": null,
+                "lastCapturedUpdate": null,
+                "lastEffect": null,
+                "lastUpdate": Object {
+                  "callback": null,
+                  "expirationTime": 1073741823,
+                  "next": null,
+                  "nextEffect": null,
+                  "payload": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={
+                        Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        }
+                      }
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "tag": 0,
+                },
+              },
+            },
+            "child": [Circular],
+            "childExpirationTime": 0,
+            "contextDependencies": null,
+            "effectTag": 32,
+            "elementType": null,
+            "expirationTime": 0,
+            "firstEffect": [Circular],
+            "index": 0,
+            "key": null,
+            "lastEffect": [Circular],
+            "memoizedProps": null,
+            "memoizedState": Object {
+              "element": <WrapperComponent
+                Component={[Function]}
+                context={null}
+                props={
+                  Object {
+                    "children": <AuthenticatedRoute
+                      authenticated={true}
+                      component={[Function]}
+                      path="/dashboard"
+                    />,
+                  }
+                }
+                wrappingComponentProps={null}
+              />,
+            },
+            "mode": 0,
+            "nextEffect": null,
+            "pendingProps": null,
+            "ref": null,
+            "return": null,
+            "selfBaseDuration": 0,
+            "sibling": null,
+            "stateNode": Object {
+              "containerInfo": <div />,
+              "context": Object {},
+              "current": [Circular],
+              "didError": false,
+              "earliestPendingTime": 0,
+              "earliestSuspendedTime": 0,
+              "expirationTime": 0,
+              "finishedWork": null,
+              "firstBatch": null,
+              "hydrate": false,
+              "interactionThreadID": 15,
+              "latestPendingTime": 0,
+              "latestPingedTime": 0,
+              "latestSuspendedTime": 0,
+              "memoizedInteractions": Set {},
+              "nextExpirationTimeToWorkOn": 0,
+              "nextScheduledRoot": null,
+              "pendingChildren": null,
+              "pendingCommitExpirationTime": 0,
+              "pendingContext": null,
+              "pendingInteractionMap": Map {},
+              "pingCache": null,
+              "timeoutHandle": -1,
+            },
+            "tag": 3,
+            "treeBaseDuration": 0,
+            "type": null,
+            "updateQueue": Object {
+              "baseState": Object {
+                "element": <WrapperComponent
+                  Component={[Function]}
+                  context={null}
+                  props={
+                    Object {
+                      "children": <AuthenticatedRoute
+                        authenticated={true}
+                        component={[Function]}
+                        path="/dashboard"
+                      />,
+                    }
+                  }
+                  wrappingComponentProps={null}
+                />,
+              },
+              "firstCapturedEffect": null,
+              "firstCapturedUpdate": null,
+              "firstEffect": null,
+              "firstUpdate": null,
+              "lastCapturedEffect": null,
+              "lastCapturedUpdate": null,
+              "lastEffect": null,
+              "lastUpdate": null,
+            },
+          },
+          "pendingProps": Object {
+            "Component": [Function],
+            "context": null,
+            "props": Object {
+              "children": <AuthenticatedRoute
+                authenticated={true}
+                component={[Function]}
+                path="/dashboard"
+              />,
+            },
+            "wrappingComponentProps": null,
+          },
+          "ref": null,
+          "return": FiberNode {
+            "_debugHookTypes": null,
+            "_debugID": 60,
+            "_debugIsCurrentlyTiming": false,
+            "_debugOwner": null,
+            "_debugSource": null,
+            "actualDuration": 0,
+            "actualStartTime": -1,
+            "alternate": FiberNode {
+              "_debugHookTypes": null,
+              "_debugID": 60,
+              "_debugIsCurrentlyTiming": false,
+              "_debugOwner": null,
+              "_debugSource": null,
+              "actualDuration": 0,
+              "actualStartTime": -1,
+              "alternate": [Circular],
+              "child": null,
+              "childExpirationTime": 0,
+              "contextDependencies": null,
+              "effectTag": 0,
+              "elementType": null,
+              "expirationTime": 1073741823,
+              "firstEffect": null,
+              "index": 0,
+              "key": null,
+              "lastEffect": null,
+              "memoizedProps": null,
+              "memoizedState": null,
+              "mode": 0,
+              "nextEffect": null,
+              "pendingProps": null,
+              "ref": null,
+              "return": null,
+              "selfBaseDuration": 0,
+              "sibling": null,
+              "stateNode": Object {
+                "containerInfo": <div />,
+                "context": Object {},
+                "current": [Circular],
+                "didError": false,
+                "earliestPendingTime": 0,
+                "earliestSuspendedTime": 0,
+                "expirationTime": 0,
+                "finishedWork": null,
+                "firstBatch": null,
+                "hydrate": false,
+                "interactionThreadID": 15,
+                "latestPendingTime": 0,
+                "latestPingedTime": 0,
+                "latestSuspendedTime": 0,
+                "memoizedInteractions": Set {},
+                "nextExpirationTimeToWorkOn": 0,
+                "nextScheduledRoot": null,
+                "pendingChildren": null,
+                "pendingCommitExpirationTime": 0,
+                "pendingContext": null,
+                "pendingInteractionMap": Map {},
+                "pingCache": null,
+                "timeoutHandle": -1,
+              },
+              "tag": 3,
+              "treeBaseDuration": 0,
+              "type": null,
+              "updateQueue": Object {
+                "baseState": null,
+                "firstCapturedEffect": null,
+                "firstCapturedUpdate": null,
+                "firstEffect": null,
+                "firstUpdate": Object {
+                  "callback": null,
+                  "expirationTime": 1073741823,
+                  "next": null,
+                  "nextEffect": null,
+                  "payload": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={
+                        Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        }
+                      }
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "tag": 0,
+                },
+                "lastCapturedEffect": null,
+                "lastCapturedUpdate": null,
+                "lastEffect": null,
+                "lastUpdate": Object {
+                  "callback": null,
+                  "expirationTime": 1073741823,
+                  "next": null,
+                  "nextEffect": null,
+                  "payload": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={
+                        Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        }
+                      }
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "tag": 0,
+                },
+              },
+            },
+            "child": [Circular],
+            "childExpirationTime": 0,
+            "contextDependencies": null,
+            "effectTag": 32,
+            "elementType": null,
+            "expirationTime": 0,
+            "firstEffect": [Circular],
+            "index": 0,
+            "key": null,
+            "lastEffect": [Circular],
+            "memoizedProps": null,
+            "memoizedState": Object {
+              "element": <WrapperComponent
+                Component={[Function]}
+                context={null}
+                props={
+                  Object {
+                    "children": <AuthenticatedRoute
+                      authenticated={true}
+                      component={[Function]}
+                      path="/dashboard"
+                    />,
+                  }
+                }
+                wrappingComponentProps={null}
+              />,
+            },
+            "mode": 0,
+            "nextEffect": null,
+            "pendingProps": null,
+            "ref": null,
+            "return": null,
+            "selfBaseDuration": 0,
+            "sibling": null,
+            "stateNode": Object {
+              "containerInfo": <div />,
+              "context": Object {},
+              "current": [Circular],
+              "didError": false,
+              "earliestPendingTime": 0,
+              "earliestSuspendedTime": 0,
+              "expirationTime": 0,
+              "finishedWork": null,
+              "firstBatch": null,
+              "hydrate": false,
+              "interactionThreadID": 15,
+              "latestPendingTime": 0,
+              "latestPingedTime": 0,
+              "latestSuspendedTime": 0,
+              "memoizedInteractions": Set {},
+              "nextExpirationTimeToWorkOn": 0,
+              "nextScheduledRoot": null,
+              "pendingChildren": null,
+              "pendingCommitExpirationTime": 0,
+              "pendingContext": null,
+              "pendingInteractionMap": Map {},
+              "pingCache": null,
+              "timeoutHandle": -1,
+            },
+            "tag": 3,
+            "treeBaseDuration": 0,
+            "type": null,
+            "updateQueue": Object {
+              "baseState": Object {
+                "element": <WrapperComponent
+                  Component={[Function]}
+                  context={null}
+                  props={
+                    Object {
+                      "children": <AuthenticatedRoute
+                        authenticated={true}
+                        component={[Function]}
+                        path="/dashboard"
+                      />,
+                    }
+                  }
+                  wrappingComponentProps={null}
+                />,
+              },
+              "firstCapturedEffect": null,
+              "firstCapturedUpdate": null,
+              "firstEffect": null,
+              "firstUpdate": null,
+              "lastCapturedEffect": null,
+              "lastCapturedUpdate": null,
+              "lastEffect": null,
+              "lastUpdate": null,
+            },
+          },
+          "selfBaseDuration": 0,
+          "sibling": null,
+          "stateNode": WrapperComponent {
+            "_reactInternalFiber": [Circular],
+            "_reactInternalInstance": Object {},
+            "context": Object {},
+            "props": Object {
+              "Component": [Function],
+              "context": null,
+              "props": Object {
+                "children": <AuthenticatedRoute
+                  authenticated={true}
+                  component={[Function]}
+                  path="/dashboard"
+                />,
+              },
+              "wrappingComponentProps": null,
+            },
+            "refs": Object {},
+            "rootFinderInstance": null,
+            "state": Object {
+              "context": null,
+              "mount": true,
+              "props": Object {
+                "children": <AuthenticatedRoute
+                  authenticated={true}
+                  component={[Function]}
+                  path="/dashboard"
+                />,
+              },
+              "wrappingComponentProps": null,
+            },
+            "updater": Object {
+              "enqueueForceUpdate": [Function],
+              "enqueueReplaceState": [Function],
+              "enqueueSetState": [Function],
+              "isMounted": [Function],
+            },
+          },
+          "tag": 1,
+          "treeBaseDuration": 0,
+          "type": [Function],
+          "updateQueue": null,
+        },
+        "_debugSource": null,
+        "actualDuration": 0,
+        "actualStartTime": -1,
+        "alternate": null,
+        "child": FiberNode {
+          "_debugHookTypes": null,
+          "_debugID": 64,
+          "_debugIsCurrentlyTiming": false,
+          "_debugOwner": [Circular],
+          "_debugSource": null,
+          "actualDuration": 0,
+          "actualStartTime": -1,
+          "alternate": null,
+          "child": FiberNode {
+            "_debugHookTypes": null,
+            "_debugID": 65,
+            "_debugIsCurrentlyTiming": false,
+            "_debugOwner": null,
+            "_debugSource": Object {
+              "fileName": "/Users/home/Documents/Projects/javascript/Andela/bp-esa/bp-esa-frontend/src/App.test.jsx",
+              "lineNumber": 123,
+            },
+            "actualDuration": 0,
+            "actualStartTime": -1,
+            "alternate": null,
+            "child": FiberNode {
+              "_debugHookTypes": null,
+              "_debugID": 66,
+              "_debugIsCurrentlyTiming": false,
+              "_debugOwner": [Circular],
+              "_debugSource": Object {
+                "fileName": "/Users/home/Documents/Projects/javascript/Andela/bp-esa/bp-esa-frontend/src/App.jsx",
+                "lineNumber": 15,
+              },
+              "actualDuration": 0,
+              "actualStartTime": -1,
+              "alternate": null,
+              "child": null,
+              "childExpirationTime": 0,
+              "contextDependencies": null,
+              "effectTag": 1,
+              "elementType": [Function],
+              "expirationTime": 0,
+              "firstEffect": null,
+              "index": 0,
+              "key": null,
+              "lastEffect": null,
+              "memoizedProps": Object {
+                "path": "/dashboard",
+                "render": [Function],
+              },
+              "memoizedState": Object {
+                "match": null,
+              },
+              "mode": 0,
+              "nextEffect": null,
+              "pendingProps": Object {
+                "path": "/dashboard",
+                "render": [Function],
+              },
+              "ref": null,
+              "return": [Circular],
+              "selfBaseDuration": 0,
+              "sibling": null,
+              "stateNode": Route {
+                "__reactInternalMemoizedMaskedChildContext": Object {
+                  "router": Object {
+                    "history": Object {
+                      "action": "POP",
+                      "block": [Function],
+                      "createHref": [Function],
+                      "go": [Function],
+                      "goBack": [Function],
+                      "goForward": [Function],
+                      "length": 1,
+                      "listen": [Function],
+                      "location": Object {
+                        "hash": "",
+                        "pathname": "/",
+                        "search": "",
+                        "state": undefined,
+                      },
+                      "push": [Function],
+                      "replace": [Function],
+                    },
+                    "route": Object {
+                      "location": Object {
+                        "hash": "",
+                        "pathname": "/",
+                        "search": "",
+                        "state": undefined,
+                      },
+                      "match": Object {
+                        "isExact": true,
+                        "params": Object {},
+                        "path": "/",
+                        "url": "/",
+                      },
+                    },
+                  },
+                },
+                "__reactInternalMemoizedMergedChildContext": Object {
+                  "router": Object {
+                    "history": Object {
+                      "action": "POP",
+                      "block": [Function],
+                      "createHref": [Function],
+                      "go": [Function],
+                      "goBack": [Function],
+                      "goForward": [Function],
+                      "length": 1,
+                      "listen": [Function],
+                      "location": Object {
+                        "hash": "",
+                        "pathname": "/",
+                        "search": "",
+                        "state": undefined,
+                      },
+                      "push": [Function],
+                      "replace": [Function],
+                    },
+                    "route": Object {
+                      "location": Object {
+                        "hash": "",
+                        "pathname": "/",
+                        "search": "",
+                        "state": undefined,
+                      },
+                      "match": null,
+                    },
+                  },
+                },
+                "__reactInternalMemoizedUnmaskedChildContext": Object {
+                  "router": Object {
+                    "history": Object {
+                      "action": "POP",
+                      "block": [Function],
+                      "createHref": [Function],
+                      "go": [Function],
+                      "goBack": [Function],
+                      "goForward": [Function],
+                      "length": 1,
+                      "listen": [Function],
+                      "location": Object {
+                        "hash": "",
+                        "pathname": "/",
+                        "search": "",
+                        "state": undefined,
+                      },
+                      "push": [Function],
+                      "replace": [Function],
+                    },
+                    "route": Object {
+                      "location": Object {
+                        "hash": "",
+                        "pathname": "/",
+                        "search": "",
+                        "state": undefined,
+                      },
+                      "match": Object {
+                        "isExact": true,
+                        "params": Object {},
+                        "path": "/",
+                        "url": "/",
+                      },
+                    },
+                  },
+                },
+                "_reactInternalFiber": [Circular],
+                "_reactInternalInstance": Object {},
+                "context": Object {
+                  "router": Object {
+                    "history": Object {
+                      "action": "POP",
+                      "block": [Function],
+                      "createHref": [Function],
+                      "go": [Function],
+                      "goBack": [Function],
+                      "goForward": [Function],
+                      "length": 1,
+                      "listen": [Function],
+                      "location": Object {
+                        "hash": "",
+                        "pathname": "/",
+                        "search": "",
+                        "state": undefined,
+                      },
+                      "push": [Function],
+                      "replace": [Function],
+                    },
+                    "route": Object {
+                      "location": Object {
+                        "hash": "",
+                        "pathname": "/",
+                        "search": "",
+                        "state": undefined,
+                      },
+                      "match": Object {
+                        "isExact": true,
+                        "params": Object {},
+                        "path": "/",
+                        "url": "/",
+                      },
+                    },
+                  },
+                },
+                "props": Object {
+                  "path": "/dashboard",
+                  "render": [Function],
+                },
+                "refs": Object {},
+                "state": Object {
+                  "match": null,
+                },
+                "updater": Object {
+                  "enqueueForceUpdate": [Function],
+                  "enqueueReplaceState": [Function],
+                  "enqueueSetState": [Function],
+                  "isMounted": [Function],
+                },
+              },
+              "tag": 1,
+              "treeBaseDuration": 0,
+              "type": [Function],
+              "updateQueue": null,
+            },
+            "childExpirationTime": 0,
+            "contextDependencies": null,
+            "effectTag": 1,
+            "elementType": [Function],
+            "expirationTime": 0,
+            "firstEffect": null,
+            "index": 0,
+            "key": null,
+            "lastEffect": null,
+            "memoizedProps": Object {
+              "authenticated": true,
+              "component": [Function],
+              "path": "/dashboard",
+            },
+            "memoizedState": null,
+            "mode": 0,
+            "nextEffect": null,
+            "pendingProps": Object {
+              "authenticated": true,
+              "component": [Function],
+              "path": "/dashboard",
+            },
+            "ref": null,
+            "return": [Circular],
+            "selfBaseDuration": 0,
+            "sibling": null,
+            "stateNode": null,
+            "tag": 0,
+            "treeBaseDuration": 0,
+            "type": [Function],
+            "updateQueue": null,
+          },
+          "childExpirationTime": 0,
+          "contextDependencies": null,
+          "effectTag": 1,
+          "elementType": [Function],
+          "expirationTime": 0,
+          "firstEffect": null,
+          "index": 0,
+          "key": null,
+          "lastEffect": null,
+          "memoizedProps": Object {
+            "children": <AuthenticatedRoute
+              authenticated={true}
+              component={[Function]}
+              path="/dashboard"
+            />,
+            "history": Object {
+              "action": "POP",
+              "block": [Function],
+              "createHref": [Function],
+              "go": [Function],
+              "goBack": [Function],
+              "goForward": [Function],
+              "length": 1,
+              "listen": [Function],
+              "location": Object {
+                "hash": "",
+                "pathname": "/",
+                "search": "",
+                "state": undefined,
+              },
+              "push": [Function],
+              "replace": [Function],
+            },
+          },
+          "memoizedState": Object {
+            "match": Object {
+              "isExact": true,
+              "params": Object {},
+              "path": "/",
+              "url": "/",
+            },
+          },
+          "mode": 0,
+          "nextEffect": null,
+          "pendingProps": Object {
+            "children": <AuthenticatedRoute
+              authenticated={true}
+              component={[Function]}
+              path="/dashboard"
+            />,
+            "history": Object {
+              "action": "POP",
+              "block": [Function],
+              "createHref": [Function],
+              "go": [Function],
+              "goBack": [Function],
+              "goForward": [Function],
+              "length": 1,
+              "listen": [Function],
+              "location": Object {
+                "hash": "",
+                "pathname": "/",
+                "search": "",
+                "state": undefined,
+              },
+              "push": [Function],
+              "replace": [Function],
+            },
+          },
+          "ref": null,
+          "return": [Circular],
+          "selfBaseDuration": 0,
+          "sibling": null,
+          "stateNode": Router {
+            "__reactInternalMemoizedMaskedChildContext": Object {
+              "router": undefined,
+            },
+            "__reactInternalMemoizedMergedChildContext": Object {
+              "router": Object {
+                "history": Object {
+                  "action": "POP",
+                  "block": [Function],
+                  "createHref": [Function],
+                  "go": [Function],
+                  "goBack": [Function],
+                  "goForward": [Function],
+                  "length": 1,
+                  "listen": [Function],
+                  "location": Object {
+                    "hash": "",
+                    "pathname": "/",
+                    "search": "",
+                    "state": undefined,
+                  },
+                  "push": [Function],
+                  "replace": [Function],
+                },
+                "route": Object {
+                  "location": Object {
+                    "hash": "",
+                    "pathname": "/",
+                    "search": "",
+                    "state": undefined,
+                  },
+                  "match": Object {
+                    "isExact": true,
+                    "params": Object {},
+                    "path": "/",
+                    "url": "/",
+                  },
+                },
+              },
+            },
+            "__reactInternalMemoizedUnmaskedChildContext": Object {},
+            "_reactInternalFiber": [Circular],
+            "_reactInternalInstance": Object {},
+            "context": Object {
+              "router": undefined,
+            },
+            "props": Object {
+              "children": <AuthenticatedRoute
+                authenticated={true}
+                component={[Function]}
+                path="/dashboard"
+              />,
+              "history": Object {
+                "action": "POP",
+                "block": [Function],
+                "createHref": [Function],
+                "go": [Function],
+                "goBack": [Function],
+                "goForward": [Function],
+                "length": 1,
+                "listen": [Function],
+                "location": Object {
+                  "hash": "",
+                  "pathname": "/",
+                  "search": "",
+                  "state": undefined,
+                },
+                "push": [Function],
+                "replace": [Function],
+              },
+            },
+            "refs": Object {},
+            "state": Object {
+              "match": Object {
+                "isExact": true,
+                "params": Object {},
+                "path": "/",
+                "url": "/",
+              },
+            },
+            "unlisten": [Function],
+            "updater": Object {
+              "enqueueForceUpdate": [Function],
+              "enqueueReplaceState": [Function],
+              "enqueueSetState": [Function],
+              "isMounted": [Function],
+            },
+          },
+          "tag": 1,
+          "treeBaseDuration": 0,
+          "type": [Function],
+          "updateQueue": null,
+        },
+        "childExpirationTime": 0,
+        "contextDependencies": null,
+        "effectTag": 1,
+        "elementType": [Function],
+        "expirationTime": 0,
+        "firstEffect": null,
+        "index": 0,
+        "key": null,
+        "lastEffect": null,
+        "memoizedProps": Object {
+          "children": <AuthenticatedRoute
+            authenticated={true}
+            component={[Function]}
+            path="/dashboard"
+          />,
+        },
+        "memoizedState": null,
+        "mode": 0,
+        "nextEffect": null,
+        "pendingProps": Object {
+          "children": <AuthenticatedRoute
+            authenticated={true}
+            component={[Function]}
+            path="/dashboard"
+          />,
+        },
+        "ref": null,
+        "return": FiberNode {
+          "_debugHookTypes": null,
+          "_debugID": 62,
+          "_debugIsCurrentlyTiming": false,
+          "_debugOwner": null,
+          "_debugSource": null,
+          "actualDuration": 0,
+          "actualStartTime": -1,
+          "alternate": null,
+          "child": [Circular],
+          "childExpirationTime": 0,
+          "contextDependencies": null,
+          "effectTag": 1,
+          "elementType": [Function],
+          "expirationTime": 0,
+          "firstEffect": null,
+          "index": 0,
+          "key": null,
+          "lastEffect": null,
+          "memoizedProps": Object {
+            "Component": [Function],
+            "context": null,
+            "props": Object {
+              "children": <AuthenticatedRoute
+                authenticated={true}
+                component={[Function]}
+                path="/dashboard"
+              />,
+            },
+            "wrappingComponentProps": null,
+          },
+          "memoizedState": Object {
+            "context": null,
+            "mount": true,
+            "props": Object {
+              "children": <AuthenticatedRoute
+                authenticated={true}
+                component={[Function]}
+                path="/dashboard"
+              />,
+            },
+            "wrappingComponentProps": null,
+          },
+          "mode": 0,
+          "nextEffect": FiberNode {
+            "_debugHookTypes": null,
+            "_debugID": 60,
+            "_debugIsCurrentlyTiming": false,
+            "_debugOwner": null,
+            "_debugSource": null,
+            "actualDuration": 0,
+            "actualStartTime": -1,
+            "alternate": FiberNode {
+              "_debugHookTypes": null,
+              "_debugID": 60,
+              "_debugIsCurrentlyTiming": false,
+              "_debugOwner": null,
+              "_debugSource": null,
+              "actualDuration": 0,
+              "actualStartTime": -1,
+              "alternate": [Circular],
+              "child": null,
+              "childExpirationTime": 0,
+              "contextDependencies": null,
+              "effectTag": 0,
+              "elementType": null,
+              "expirationTime": 1073741823,
+              "firstEffect": null,
+              "index": 0,
+              "key": null,
+              "lastEffect": null,
+              "memoizedProps": null,
+              "memoizedState": null,
+              "mode": 0,
+              "nextEffect": null,
+              "pendingProps": null,
+              "ref": null,
+              "return": null,
+              "selfBaseDuration": 0,
+              "sibling": null,
+              "stateNode": Object {
+                "containerInfo": <div />,
+                "context": Object {},
+                "current": [Circular],
+                "didError": false,
+                "earliestPendingTime": 0,
+                "earliestSuspendedTime": 0,
+                "expirationTime": 0,
+                "finishedWork": null,
+                "firstBatch": null,
+                "hydrate": false,
+                "interactionThreadID": 15,
+                "latestPendingTime": 0,
+                "latestPingedTime": 0,
+                "latestSuspendedTime": 0,
+                "memoizedInteractions": Set {},
+                "nextExpirationTimeToWorkOn": 0,
+                "nextScheduledRoot": null,
+                "pendingChildren": null,
+                "pendingCommitExpirationTime": 0,
+                "pendingContext": null,
+                "pendingInteractionMap": Map {},
+                "pingCache": null,
+                "timeoutHandle": -1,
+              },
+              "tag": 3,
+              "treeBaseDuration": 0,
+              "type": null,
+              "updateQueue": Object {
+                "baseState": null,
+                "firstCapturedEffect": null,
+                "firstCapturedUpdate": null,
+                "firstEffect": null,
+                "firstUpdate": Object {
+                  "callback": null,
+                  "expirationTime": 1073741823,
+                  "next": null,
+                  "nextEffect": null,
+                  "payload": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={
+                        Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        }
+                      }
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "tag": 0,
+                },
+                "lastCapturedEffect": null,
+                "lastCapturedUpdate": null,
+                "lastEffect": null,
+                "lastUpdate": Object {
+                  "callback": null,
+                  "expirationTime": 1073741823,
+                  "next": null,
+                  "nextEffect": null,
+                  "payload": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={
+                        Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        }
+                      }
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "tag": 0,
+                },
+              },
+            },
+            "child": [Circular],
+            "childExpirationTime": 0,
+            "contextDependencies": null,
+            "effectTag": 32,
+            "elementType": null,
+            "expirationTime": 0,
+            "firstEffect": [Circular],
+            "index": 0,
+            "key": null,
+            "lastEffect": [Circular],
+            "memoizedProps": null,
+            "memoizedState": Object {
+              "element": <WrapperComponent
+                Component={[Function]}
+                context={null}
+                props={
+                  Object {
+                    "children": <AuthenticatedRoute
+                      authenticated={true}
+                      component={[Function]}
+                      path="/dashboard"
+                    />,
+                  }
+                }
+                wrappingComponentProps={null}
+              />,
+            },
+            "mode": 0,
+            "nextEffect": null,
+            "pendingProps": null,
+            "ref": null,
+            "return": null,
+            "selfBaseDuration": 0,
+            "sibling": null,
+            "stateNode": Object {
+              "containerInfo": <div />,
+              "context": Object {},
+              "current": [Circular],
+              "didError": false,
+              "earliestPendingTime": 0,
+              "earliestSuspendedTime": 0,
+              "expirationTime": 0,
+              "finishedWork": null,
+              "firstBatch": null,
+              "hydrate": false,
+              "interactionThreadID": 15,
+              "latestPendingTime": 0,
+              "latestPingedTime": 0,
+              "latestSuspendedTime": 0,
+              "memoizedInteractions": Set {},
+              "nextExpirationTimeToWorkOn": 0,
+              "nextScheduledRoot": null,
+              "pendingChildren": null,
+              "pendingCommitExpirationTime": 0,
+              "pendingContext": null,
+              "pendingInteractionMap": Map {},
+              "pingCache": null,
+              "timeoutHandle": -1,
+            },
+            "tag": 3,
+            "treeBaseDuration": 0,
+            "type": null,
+            "updateQueue": Object {
+              "baseState": Object {
+                "element": <WrapperComponent
+                  Component={[Function]}
+                  context={null}
+                  props={
+                    Object {
+                      "children": <AuthenticatedRoute
+                        authenticated={true}
+                        component={[Function]}
+                        path="/dashboard"
+                      />,
+                    }
+                  }
+                  wrappingComponentProps={null}
+                />,
+              },
+              "firstCapturedEffect": null,
+              "firstCapturedUpdate": null,
+              "firstEffect": null,
+              "firstUpdate": null,
+              "lastCapturedEffect": null,
+              "lastCapturedUpdate": null,
+              "lastEffect": null,
+              "lastUpdate": null,
+            },
+          },
+          "pendingProps": Object {
+            "Component": [Function],
+            "context": null,
+            "props": Object {
+              "children": <AuthenticatedRoute
+                authenticated={true}
+                component={[Function]}
+                path="/dashboard"
+              />,
+            },
+            "wrappingComponentProps": null,
+          },
+          "ref": null,
+          "return": FiberNode {
+            "_debugHookTypes": null,
+            "_debugID": 60,
+            "_debugIsCurrentlyTiming": false,
+            "_debugOwner": null,
+            "_debugSource": null,
+            "actualDuration": 0,
+            "actualStartTime": -1,
+            "alternate": FiberNode {
+              "_debugHookTypes": null,
+              "_debugID": 60,
+              "_debugIsCurrentlyTiming": false,
+              "_debugOwner": null,
+              "_debugSource": null,
+              "actualDuration": 0,
+              "actualStartTime": -1,
+              "alternate": [Circular],
+              "child": null,
+              "childExpirationTime": 0,
+              "contextDependencies": null,
+              "effectTag": 0,
+              "elementType": null,
+              "expirationTime": 1073741823,
+              "firstEffect": null,
+              "index": 0,
+              "key": null,
+              "lastEffect": null,
+              "memoizedProps": null,
+              "memoizedState": null,
+              "mode": 0,
+              "nextEffect": null,
+              "pendingProps": null,
+              "ref": null,
+              "return": null,
+              "selfBaseDuration": 0,
+              "sibling": null,
+              "stateNode": Object {
+                "containerInfo": <div />,
+                "context": Object {},
+                "current": [Circular],
+                "didError": false,
+                "earliestPendingTime": 0,
+                "earliestSuspendedTime": 0,
+                "expirationTime": 0,
+                "finishedWork": null,
+                "firstBatch": null,
+                "hydrate": false,
+                "interactionThreadID": 15,
+                "latestPendingTime": 0,
+                "latestPingedTime": 0,
+                "latestSuspendedTime": 0,
+                "memoizedInteractions": Set {},
+                "nextExpirationTimeToWorkOn": 0,
+                "nextScheduledRoot": null,
+                "pendingChildren": null,
+                "pendingCommitExpirationTime": 0,
+                "pendingContext": null,
+                "pendingInteractionMap": Map {},
+                "pingCache": null,
+                "timeoutHandle": -1,
+              },
+              "tag": 3,
+              "treeBaseDuration": 0,
+              "type": null,
+              "updateQueue": Object {
+                "baseState": null,
+                "firstCapturedEffect": null,
+                "firstCapturedUpdate": null,
+                "firstEffect": null,
+                "firstUpdate": Object {
+                  "callback": null,
+                  "expirationTime": 1073741823,
+                  "next": null,
+                  "nextEffect": null,
+                  "payload": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={
+                        Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        }
+                      }
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "tag": 0,
+                },
+                "lastCapturedEffect": null,
+                "lastCapturedUpdate": null,
+                "lastEffect": null,
+                "lastUpdate": Object {
+                  "callback": null,
+                  "expirationTime": 1073741823,
+                  "next": null,
+                  "nextEffect": null,
+                  "payload": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={
+                        Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        }
+                      }
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "tag": 0,
+                },
+              },
+            },
+            "child": [Circular],
+            "childExpirationTime": 0,
+            "contextDependencies": null,
+            "effectTag": 32,
+            "elementType": null,
+            "expirationTime": 0,
+            "firstEffect": [Circular],
+            "index": 0,
+            "key": null,
+            "lastEffect": [Circular],
+            "memoizedProps": null,
+            "memoizedState": Object {
+              "element": <WrapperComponent
+                Component={[Function]}
+                context={null}
+                props={
+                  Object {
+                    "children": <AuthenticatedRoute
+                      authenticated={true}
+                      component={[Function]}
+                      path="/dashboard"
+                    />,
+                  }
+                }
+                wrappingComponentProps={null}
+              />,
+            },
+            "mode": 0,
+            "nextEffect": null,
+            "pendingProps": null,
+            "ref": null,
+            "return": null,
+            "selfBaseDuration": 0,
+            "sibling": null,
+            "stateNode": Object {
+              "containerInfo": <div />,
+              "context": Object {},
+              "current": [Circular],
+              "didError": false,
+              "earliestPendingTime": 0,
+              "earliestSuspendedTime": 0,
+              "expirationTime": 0,
+              "finishedWork": null,
+              "firstBatch": null,
+              "hydrate": false,
+              "interactionThreadID": 15,
+              "latestPendingTime": 0,
+              "latestPingedTime": 0,
+              "latestSuspendedTime": 0,
+              "memoizedInteractions": Set {},
+              "nextExpirationTimeToWorkOn": 0,
+              "nextScheduledRoot": null,
+              "pendingChildren": null,
+              "pendingCommitExpirationTime": 0,
+              "pendingContext": null,
+              "pendingInteractionMap": Map {},
+              "pingCache": null,
+              "timeoutHandle": -1,
+            },
+            "tag": 3,
+            "treeBaseDuration": 0,
+            "type": null,
+            "updateQueue": Object {
+              "baseState": Object {
+                "element": <WrapperComponent
+                  Component={[Function]}
+                  context={null}
+                  props={
+                    Object {
+                      "children": <AuthenticatedRoute
+                        authenticated={true}
+                        component={[Function]}
+                        path="/dashboard"
+                      />,
+                    }
+                  }
+                  wrappingComponentProps={null}
+                />,
+              },
+              "firstCapturedEffect": null,
+              "firstCapturedUpdate": null,
+              "firstEffect": null,
+              "firstUpdate": null,
+              "lastCapturedEffect": null,
+              "lastCapturedUpdate": null,
+              "lastEffect": null,
+              "lastUpdate": null,
+            },
+          },
+          "selfBaseDuration": 0,
+          "sibling": null,
+          "stateNode": WrapperComponent {
+            "_reactInternalFiber": [Circular],
+            "_reactInternalInstance": Object {},
+            "context": Object {},
+            "props": Object {
+              "Component": [Function],
+              "context": null,
+              "props": Object {
+                "children": <AuthenticatedRoute
+                  authenticated={true}
+                  component={[Function]}
+                  path="/dashboard"
+                />,
+              },
+              "wrappingComponentProps": null,
+            },
+            "refs": Object {},
+            "rootFinderInstance": null,
+            "state": Object {
+              "context": null,
+              "mount": true,
+              "props": Object {
+                "children": <AuthenticatedRoute
+                  authenticated={true}
+                  component={[Function]}
+                  path="/dashboard"
+                />,
+              },
+              "wrappingComponentProps": null,
+            },
+            "updater": Object {
+              "enqueueForceUpdate": [Function],
+              "enqueueReplaceState": [Function],
+              "enqueueSetState": [Function],
+              "isMounted": [Function],
+            },
+          },
+          "tag": 1,
+          "treeBaseDuration": 0,
+          "type": [Function],
+          "updateQueue": null,
+        },
+        "selfBaseDuration": 0,
+        "sibling": null,
+        "stateNode": [Circular],
+        "tag": 1,
+        "treeBaseDuration": 0,
+        "type": [Function],
+        "updateQueue": null,
+      },
+      "_reactInternalInstance": Object {},
+      "context": Object {},
+      "history": Object {
+        "action": "POP",
+        "block": [Function],
+        "createHref": [Function],
+        "go": [Function],
+        "goBack": [Function],
+        "goForward": [Function],
+        "length": 1,
+        "listen": [Function],
+        "location": Object {
+          "hash": "",
+          "pathname": "/",
+          "search": "",
+          "state": undefined,
+        },
+        "push": [Function],
+        "replace": [Function],
+      },
+      "props": Object {
+        "children": <AuthenticatedRoute
+          authenticated={true}
+          component={[Function]}
+          path="/dashboard"
+        />,
+      },
+      "refs": Object {},
+      "state": null,
+      "updater": Object {
+        "enqueueForceUpdate": [Function],
+        "enqueueReplaceState": [Function],
+        "enqueueSetState": [Function],
+        "isMounted": [Function],
+      },
+    },
+    "key": undefined,
+    "nodeType": "class",
+    "props": Object {
+      "children": <AuthenticatedRoute
+        authenticated={true}
+        component={[Function]}
+        path="/dashboard"
+      />,
+    },
+    "ref": null,
+    "rendered": Object {
+      "instance": Router {
+        "__reactInternalMemoizedMaskedChildContext": Object {
+          "router": undefined,
+        },
+        "__reactInternalMemoizedMergedChildContext": Object {
+          "router": Object {
+            "history": Object {
+              "action": "POP",
+              "block": [Function],
+              "createHref": [Function],
+              "go": [Function],
+              "goBack": [Function],
+              "goForward": [Function],
+              "length": 1,
+              "listen": [Function],
+              "location": Object {
+                "hash": "",
+                "pathname": "/",
+                "search": "",
+                "state": undefined,
+              },
+              "push": [Function],
+              "replace": [Function],
+            },
+            "route": Object {
+              "location": Object {
+                "hash": "",
+                "pathname": "/",
+                "search": "",
+                "state": undefined,
+              },
+              "match": Object {
+                "isExact": true,
+                "params": Object {},
+                "path": "/",
+                "url": "/",
+              },
+            },
+          },
+        },
+        "__reactInternalMemoizedUnmaskedChildContext": Object {},
+        "_reactInternalFiber": FiberNode {
+          "_debugHookTypes": null,
+          "_debugID": 64,
+          "_debugIsCurrentlyTiming": false,
+          "_debugOwner": FiberNode {
+            "_debugHookTypes": null,
+            "_debugID": 63,
+            "_debugIsCurrentlyTiming": false,
+            "_debugOwner": FiberNode {
+              "_debugHookTypes": null,
+              "_debugID": 62,
+              "_debugIsCurrentlyTiming": false,
+              "_debugOwner": null,
+              "_debugSource": null,
+              "actualDuration": 0,
+              "actualStartTime": -1,
+              "alternate": null,
+              "child": [Circular],
+              "childExpirationTime": 0,
+              "contextDependencies": null,
+              "effectTag": 1,
+              "elementType": [Function],
+              "expirationTime": 0,
+              "firstEffect": null,
+              "index": 0,
+              "key": null,
+              "lastEffect": null,
+              "memoizedProps": Object {
+                "Component": [Function],
+                "context": null,
+                "props": Object {
+                  "children": <AuthenticatedRoute
+                    authenticated={true}
+                    component={[Function]}
+                    path="/dashboard"
+                  />,
+                },
+                "wrappingComponentProps": null,
+              },
+              "memoizedState": Object {
+                "context": null,
+                "mount": true,
+                "props": Object {
+                  "children": <AuthenticatedRoute
+                    authenticated={true}
+                    component={[Function]}
+                    path="/dashboard"
+                  />,
+                },
+                "wrappingComponentProps": null,
+              },
+              "mode": 0,
+              "nextEffect": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 60,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": null,
+                "_debugSource": null,
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 60,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": null,
+                  "_debugSource": null,
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": [Circular],
+                  "child": null,
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 0,
+                  "elementType": null,
+                  "expirationTime": 1073741823,
+                  "firstEffect": null,
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": null,
+                  "memoizedProps": null,
+                  "memoizedState": null,
+                  "mode": 0,
+                  "nextEffect": null,
+                  "pendingProps": null,
+                  "ref": null,
+                  "return": null,
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": Object {
+                    "containerInfo": <div />,
+                    "context": Object {},
+                    "current": [Circular],
+                    "didError": false,
+                    "earliestPendingTime": 0,
+                    "earliestSuspendedTime": 0,
+                    "expirationTime": 0,
+                    "finishedWork": null,
+                    "firstBatch": null,
+                    "hydrate": false,
+                    "interactionThreadID": 15,
+                    "latestPendingTime": 0,
+                    "latestPingedTime": 0,
+                    "latestSuspendedTime": 0,
+                    "memoizedInteractions": Set {},
+                    "nextExpirationTimeToWorkOn": 0,
+                    "nextScheduledRoot": null,
+                    "pendingChildren": null,
+                    "pendingCommitExpirationTime": 0,
+                    "pendingContext": null,
+                    "pendingInteractionMap": Map {},
+                    "pingCache": null,
+                    "timeoutHandle": -1,
+                  },
+                  "tag": 3,
+                  "treeBaseDuration": 0,
+                  "type": null,
+                  "updateQueue": Object {
+                    "baseState": null,
+                    "firstCapturedEffect": null,
+                    "firstCapturedUpdate": null,
+                    "firstEffect": null,
+                    "firstUpdate": Object {
+                      "callback": null,
+                      "expirationTime": 1073741823,
+                      "next": null,
+                      "nextEffect": null,
+                      "payload": Object {
+                        "element": <WrapperComponent
+                          Component={[Function]}
+                          context={null}
+                          props={
+                            Object {
+                              "children": <AuthenticatedRoute
+                                authenticated={true}
+                                component={[Function]}
+                                path="/dashboard"
+                              />,
+                            }
+                          }
+                          wrappingComponentProps={null}
+                        />,
+                      },
+                      "tag": 0,
+                    },
+                    "lastCapturedEffect": null,
+                    "lastCapturedUpdate": null,
+                    "lastEffect": null,
+                    "lastUpdate": Object {
+                      "callback": null,
+                      "expirationTime": 1073741823,
+                      "next": null,
+                      "nextEffect": null,
+                      "payload": Object {
+                        "element": <WrapperComponent
+                          Component={[Function]}
+                          context={null}
+                          props={
+                            Object {
+                              "children": <AuthenticatedRoute
+                                authenticated={true}
+                                component={[Function]}
+                                path="/dashboard"
+                              />,
+                            }
+                          }
+                          wrappingComponentProps={null}
+                        />,
+                      },
+                      "tag": 0,
+                    },
+                  },
+                },
+                "child": [Circular],
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 32,
+                "elementType": null,
+                "expirationTime": 0,
+                "firstEffect": [Circular],
+                "index": 0,
+                "key": null,
+                "lastEffect": [Circular],
+                "memoizedProps": null,
+                "memoizedState": Object {
+                  "element": <WrapperComponent
+                    Component={[Function]}
+                    context={null}
+                    props={
+                      Object {
+                        "children": <AuthenticatedRoute
+                          authenticated={true}
+                          component={[Function]}
+                          path="/dashboard"
+                        />,
+                      }
+                    }
+                    wrappingComponentProps={null}
+                  />,
+                },
+                "mode": 0,
+                "nextEffect": null,
+                "pendingProps": null,
+                "ref": null,
+                "return": null,
+                "selfBaseDuration": 0,
+                "sibling": null,
+                "stateNode": Object {
+                  "containerInfo": <div />,
+                  "context": Object {},
+                  "current": [Circular],
+                  "didError": false,
+                  "earliestPendingTime": 0,
+                  "earliestSuspendedTime": 0,
+                  "expirationTime": 0,
+                  "finishedWork": null,
+                  "firstBatch": null,
+                  "hydrate": false,
+                  "interactionThreadID": 15,
+                  "latestPendingTime": 0,
+                  "latestPingedTime": 0,
+                  "latestSuspendedTime": 0,
+                  "memoizedInteractions": Set {},
+                  "nextExpirationTimeToWorkOn": 0,
+                  "nextScheduledRoot": null,
+                  "pendingChildren": null,
+                  "pendingCommitExpirationTime": 0,
+                  "pendingContext": null,
+                  "pendingInteractionMap": Map {},
+                  "pingCache": null,
+                  "timeoutHandle": -1,
+                },
+                "tag": 3,
+                "treeBaseDuration": 0,
+                "type": null,
+                "updateQueue": Object {
+                  "baseState": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={
+                        Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        }
+                      }
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "firstCapturedEffect": null,
+                  "firstCapturedUpdate": null,
+                  "firstEffect": null,
+                  "firstUpdate": null,
+                  "lastCapturedEffect": null,
+                  "lastCapturedUpdate": null,
+                  "lastEffect": null,
+                  "lastUpdate": null,
+                },
+              },
+              "pendingProps": Object {
+                "Component": [Function],
+                "context": null,
+                "props": Object {
+                  "children": <AuthenticatedRoute
+                    authenticated={true}
+                    component={[Function]}
+                    path="/dashboard"
+                  />,
+                },
+                "wrappingComponentProps": null,
+              },
+              "ref": null,
+              "return": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 60,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": null,
+                "_debugSource": null,
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 60,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": null,
+                  "_debugSource": null,
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": [Circular],
+                  "child": null,
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 0,
+                  "elementType": null,
+                  "expirationTime": 1073741823,
+                  "firstEffect": null,
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": null,
+                  "memoizedProps": null,
+                  "memoizedState": null,
+                  "mode": 0,
+                  "nextEffect": null,
+                  "pendingProps": null,
+                  "ref": null,
+                  "return": null,
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": Object {
+                    "containerInfo": <div />,
+                    "context": Object {},
+                    "current": [Circular],
+                    "didError": false,
+                    "earliestPendingTime": 0,
+                    "earliestSuspendedTime": 0,
+                    "expirationTime": 0,
+                    "finishedWork": null,
+                    "firstBatch": null,
+                    "hydrate": false,
+                    "interactionThreadID": 15,
+                    "latestPendingTime": 0,
+                    "latestPingedTime": 0,
+                    "latestSuspendedTime": 0,
+                    "memoizedInteractions": Set {},
+                    "nextExpirationTimeToWorkOn": 0,
+                    "nextScheduledRoot": null,
+                    "pendingChildren": null,
+                    "pendingCommitExpirationTime": 0,
+                    "pendingContext": null,
+                    "pendingInteractionMap": Map {},
+                    "pingCache": null,
+                    "timeoutHandle": -1,
+                  },
+                  "tag": 3,
+                  "treeBaseDuration": 0,
+                  "type": null,
+                  "updateQueue": Object {
+                    "baseState": null,
+                    "firstCapturedEffect": null,
+                    "firstCapturedUpdate": null,
+                    "firstEffect": null,
+                    "firstUpdate": Object {
+                      "callback": null,
+                      "expirationTime": 1073741823,
+                      "next": null,
+                      "nextEffect": null,
+                      "payload": Object {
+                        "element": <WrapperComponent
+                          Component={[Function]}
+                          context={null}
+                          props={
+                            Object {
+                              "children": <AuthenticatedRoute
+                                authenticated={true}
+                                component={[Function]}
+                                path="/dashboard"
+                              />,
+                            }
+                          }
+                          wrappingComponentProps={null}
+                        />,
+                      },
+                      "tag": 0,
+                    },
+                    "lastCapturedEffect": null,
+                    "lastCapturedUpdate": null,
+                    "lastEffect": null,
+                    "lastUpdate": Object {
+                      "callback": null,
+                      "expirationTime": 1073741823,
+                      "next": null,
+                      "nextEffect": null,
+                      "payload": Object {
+                        "element": <WrapperComponent
+                          Component={[Function]}
+                          context={null}
+                          props={
+                            Object {
+                              "children": <AuthenticatedRoute
+                                authenticated={true}
+                                component={[Function]}
+                                path="/dashboard"
+                              />,
+                            }
+                          }
+                          wrappingComponentProps={null}
+                        />,
+                      },
+                      "tag": 0,
+                    },
+                  },
+                },
+                "child": [Circular],
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 32,
+                "elementType": null,
+                "expirationTime": 0,
+                "firstEffect": [Circular],
+                "index": 0,
+                "key": null,
+                "lastEffect": [Circular],
+                "memoizedProps": null,
+                "memoizedState": Object {
+                  "element": <WrapperComponent
+                    Component={[Function]}
+                    context={null}
+                    props={
+                      Object {
+                        "children": <AuthenticatedRoute
+                          authenticated={true}
+                          component={[Function]}
+                          path="/dashboard"
+                        />,
+                      }
+                    }
+                    wrappingComponentProps={null}
+                  />,
+                },
+                "mode": 0,
+                "nextEffect": null,
+                "pendingProps": null,
+                "ref": null,
+                "return": null,
+                "selfBaseDuration": 0,
+                "sibling": null,
+                "stateNode": Object {
+                  "containerInfo": <div />,
+                  "context": Object {},
+                  "current": [Circular],
+                  "didError": false,
+                  "earliestPendingTime": 0,
+                  "earliestSuspendedTime": 0,
+                  "expirationTime": 0,
+                  "finishedWork": null,
+                  "firstBatch": null,
+                  "hydrate": false,
+                  "interactionThreadID": 15,
+                  "latestPendingTime": 0,
+                  "latestPingedTime": 0,
+                  "latestSuspendedTime": 0,
+                  "memoizedInteractions": Set {},
+                  "nextExpirationTimeToWorkOn": 0,
+                  "nextScheduledRoot": null,
+                  "pendingChildren": null,
+                  "pendingCommitExpirationTime": 0,
+                  "pendingContext": null,
+                  "pendingInteractionMap": Map {},
+                  "pingCache": null,
+                  "timeoutHandle": -1,
+                },
+                "tag": 3,
+                "treeBaseDuration": 0,
+                "type": null,
+                "updateQueue": Object {
+                  "baseState": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={
+                        Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        }
+                      }
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "firstCapturedEffect": null,
+                  "firstCapturedUpdate": null,
+                  "firstEffect": null,
+                  "firstUpdate": null,
+                  "lastCapturedEffect": null,
+                  "lastCapturedUpdate": null,
+                  "lastEffect": null,
+                  "lastUpdate": null,
+                },
+              },
+              "selfBaseDuration": 0,
+              "sibling": null,
+              "stateNode": WrapperComponent {
+                "_reactInternalFiber": [Circular],
+                "_reactInternalInstance": Object {},
+                "context": Object {},
+                "props": Object {
+                  "Component": [Function],
+                  "context": null,
+                  "props": Object {
+                    "children": <AuthenticatedRoute
+                      authenticated={true}
+                      component={[Function]}
+                      path="/dashboard"
+                    />,
+                  },
+                  "wrappingComponentProps": null,
+                },
+                "refs": Object {},
+                "rootFinderInstance": null,
+                "state": Object {
+                  "context": null,
+                  "mount": true,
+                  "props": Object {
+                    "children": <AuthenticatedRoute
+                      authenticated={true}
+                      component={[Function]}
+                      path="/dashboard"
+                    />,
+                  },
+                  "wrappingComponentProps": null,
+                },
+                "updater": Object {
+                  "enqueueForceUpdate": [Function],
+                  "enqueueReplaceState": [Function],
+                  "enqueueSetState": [Function],
+                  "isMounted": [Function],
+                },
+              },
+              "tag": 1,
+              "treeBaseDuration": 0,
+              "type": [Function],
+              "updateQueue": null,
+            },
+            "_debugSource": null,
+            "actualDuration": 0,
+            "actualStartTime": -1,
+            "alternate": null,
+            "child": [Circular],
+            "childExpirationTime": 0,
+            "contextDependencies": null,
+            "effectTag": 1,
+            "elementType": [Function],
+            "expirationTime": 0,
+            "firstEffect": null,
+            "index": 0,
+            "key": null,
+            "lastEffect": null,
+            "memoizedProps": Object {
+              "children": <AuthenticatedRoute
+                authenticated={true}
+                component={[Function]}
+                path="/dashboard"
+              />,
+            },
+            "memoizedState": null,
+            "mode": 0,
+            "nextEffect": null,
+            "pendingProps": Object {
+              "children": <AuthenticatedRoute
+                authenticated={true}
+                component={[Function]}
+                path="/dashboard"
+              />,
+            },
+            "ref": null,
+            "return": FiberNode {
+              "_debugHookTypes": null,
+              "_debugID": 62,
+              "_debugIsCurrentlyTiming": false,
+              "_debugOwner": null,
+              "_debugSource": null,
+              "actualDuration": 0,
+              "actualStartTime": -1,
+              "alternate": null,
+              "child": [Circular],
+              "childExpirationTime": 0,
+              "contextDependencies": null,
+              "effectTag": 1,
+              "elementType": [Function],
+              "expirationTime": 0,
+              "firstEffect": null,
+              "index": 0,
+              "key": null,
+              "lastEffect": null,
+              "memoizedProps": Object {
+                "Component": [Function],
+                "context": null,
+                "props": Object {
+                  "children": <AuthenticatedRoute
+                    authenticated={true}
+                    component={[Function]}
+                    path="/dashboard"
+                  />,
+                },
+                "wrappingComponentProps": null,
+              },
+              "memoizedState": Object {
+                "context": null,
+                "mount": true,
+                "props": Object {
+                  "children": <AuthenticatedRoute
+                    authenticated={true}
+                    component={[Function]}
+                    path="/dashboard"
+                  />,
+                },
+                "wrappingComponentProps": null,
+              },
+              "mode": 0,
+              "nextEffect": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 60,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": null,
+                "_debugSource": null,
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 60,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": null,
+                  "_debugSource": null,
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": [Circular],
+                  "child": null,
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 0,
+                  "elementType": null,
+                  "expirationTime": 1073741823,
+                  "firstEffect": null,
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": null,
+                  "memoizedProps": null,
+                  "memoizedState": null,
+                  "mode": 0,
+                  "nextEffect": null,
+                  "pendingProps": null,
+                  "ref": null,
+                  "return": null,
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": Object {
+                    "containerInfo": <div />,
+                    "context": Object {},
+                    "current": [Circular],
+                    "didError": false,
+                    "earliestPendingTime": 0,
+                    "earliestSuspendedTime": 0,
+                    "expirationTime": 0,
+                    "finishedWork": null,
+                    "firstBatch": null,
+                    "hydrate": false,
+                    "interactionThreadID": 15,
+                    "latestPendingTime": 0,
+                    "latestPingedTime": 0,
+                    "latestSuspendedTime": 0,
+                    "memoizedInteractions": Set {},
+                    "nextExpirationTimeToWorkOn": 0,
+                    "nextScheduledRoot": null,
+                    "pendingChildren": null,
+                    "pendingCommitExpirationTime": 0,
+                    "pendingContext": null,
+                    "pendingInteractionMap": Map {},
+                    "pingCache": null,
+                    "timeoutHandle": -1,
+                  },
+                  "tag": 3,
+                  "treeBaseDuration": 0,
+                  "type": null,
+                  "updateQueue": Object {
+                    "baseState": null,
+                    "firstCapturedEffect": null,
+                    "firstCapturedUpdate": null,
+                    "firstEffect": null,
+                    "firstUpdate": Object {
+                      "callback": null,
+                      "expirationTime": 1073741823,
+                      "next": null,
+                      "nextEffect": null,
+                      "payload": Object {
+                        "element": <WrapperComponent
+                          Component={[Function]}
+                          context={null}
+                          props={
+                            Object {
+                              "children": <AuthenticatedRoute
+                                authenticated={true}
+                                component={[Function]}
+                                path="/dashboard"
+                              />,
+                            }
+                          }
+                          wrappingComponentProps={null}
+                        />,
+                      },
+                      "tag": 0,
+                    },
+                    "lastCapturedEffect": null,
+                    "lastCapturedUpdate": null,
+                    "lastEffect": null,
+                    "lastUpdate": Object {
+                      "callback": null,
+                      "expirationTime": 1073741823,
+                      "next": null,
+                      "nextEffect": null,
+                      "payload": Object {
+                        "element": <WrapperComponent
+                          Component={[Function]}
+                          context={null}
+                          props={
+                            Object {
+                              "children": <AuthenticatedRoute
+                                authenticated={true}
+                                component={[Function]}
+                                path="/dashboard"
+                              />,
+                            }
+                          }
+                          wrappingComponentProps={null}
+                        />,
+                      },
+                      "tag": 0,
+                    },
+                  },
+                },
+                "child": [Circular],
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 32,
+                "elementType": null,
+                "expirationTime": 0,
+                "firstEffect": [Circular],
+                "index": 0,
+                "key": null,
+                "lastEffect": [Circular],
+                "memoizedProps": null,
+                "memoizedState": Object {
+                  "element": <WrapperComponent
+                    Component={[Function]}
+                    context={null}
+                    props={
+                      Object {
+                        "children": <AuthenticatedRoute
+                          authenticated={true}
+                          component={[Function]}
+                          path="/dashboard"
+                        />,
+                      }
+                    }
+                    wrappingComponentProps={null}
+                  />,
+                },
+                "mode": 0,
+                "nextEffect": null,
+                "pendingProps": null,
+                "ref": null,
+                "return": null,
+                "selfBaseDuration": 0,
+                "sibling": null,
+                "stateNode": Object {
+                  "containerInfo": <div />,
+                  "context": Object {},
+                  "current": [Circular],
+                  "didError": false,
+                  "earliestPendingTime": 0,
+                  "earliestSuspendedTime": 0,
+                  "expirationTime": 0,
+                  "finishedWork": null,
+                  "firstBatch": null,
+                  "hydrate": false,
+                  "interactionThreadID": 15,
+                  "latestPendingTime": 0,
+                  "latestPingedTime": 0,
+                  "latestSuspendedTime": 0,
+                  "memoizedInteractions": Set {},
+                  "nextExpirationTimeToWorkOn": 0,
+                  "nextScheduledRoot": null,
+                  "pendingChildren": null,
+                  "pendingCommitExpirationTime": 0,
+                  "pendingContext": null,
+                  "pendingInteractionMap": Map {},
+                  "pingCache": null,
+                  "timeoutHandle": -1,
+                },
+                "tag": 3,
+                "treeBaseDuration": 0,
+                "type": null,
+                "updateQueue": Object {
+                  "baseState": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={
+                        Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        }
+                      }
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "firstCapturedEffect": null,
+                  "firstCapturedUpdate": null,
+                  "firstEffect": null,
+                  "firstUpdate": null,
+                  "lastCapturedEffect": null,
+                  "lastCapturedUpdate": null,
+                  "lastEffect": null,
+                  "lastUpdate": null,
+                },
+              },
+              "pendingProps": Object {
+                "Component": [Function],
+                "context": null,
+                "props": Object {
+                  "children": <AuthenticatedRoute
+                    authenticated={true}
+                    component={[Function]}
+                    path="/dashboard"
+                  />,
+                },
+                "wrappingComponentProps": null,
+              },
+              "ref": null,
+              "return": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 60,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": null,
+                "_debugSource": null,
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 60,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": null,
+                  "_debugSource": null,
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": [Circular],
+                  "child": null,
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 0,
+                  "elementType": null,
+                  "expirationTime": 1073741823,
+                  "firstEffect": null,
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": null,
+                  "memoizedProps": null,
+                  "memoizedState": null,
+                  "mode": 0,
+                  "nextEffect": null,
+                  "pendingProps": null,
+                  "ref": null,
+                  "return": null,
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": Object {
+                    "containerInfo": <div />,
+                    "context": Object {},
+                    "current": [Circular],
+                    "didError": false,
+                    "earliestPendingTime": 0,
+                    "earliestSuspendedTime": 0,
+                    "expirationTime": 0,
+                    "finishedWork": null,
+                    "firstBatch": null,
+                    "hydrate": false,
+                    "interactionThreadID": 15,
+                    "latestPendingTime": 0,
+                    "latestPingedTime": 0,
+                    "latestSuspendedTime": 0,
+                    "memoizedInteractions": Set {},
+                    "nextExpirationTimeToWorkOn": 0,
+                    "nextScheduledRoot": null,
+                    "pendingChildren": null,
+                    "pendingCommitExpirationTime": 0,
+                    "pendingContext": null,
+                    "pendingInteractionMap": Map {},
+                    "pingCache": null,
+                    "timeoutHandle": -1,
+                  },
+                  "tag": 3,
+                  "treeBaseDuration": 0,
+                  "type": null,
+                  "updateQueue": Object {
+                    "baseState": null,
+                    "firstCapturedEffect": null,
+                    "firstCapturedUpdate": null,
+                    "firstEffect": null,
+                    "firstUpdate": Object {
+                      "callback": null,
+                      "expirationTime": 1073741823,
+                      "next": null,
+                      "nextEffect": null,
+                      "payload": Object {
+                        "element": <WrapperComponent
+                          Component={[Function]}
+                          context={null}
+                          props={
+                            Object {
+                              "children": <AuthenticatedRoute
+                                authenticated={true}
+                                component={[Function]}
+                                path="/dashboard"
+                              />,
+                            }
+                          }
+                          wrappingComponentProps={null}
+                        />,
+                      },
+                      "tag": 0,
+                    },
+                    "lastCapturedEffect": null,
+                    "lastCapturedUpdate": null,
+                    "lastEffect": null,
+                    "lastUpdate": Object {
+                      "callback": null,
+                      "expirationTime": 1073741823,
+                      "next": null,
+                      "nextEffect": null,
+                      "payload": Object {
+                        "element": <WrapperComponent
+                          Component={[Function]}
+                          context={null}
+                          props={
+                            Object {
+                              "children": <AuthenticatedRoute
+                                authenticated={true}
+                                component={[Function]}
+                                path="/dashboard"
+                              />,
+                            }
+                          }
+                          wrappingComponentProps={null}
+                        />,
+                      },
+                      "tag": 0,
+                    },
+                  },
+                },
+                "child": [Circular],
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 32,
+                "elementType": null,
+                "expirationTime": 0,
+                "firstEffect": [Circular],
+                "index": 0,
+                "key": null,
+                "lastEffect": [Circular],
+                "memoizedProps": null,
+                "memoizedState": Object {
+                  "element": <WrapperComponent
+                    Component={[Function]}
+                    context={null}
+                    props={
+                      Object {
+                        "children": <AuthenticatedRoute
+                          authenticated={true}
+                          component={[Function]}
+                          path="/dashboard"
+                        />,
+                      }
+                    }
+                    wrappingComponentProps={null}
+                  />,
+                },
+                "mode": 0,
+                "nextEffect": null,
+                "pendingProps": null,
+                "ref": null,
+                "return": null,
+                "selfBaseDuration": 0,
+                "sibling": null,
+                "stateNode": Object {
+                  "containerInfo": <div />,
+                  "context": Object {},
+                  "current": [Circular],
+                  "didError": false,
+                  "earliestPendingTime": 0,
+                  "earliestSuspendedTime": 0,
+                  "expirationTime": 0,
+                  "finishedWork": null,
+                  "firstBatch": null,
+                  "hydrate": false,
+                  "interactionThreadID": 15,
+                  "latestPendingTime": 0,
+                  "latestPingedTime": 0,
+                  "latestSuspendedTime": 0,
+                  "memoizedInteractions": Set {},
+                  "nextExpirationTimeToWorkOn": 0,
+                  "nextScheduledRoot": null,
+                  "pendingChildren": null,
+                  "pendingCommitExpirationTime": 0,
+                  "pendingContext": null,
+                  "pendingInteractionMap": Map {},
+                  "pingCache": null,
+                  "timeoutHandle": -1,
+                },
+                "tag": 3,
+                "treeBaseDuration": 0,
+                "type": null,
+                "updateQueue": Object {
+                  "baseState": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={
+                        Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        }
+                      }
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "firstCapturedEffect": null,
+                  "firstCapturedUpdate": null,
+                  "firstEffect": null,
+                  "firstUpdate": null,
+                  "lastCapturedEffect": null,
+                  "lastCapturedUpdate": null,
+                  "lastEffect": null,
+                  "lastUpdate": null,
+                },
+              },
+              "selfBaseDuration": 0,
+              "sibling": null,
+              "stateNode": WrapperComponent {
+                "_reactInternalFiber": [Circular],
+                "_reactInternalInstance": Object {},
+                "context": Object {},
+                "props": Object {
+                  "Component": [Function],
+                  "context": null,
+                  "props": Object {
+                    "children": <AuthenticatedRoute
+                      authenticated={true}
+                      component={[Function]}
+                      path="/dashboard"
+                    />,
+                  },
+                  "wrappingComponentProps": null,
+                },
+                "refs": Object {},
+                "rootFinderInstance": null,
+                "state": Object {
+                  "context": null,
+                  "mount": true,
+                  "props": Object {
+                    "children": <AuthenticatedRoute
+                      authenticated={true}
+                      component={[Function]}
+                      path="/dashboard"
+                    />,
+                  },
+                  "wrappingComponentProps": null,
+                },
+                "updater": Object {
+                  "enqueueForceUpdate": [Function],
+                  "enqueueReplaceState": [Function],
+                  "enqueueSetState": [Function],
+                  "isMounted": [Function],
+                },
+              },
+              "tag": 1,
+              "treeBaseDuration": 0,
+              "type": [Function],
+              "updateQueue": null,
+            },
+            "selfBaseDuration": 0,
+            "sibling": null,
+            "stateNode": BrowserRouter {
+              "_reactInternalFiber": [Circular],
+              "_reactInternalInstance": Object {},
+              "context": Object {},
+              "history": Object {
+                "action": "POP",
+                "block": [Function],
+                "createHref": [Function],
+                "go": [Function],
+                "goBack": [Function],
+                "goForward": [Function],
+                "length": 1,
+                "listen": [Function],
+                "location": Object {
+                  "hash": "",
+                  "pathname": "/",
+                  "search": "",
+                  "state": undefined,
+                },
+                "push": [Function],
+                "replace": [Function],
+              },
+              "props": Object {
+                "children": <AuthenticatedRoute
+                  authenticated={true}
+                  component={[Function]}
+                  path="/dashboard"
+                />,
+              },
+              "refs": Object {},
+              "state": null,
+              "updater": Object {
+                "enqueueForceUpdate": [Function],
+                "enqueueReplaceState": [Function],
+                "enqueueSetState": [Function],
+                "isMounted": [Function],
+              },
+            },
+            "tag": 1,
+            "treeBaseDuration": 0,
+            "type": [Function],
+            "updateQueue": null,
+          },
+          "_debugSource": null,
+          "actualDuration": 0,
+          "actualStartTime": -1,
+          "alternate": null,
+          "child": FiberNode {
+            "_debugHookTypes": null,
+            "_debugID": 65,
+            "_debugIsCurrentlyTiming": false,
+            "_debugOwner": null,
+            "_debugSource": Object {
+              "fileName": "/Users/home/Documents/Projects/javascript/Andela/bp-esa/bp-esa-frontend/src/App.test.jsx",
+              "lineNumber": 123,
+            },
+            "actualDuration": 0,
+            "actualStartTime": -1,
+            "alternate": null,
+            "child": FiberNode {
+              "_debugHookTypes": null,
+              "_debugID": 66,
+              "_debugIsCurrentlyTiming": false,
+              "_debugOwner": [Circular],
+              "_debugSource": Object {
+                "fileName": "/Users/home/Documents/Projects/javascript/Andela/bp-esa/bp-esa-frontend/src/App.jsx",
+                "lineNumber": 15,
+              },
+              "actualDuration": 0,
+              "actualStartTime": -1,
+              "alternate": null,
+              "child": null,
+              "childExpirationTime": 0,
+              "contextDependencies": null,
+              "effectTag": 1,
+              "elementType": [Function],
+              "expirationTime": 0,
+              "firstEffect": null,
+              "index": 0,
+              "key": null,
+              "lastEffect": null,
+              "memoizedProps": Object {
+                "path": "/dashboard",
+                "render": [Function],
+              },
+              "memoizedState": Object {
+                "match": null,
+              },
+              "mode": 0,
+              "nextEffect": null,
+              "pendingProps": Object {
+                "path": "/dashboard",
+                "render": [Function],
+              },
+              "ref": null,
+              "return": [Circular],
+              "selfBaseDuration": 0,
+              "sibling": null,
+              "stateNode": Route {
+                "__reactInternalMemoizedMaskedChildContext": Object {
+                  "router": Object {
+                    "history": Object {
+                      "action": "POP",
+                      "block": [Function],
+                      "createHref": [Function],
+                      "go": [Function],
+                      "goBack": [Function],
+                      "goForward": [Function],
+                      "length": 1,
+                      "listen": [Function],
+                      "location": Object {
+                        "hash": "",
+                        "pathname": "/",
+                        "search": "",
+                        "state": undefined,
+                      },
+                      "push": [Function],
+                      "replace": [Function],
+                    },
+                    "route": Object {
+                      "location": Object {
+                        "hash": "",
+                        "pathname": "/",
+                        "search": "",
+                        "state": undefined,
+                      },
+                      "match": Object {
+                        "isExact": true,
+                        "params": Object {},
+                        "path": "/",
+                        "url": "/",
+                      },
+                    },
+                  },
+                },
+                "__reactInternalMemoizedMergedChildContext": Object {
+                  "router": Object {
+                    "history": Object {
+                      "action": "POP",
+                      "block": [Function],
+                      "createHref": [Function],
+                      "go": [Function],
+                      "goBack": [Function],
+                      "goForward": [Function],
+                      "length": 1,
+                      "listen": [Function],
+                      "location": Object {
+                        "hash": "",
+                        "pathname": "/",
+                        "search": "",
+                        "state": undefined,
+                      },
+                      "push": [Function],
+                      "replace": [Function],
+                    },
+                    "route": Object {
+                      "location": Object {
+                        "hash": "",
+                        "pathname": "/",
+                        "search": "",
+                        "state": undefined,
+                      },
+                      "match": null,
+                    },
+                  },
+                },
+                "__reactInternalMemoizedUnmaskedChildContext": Object {
+                  "router": Object {
+                    "history": Object {
+                      "action": "POP",
+                      "block": [Function],
+                      "createHref": [Function],
+                      "go": [Function],
+                      "goBack": [Function],
+                      "goForward": [Function],
+                      "length": 1,
+                      "listen": [Function],
+                      "location": Object {
+                        "hash": "",
+                        "pathname": "/",
+                        "search": "",
+                        "state": undefined,
+                      },
+                      "push": [Function],
+                      "replace": [Function],
+                    },
+                    "route": Object {
+                      "location": Object {
+                        "hash": "",
+                        "pathname": "/",
+                        "search": "",
+                        "state": undefined,
+                      },
+                      "match": Object {
+                        "isExact": true,
+                        "params": Object {},
+                        "path": "/",
+                        "url": "/",
+                      },
+                    },
+                  },
+                },
+                "_reactInternalFiber": [Circular],
+                "_reactInternalInstance": Object {},
+                "context": Object {
+                  "router": Object {
+                    "history": Object {
+                      "action": "POP",
+                      "block": [Function],
+                      "createHref": [Function],
+                      "go": [Function],
+                      "goBack": [Function],
+                      "goForward": [Function],
+                      "length": 1,
+                      "listen": [Function],
+                      "location": Object {
+                        "hash": "",
+                        "pathname": "/",
+                        "search": "",
+                        "state": undefined,
+                      },
+                      "push": [Function],
+                      "replace": [Function],
+                    },
+                    "route": Object {
+                      "location": Object {
+                        "hash": "",
+                        "pathname": "/",
+                        "search": "",
+                        "state": undefined,
+                      },
+                      "match": Object {
+                        "isExact": true,
+                        "params": Object {},
+                        "path": "/",
+                        "url": "/",
+                      },
+                    },
+                  },
+                },
+                "props": Object {
+                  "path": "/dashboard",
+                  "render": [Function],
+                },
+                "refs": Object {},
+                "state": Object {
+                  "match": null,
+                },
+                "updater": Object {
+                  "enqueueForceUpdate": [Function],
+                  "enqueueReplaceState": [Function],
+                  "enqueueSetState": [Function],
+                  "isMounted": [Function],
+                },
+              },
+              "tag": 1,
+              "treeBaseDuration": 0,
+              "type": [Function],
+              "updateQueue": null,
+            },
+            "childExpirationTime": 0,
+            "contextDependencies": null,
+            "effectTag": 1,
+            "elementType": [Function],
+            "expirationTime": 0,
+            "firstEffect": null,
+            "index": 0,
+            "key": null,
+            "lastEffect": null,
+            "memoizedProps": Object {
+              "authenticated": true,
+              "component": [Function],
+              "path": "/dashboard",
+            },
+            "memoizedState": null,
+            "mode": 0,
+            "nextEffect": null,
+            "pendingProps": Object {
+              "authenticated": true,
+              "component": [Function],
+              "path": "/dashboard",
+            },
+            "ref": null,
+            "return": [Circular],
+            "selfBaseDuration": 0,
+            "sibling": null,
+            "stateNode": null,
+            "tag": 0,
+            "treeBaseDuration": 0,
+            "type": [Function],
+            "updateQueue": null,
+          },
+          "childExpirationTime": 0,
+          "contextDependencies": null,
+          "effectTag": 1,
+          "elementType": [Function],
+          "expirationTime": 0,
+          "firstEffect": null,
+          "index": 0,
+          "key": null,
+          "lastEffect": null,
+          "memoizedProps": Object {
+            "children": <AuthenticatedRoute
+              authenticated={true}
+              component={[Function]}
+              path="/dashboard"
+            />,
+            "history": Object {
+              "action": "POP",
+              "block": [Function],
+              "createHref": [Function],
+              "go": [Function],
+              "goBack": [Function],
+              "goForward": [Function],
+              "length": 1,
+              "listen": [Function],
+              "location": Object {
+                "hash": "",
+                "pathname": "/",
+                "search": "",
+                "state": undefined,
+              },
+              "push": [Function],
+              "replace": [Function],
+            },
+          },
+          "memoizedState": Object {
+            "match": Object {
+              "isExact": true,
+              "params": Object {},
+              "path": "/",
+              "url": "/",
+            },
+          },
+          "mode": 0,
+          "nextEffect": null,
+          "pendingProps": Object {
+            "children": <AuthenticatedRoute
+              authenticated={true}
+              component={[Function]}
+              path="/dashboard"
+            />,
+            "history": Object {
+              "action": "POP",
+              "block": [Function],
+              "createHref": [Function],
+              "go": [Function],
+              "goBack": [Function],
+              "goForward": [Function],
+              "length": 1,
+              "listen": [Function],
+              "location": Object {
+                "hash": "",
+                "pathname": "/",
+                "search": "",
+                "state": undefined,
+              },
+              "push": [Function],
+              "replace": [Function],
+            },
+          },
+          "ref": null,
+          "return": FiberNode {
+            "_debugHookTypes": null,
+            "_debugID": 63,
+            "_debugIsCurrentlyTiming": false,
+            "_debugOwner": FiberNode {
+              "_debugHookTypes": null,
+              "_debugID": 62,
+              "_debugIsCurrentlyTiming": false,
+              "_debugOwner": null,
+              "_debugSource": null,
+              "actualDuration": 0,
+              "actualStartTime": -1,
+              "alternate": null,
+              "child": [Circular],
+              "childExpirationTime": 0,
+              "contextDependencies": null,
+              "effectTag": 1,
+              "elementType": [Function],
+              "expirationTime": 0,
+              "firstEffect": null,
+              "index": 0,
+              "key": null,
+              "lastEffect": null,
+              "memoizedProps": Object {
+                "Component": [Function],
+                "context": null,
+                "props": Object {
+                  "children": <AuthenticatedRoute
+                    authenticated={true}
+                    component={[Function]}
+                    path="/dashboard"
+                  />,
+                },
+                "wrappingComponentProps": null,
+              },
+              "memoizedState": Object {
+                "context": null,
+                "mount": true,
+                "props": Object {
+                  "children": <AuthenticatedRoute
+                    authenticated={true}
+                    component={[Function]}
+                    path="/dashboard"
+                  />,
+                },
+                "wrappingComponentProps": null,
+              },
+              "mode": 0,
+              "nextEffect": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 60,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": null,
+                "_debugSource": null,
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 60,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": null,
+                  "_debugSource": null,
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": [Circular],
+                  "child": null,
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 0,
+                  "elementType": null,
+                  "expirationTime": 1073741823,
+                  "firstEffect": null,
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": null,
+                  "memoizedProps": null,
+                  "memoizedState": null,
+                  "mode": 0,
+                  "nextEffect": null,
+                  "pendingProps": null,
+                  "ref": null,
+                  "return": null,
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": Object {
+                    "containerInfo": <div />,
+                    "context": Object {},
+                    "current": [Circular],
+                    "didError": false,
+                    "earliestPendingTime": 0,
+                    "earliestSuspendedTime": 0,
+                    "expirationTime": 0,
+                    "finishedWork": null,
+                    "firstBatch": null,
+                    "hydrate": false,
+                    "interactionThreadID": 15,
+                    "latestPendingTime": 0,
+                    "latestPingedTime": 0,
+                    "latestSuspendedTime": 0,
+                    "memoizedInteractions": Set {},
+                    "nextExpirationTimeToWorkOn": 0,
+                    "nextScheduledRoot": null,
+                    "pendingChildren": null,
+                    "pendingCommitExpirationTime": 0,
+                    "pendingContext": null,
+                    "pendingInteractionMap": Map {},
+                    "pingCache": null,
+                    "timeoutHandle": -1,
+                  },
+                  "tag": 3,
+                  "treeBaseDuration": 0,
+                  "type": null,
+                  "updateQueue": Object {
+                    "baseState": null,
+                    "firstCapturedEffect": null,
+                    "firstCapturedUpdate": null,
+                    "firstEffect": null,
+                    "firstUpdate": Object {
+                      "callback": null,
+                      "expirationTime": 1073741823,
+                      "next": null,
+                      "nextEffect": null,
+                      "payload": Object {
+                        "element": <WrapperComponent
+                          Component={[Function]}
+                          context={null}
+                          props={
+                            Object {
+                              "children": <AuthenticatedRoute
+                                authenticated={true}
+                                component={[Function]}
+                                path="/dashboard"
+                              />,
+                            }
+                          }
+                          wrappingComponentProps={null}
+                        />,
+                      },
+                      "tag": 0,
+                    },
+                    "lastCapturedEffect": null,
+                    "lastCapturedUpdate": null,
+                    "lastEffect": null,
+                    "lastUpdate": Object {
+                      "callback": null,
+                      "expirationTime": 1073741823,
+                      "next": null,
+                      "nextEffect": null,
+                      "payload": Object {
+                        "element": <WrapperComponent
+                          Component={[Function]}
+                          context={null}
+                          props={
+                            Object {
+                              "children": <AuthenticatedRoute
+                                authenticated={true}
+                                component={[Function]}
+                                path="/dashboard"
+                              />,
+                            }
+                          }
+                          wrappingComponentProps={null}
+                        />,
+                      },
+                      "tag": 0,
+                    },
+                  },
+                },
+                "child": [Circular],
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 32,
+                "elementType": null,
+                "expirationTime": 0,
+                "firstEffect": [Circular],
+                "index": 0,
+                "key": null,
+                "lastEffect": [Circular],
+                "memoizedProps": null,
+                "memoizedState": Object {
+                  "element": <WrapperComponent
+                    Component={[Function]}
+                    context={null}
+                    props={
+                      Object {
+                        "children": <AuthenticatedRoute
+                          authenticated={true}
+                          component={[Function]}
+                          path="/dashboard"
+                        />,
+                      }
+                    }
+                    wrappingComponentProps={null}
+                  />,
+                },
+                "mode": 0,
+                "nextEffect": null,
+                "pendingProps": null,
+                "ref": null,
+                "return": null,
+                "selfBaseDuration": 0,
+                "sibling": null,
+                "stateNode": Object {
+                  "containerInfo": <div />,
+                  "context": Object {},
+                  "current": [Circular],
+                  "didError": false,
+                  "earliestPendingTime": 0,
+                  "earliestSuspendedTime": 0,
+                  "expirationTime": 0,
+                  "finishedWork": null,
+                  "firstBatch": null,
+                  "hydrate": false,
+                  "interactionThreadID": 15,
+                  "latestPendingTime": 0,
+                  "latestPingedTime": 0,
+                  "latestSuspendedTime": 0,
+                  "memoizedInteractions": Set {},
+                  "nextExpirationTimeToWorkOn": 0,
+                  "nextScheduledRoot": null,
+                  "pendingChildren": null,
+                  "pendingCommitExpirationTime": 0,
+                  "pendingContext": null,
+                  "pendingInteractionMap": Map {},
+                  "pingCache": null,
+                  "timeoutHandle": -1,
+                },
+                "tag": 3,
+                "treeBaseDuration": 0,
+                "type": null,
+                "updateQueue": Object {
+                  "baseState": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={
+                        Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        }
+                      }
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "firstCapturedEffect": null,
+                  "firstCapturedUpdate": null,
+                  "firstEffect": null,
+                  "firstUpdate": null,
+                  "lastCapturedEffect": null,
+                  "lastCapturedUpdate": null,
+                  "lastEffect": null,
+                  "lastUpdate": null,
+                },
+              },
+              "pendingProps": Object {
+                "Component": [Function],
+                "context": null,
+                "props": Object {
+                  "children": <AuthenticatedRoute
+                    authenticated={true}
+                    component={[Function]}
+                    path="/dashboard"
+                  />,
+                },
+                "wrappingComponentProps": null,
+              },
+              "ref": null,
+              "return": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 60,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": null,
+                "_debugSource": null,
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 60,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": null,
+                  "_debugSource": null,
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": [Circular],
+                  "child": null,
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 0,
+                  "elementType": null,
+                  "expirationTime": 1073741823,
+                  "firstEffect": null,
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": null,
+                  "memoizedProps": null,
+                  "memoizedState": null,
+                  "mode": 0,
+                  "nextEffect": null,
+                  "pendingProps": null,
+                  "ref": null,
+                  "return": null,
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": Object {
+                    "containerInfo": <div />,
+                    "context": Object {},
+                    "current": [Circular],
+                    "didError": false,
+                    "earliestPendingTime": 0,
+                    "earliestSuspendedTime": 0,
+                    "expirationTime": 0,
+                    "finishedWork": null,
+                    "firstBatch": null,
+                    "hydrate": false,
+                    "interactionThreadID": 15,
+                    "latestPendingTime": 0,
+                    "latestPingedTime": 0,
+                    "latestSuspendedTime": 0,
+                    "memoizedInteractions": Set {},
+                    "nextExpirationTimeToWorkOn": 0,
+                    "nextScheduledRoot": null,
+                    "pendingChildren": null,
+                    "pendingCommitExpirationTime": 0,
+                    "pendingContext": null,
+                    "pendingInteractionMap": Map {},
+                    "pingCache": null,
+                    "timeoutHandle": -1,
+                  },
+                  "tag": 3,
+                  "treeBaseDuration": 0,
+                  "type": null,
+                  "updateQueue": Object {
+                    "baseState": null,
+                    "firstCapturedEffect": null,
+                    "firstCapturedUpdate": null,
+                    "firstEffect": null,
+                    "firstUpdate": Object {
+                      "callback": null,
+                      "expirationTime": 1073741823,
+                      "next": null,
+                      "nextEffect": null,
+                      "payload": Object {
+                        "element": <WrapperComponent
+                          Component={[Function]}
+                          context={null}
+                          props={
+                            Object {
+                              "children": <AuthenticatedRoute
+                                authenticated={true}
+                                component={[Function]}
+                                path="/dashboard"
+                              />,
+                            }
+                          }
+                          wrappingComponentProps={null}
+                        />,
+                      },
+                      "tag": 0,
+                    },
+                    "lastCapturedEffect": null,
+                    "lastCapturedUpdate": null,
+                    "lastEffect": null,
+                    "lastUpdate": Object {
+                      "callback": null,
+                      "expirationTime": 1073741823,
+                      "next": null,
+                      "nextEffect": null,
+                      "payload": Object {
+                        "element": <WrapperComponent
+                          Component={[Function]}
+                          context={null}
+                          props={
+                            Object {
+                              "children": <AuthenticatedRoute
+                                authenticated={true}
+                                component={[Function]}
+                                path="/dashboard"
+                              />,
+                            }
+                          }
+                          wrappingComponentProps={null}
+                        />,
+                      },
+                      "tag": 0,
+                    },
+                  },
+                },
+                "child": [Circular],
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 32,
+                "elementType": null,
+                "expirationTime": 0,
+                "firstEffect": [Circular],
+                "index": 0,
+                "key": null,
+                "lastEffect": [Circular],
+                "memoizedProps": null,
+                "memoizedState": Object {
+                  "element": <WrapperComponent
+                    Component={[Function]}
+                    context={null}
+                    props={
+                      Object {
+                        "children": <AuthenticatedRoute
+                          authenticated={true}
+                          component={[Function]}
+                          path="/dashboard"
+                        />,
+                      }
+                    }
+                    wrappingComponentProps={null}
+                  />,
+                },
+                "mode": 0,
+                "nextEffect": null,
+                "pendingProps": null,
+                "ref": null,
+                "return": null,
+                "selfBaseDuration": 0,
+                "sibling": null,
+                "stateNode": Object {
+                  "containerInfo": <div />,
+                  "context": Object {},
+                  "current": [Circular],
+                  "didError": false,
+                  "earliestPendingTime": 0,
+                  "earliestSuspendedTime": 0,
+                  "expirationTime": 0,
+                  "finishedWork": null,
+                  "firstBatch": null,
+                  "hydrate": false,
+                  "interactionThreadID": 15,
+                  "latestPendingTime": 0,
+                  "latestPingedTime": 0,
+                  "latestSuspendedTime": 0,
+                  "memoizedInteractions": Set {},
+                  "nextExpirationTimeToWorkOn": 0,
+                  "nextScheduledRoot": null,
+                  "pendingChildren": null,
+                  "pendingCommitExpirationTime": 0,
+                  "pendingContext": null,
+                  "pendingInteractionMap": Map {},
+                  "pingCache": null,
+                  "timeoutHandle": -1,
+                },
+                "tag": 3,
+                "treeBaseDuration": 0,
+                "type": null,
+                "updateQueue": Object {
+                  "baseState": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={
+                        Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        }
+                      }
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "firstCapturedEffect": null,
+                  "firstCapturedUpdate": null,
+                  "firstEffect": null,
+                  "firstUpdate": null,
+                  "lastCapturedEffect": null,
+                  "lastCapturedUpdate": null,
+                  "lastEffect": null,
+                  "lastUpdate": null,
+                },
+              },
+              "selfBaseDuration": 0,
+              "sibling": null,
+              "stateNode": WrapperComponent {
+                "_reactInternalFiber": [Circular],
+                "_reactInternalInstance": Object {},
+                "context": Object {},
+                "props": Object {
+                  "Component": [Function],
+                  "context": null,
+                  "props": Object {
+                    "children": <AuthenticatedRoute
+                      authenticated={true}
+                      component={[Function]}
+                      path="/dashboard"
+                    />,
+                  },
+                  "wrappingComponentProps": null,
+                },
+                "refs": Object {},
+                "rootFinderInstance": null,
+                "state": Object {
+                  "context": null,
+                  "mount": true,
+                  "props": Object {
+                    "children": <AuthenticatedRoute
+                      authenticated={true}
+                      component={[Function]}
+                      path="/dashboard"
+                    />,
+                  },
+                  "wrappingComponentProps": null,
+                },
+                "updater": Object {
+                  "enqueueForceUpdate": [Function],
+                  "enqueueReplaceState": [Function],
+                  "enqueueSetState": [Function],
+                  "isMounted": [Function],
+                },
+              },
+              "tag": 1,
+              "treeBaseDuration": 0,
+              "type": [Function],
+              "updateQueue": null,
+            },
+            "_debugSource": null,
+            "actualDuration": 0,
+            "actualStartTime": -1,
+            "alternate": null,
+            "child": [Circular],
+            "childExpirationTime": 0,
+            "contextDependencies": null,
+            "effectTag": 1,
+            "elementType": [Function],
+            "expirationTime": 0,
+            "firstEffect": null,
+            "index": 0,
+            "key": null,
+            "lastEffect": null,
+            "memoizedProps": Object {
+              "children": <AuthenticatedRoute
+                authenticated={true}
+                component={[Function]}
+                path="/dashboard"
+              />,
+            },
+            "memoizedState": null,
+            "mode": 0,
+            "nextEffect": null,
+            "pendingProps": Object {
+              "children": <AuthenticatedRoute
+                authenticated={true}
+                component={[Function]}
+                path="/dashboard"
+              />,
+            },
+            "ref": null,
+            "return": FiberNode {
+              "_debugHookTypes": null,
+              "_debugID": 62,
+              "_debugIsCurrentlyTiming": false,
+              "_debugOwner": null,
+              "_debugSource": null,
+              "actualDuration": 0,
+              "actualStartTime": -1,
+              "alternate": null,
+              "child": [Circular],
+              "childExpirationTime": 0,
+              "contextDependencies": null,
+              "effectTag": 1,
+              "elementType": [Function],
+              "expirationTime": 0,
+              "firstEffect": null,
+              "index": 0,
+              "key": null,
+              "lastEffect": null,
+              "memoizedProps": Object {
+                "Component": [Function],
+                "context": null,
+                "props": Object {
+                  "children": <AuthenticatedRoute
+                    authenticated={true}
+                    component={[Function]}
+                    path="/dashboard"
+                  />,
+                },
+                "wrappingComponentProps": null,
+              },
+              "memoizedState": Object {
+                "context": null,
+                "mount": true,
+                "props": Object {
+                  "children": <AuthenticatedRoute
+                    authenticated={true}
+                    component={[Function]}
+                    path="/dashboard"
+                  />,
+                },
+                "wrappingComponentProps": null,
+              },
+              "mode": 0,
+              "nextEffect": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 60,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": null,
+                "_debugSource": null,
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 60,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": null,
+                  "_debugSource": null,
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": [Circular],
+                  "child": null,
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 0,
+                  "elementType": null,
+                  "expirationTime": 1073741823,
+                  "firstEffect": null,
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": null,
+                  "memoizedProps": null,
+                  "memoizedState": null,
+                  "mode": 0,
+                  "nextEffect": null,
+                  "pendingProps": null,
+                  "ref": null,
+                  "return": null,
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": Object {
+                    "containerInfo": <div />,
+                    "context": Object {},
+                    "current": [Circular],
+                    "didError": false,
+                    "earliestPendingTime": 0,
+                    "earliestSuspendedTime": 0,
+                    "expirationTime": 0,
+                    "finishedWork": null,
+                    "firstBatch": null,
+                    "hydrate": false,
+                    "interactionThreadID": 15,
+                    "latestPendingTime": 0,
+                    "latestPingedTime": 0,
+                    "latestSuspendedTime": 0,
+                    "memoizedInteractions": Set {},
+                    "nextExpirationTimeToWorkOn": 0,
+                    "nextScheduledRoot": null,
+                    "pendingChildren": null,
+                    "pendingCommitExpirationTime": 0,
+                    "pendingContext": null,
+                    "pendingInteractionMap": Map {},
+                    "pingCache": null,
+                    "timeoutHandle": -1,
+                  },
+                  "tag": 3,
+                  "treeBaseDuration": 0,
+                  "type": null,
+                  "updateQueue": Object {
+                    "baseState": null,
+                    "firstCapturedEffect": null,
+                    "firstCapturedUpdate": null,
+                    "firstEffect": null,
+                    "firstUpdate": Object {
+                      "callback": null,
+                      "expirationTime": 1073741823,
+                      "next": null,
+                      "nextEffect": null,
+                      "payload": Object {
+                        "element": <WrapperComponent
+                          Component={[Function]}
+                          context={null}
+                          props={
+                            Object {
+                              "children": <AuthenticatedRoute
+                                authenticated={true}
+                                component={[Function]}
+                                path="/dashboard"
+                              />,
+                            }
+                          }
+                          wrappingComponentProps={null}
+                        />,
+                      },
+                      "tag": 0,
+                    },
+                    "lastCapturedEffect": null,
+                    "lastCapturedUpdate": null,
+                    "lastEffect": null,
+                    "lastUpdate": Object {
+                      "callback": null,
+                      "expirationTime": 1073741823,
+                      "next": null,
+                      "nextEffect": null,
+                      "payload": Object {
+                        "element": <WrapperComponent
+                          Component={[Function]}
+                          context={null}
+                          props={
+                            Object {
+                              "children": <AuthenticatedRoute
+                                authenticated={true}
+                                component={[Function]}
+                                path="/dashboard"
+                              />,
+                            }
+                          }
+                          wrappingComponentProps={null}
+                        />,
+                      },
+                      "tag": 0,
+                    },
+                  },
+                },
+                "child": [Circular],
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 32,
+                "elementType": null,
+                "expirationTime": 0,
+                "firstEffect": [Circular],
+                "index": 0,
+                "key": null,
+                "lastEffect": [Circular],
+                "memoizedProps": null,
+                "memoizedState": Object {
+                  "element": <WrapperComponent
+                    Component={[Function]}
+                    context={null}
+                    props={
+                      Object {
+                        "children": <AuthenticatedRoute
+                          authenticated={true}
+                          component={[Function]}
+                          path="/dashboard"
+                        />,
+                      }
+                    }
+                    wrappingComponentProps={null}
+                  />,
+                },
+                "mode": 0,
+                "nextEffect": null,
+                "pendingProps": null,
+                "ref": null,
+                "return": null,
+                "selfBaseDuration": 0,
+                "sibling": null,
+                "stateNode": Object {
+                  "containerInfo": <div />,
+                  "context": Object {},
+                  "current": [Circular],
+                  "didError": false,
+                  "earliestPendingTime": 0,
+                  "earliestSuspendedTime": 0,
+                  "expirationTime": 0,
+                  "finishedWork": null,
+                  "firstBatch": null,
+                  "hydrate": false,
+                  "interactionThreadID": 15,
+                  "latestPendingTime": 0,
+                  "latestPingedTime": 0,
+                  "latestSuspendedTime": 0,
+                  "memoizedInteractions": Set {},
+                  "nextExpirationTimeToWorkOn": 0,
+                  "nextScheduledRoot": null,
+                  "pendingChildren": null,
+                  "pendingCommitExpirationTime": 0,
+                  "pendingContext": null,
+                  "pendingInteractionMap": Map {},
+                  "pingCache": null,
+                  "timeoutHandle": -1,
+                },
+                "tag": 3,
+                "treeBaseDuration": 0,
+                "type": null,
+                "updateQueue": Object {
+                  "baseState": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={
+                        Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        }
+                      }
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "firstCapturedEffect": null,
+                  "firstCapturedUpdate": null,
+                  "firstEffect": null,
+                  "firstUpdate": null,
+                  "lastCapturedEffect": null,
+                  "lastCapturedUpdate": null,
+                  "lastEffect": null,
+                  "lastUpdate": null,
+                },
+              },
+              "pendingProps": Object {
+                "Component": [Function],
+                "context": null,
+                "props": Object {
+                  "children": <AuthenticatedRoute
+                    authenticated={true}
+                    component={[Function]}
+                    path="/dashboard"
+                  />,
+                },
+                "wrappingComponentProps": null,
+              },
+              "ref": null,
+              "return": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 60,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": null,
+                "_debugSource": null,
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 60,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": null,
+                  "_debugSource": null,
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": [Circular],
+                  "child": null,
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 0,
+                  "elementType": null,
+                  "expirationTime": 1073741823,
+                  "firstEffect": null,
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": null,
+                  "memoizedProps": null,
+                  "memoizedState": null,
+                  "mode": 0,
+                  "nextEffect": null,
+                  "pendingProps": null,
+                  "ref": null,
+                  "return": null,
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": Object {
+                    "containerInfo": <div />,
+                    "context": Object {},
+                    "current": [Circular],
+                    "didError": false,
+                    "earliestPendingTime": 0,
+                    "earliestSuspendedTime": 0,
+                    "expirationTime": 0,
+                    "finishedWork": null,
+                    "firstBatch": null,
+                    "hydrate": false,
+                    "interactionThreadID": 15,
+                    "latestPendingTime": 0,
+                    "latestPingedTime": 0,
+                    "latestSuspendedTime": 0,
+                    "memoizedInteractions": Set {},
+                    "nextExpirationTimeToWorkOn": 0,
+                    "nextScheduledRoot": null,
+                    "pendingChildren": null,
+                    "pendingCommitExpirationTime": 0,
+                    "pendingContext": null,
+                    "pendingInteractionMap": Map {},
+                    "pingCache": null,
+                    "timeoutHandle": -1,
+                  },
+                  "tag": 3,
+                  "treeBaseDuration": 0,
+                  "type": null,
+                  "updateQueue": Object {
+                    "baseState": null,
+                    "firstCapturedEffect": null,
+                    "firstCapturedUpdate": null,
+                    "firstEffect": null,
+                    "firstUpdate": Object {
+                      "callback": null,
+                      "expirationTime": 1073741823,
+                      "next": null,
+                      "nextEffect": null,
+                      "payload": Object {
+                        "element": <WrapperComponent
+                          Component={[Function]}
+                          context={null}
+                          props={
+                            Object {
+                              "children": <AuthenticatedRoute
+                                authenticated={true}
+                                component={[Function]}
+                                path="/dashboard"
+                              />,
+                            }
+                          }
+                          wrappingComponentProps={null}
+                        />,
+                      },
+                      "tag": 0,
+                    },
+                    "lastCapturedEffect": null,
+                    "lastCapturedUpdate": null,
+                    "lastEffect": null,
+                    "lastUpdate": Object {
+                      "callback": null,
+                      "expirationTime": 1073741823,
+                      "next": null,
+                      "nextEffect": null,
+                      "payload": Object {
+                        "element": <WrapperComponent
+                          Component={[Function]}
+                          context={null}
+                          props={
+                            Object {
+                              "children": <AuthenticatedRoute
+                                authenticated={true}
+                                component={[Function]}
+                                path="/dashboard"
+                              />,
+                            }
+                          }
+                          wrappingComponentProps={null}
+                        />,
+                      },
+                      "tag": 0,
+                    },
+                  },
+                },
+                "child": [Circular],
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 32,
+                "elementType": null,
+                "expirationTime": 0,
+                "firstEffect": [Circular],
+                "index": 0,
+                "key": null,
+                "lastEffect": [Circular],
+                "memoizedProps": null,
+                "memoizedState": Object {
+                  "element": <WrapperComponent
+                    Component={[Function]}
+                    context={null}
+                    props={
+                      Object {
+                        "children": <AuthenticatedRoute
+                          authenticated={true}
+                          component={[Function]}
+                          path="/dashboard"
+                        />,
+                      }
+                    }
+                    wrappingComponentProps={null}
+                  />,
+                },
+                "mode": 0,
+                "nextEffect": null,
+                "pendingProps": null,
+                "ref": null,
+                "return": null,
+                "selfBaseDuration": 0,
+                "sibling": null,
+                "stateNode": Object {
+                  "containerInfo": <div />,
+                  "context": Object {},
+                  "current": [Circular],
+                  "didError": false,
+                  "earliestPendingTime": 0,
+                  "earliestSuspendedTime": 0,
+                  "expirationTime": 0,
+                  "finishedWork": null,
+                  "firstBatch": null,
+                  "hydrate": false,
+                  "interactionThreadID": 15,
+                  "latestPendingTime": 0,
+                  "latestPingedTime": 0,
+                  "latestSuspendedTime": 0,
+                  "memoizedInteractions": Set {},
+                  "nextExpirationTimeToWorkOn": 0,
+                  "nextScheduledRoot": null,
+                  "pendingChildren": null,
+                  "pendingCommitExpirationTime": 0,
+                  "pendingContext": null,
+                  "pendingInteractionMap": Map {},
+                  "pingCache": null,
+                  "timeoutHandle": -1,
+                },
+                "tag": 3,
+                "treeBaseDuration": 0,
+                "type": null,
+                "updateQueue": Object {
+                  "baseState": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={
+                        Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        }
+                      }
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "firstCapturedEffect": null,
+                  "firstCapturedUpdate": null,
+                  "firstEffect": null,
+                  "firstUpdate": null,
+                  "lastCapturedEffect": null,
+                  "lastCapturedUpdate": null,
+                  "lastEffect": null,
+                  "lastUpdate": null,
+                },
+              },
+              "selfBaseDuration": 0,
+              "sibling": null,
+              "stateNode": WrapperComponent {
+                "_reactInternalFiber": [Circular],
+                "_reactInternalInstance": Object {},
+                "context": Object {},
+                "props": Object {
+                  "Component": [Function],
+                  "context": null,
+                  "props": Object {
+                    "children": <AuthenticatedRoute
+                      authenticated={true}
+                      component={[Function]}
+                      path="/dashboard"
+                    />,
+                  },
+                  "wrappingComponentProps": null,
+                },
+                "refs": Object {},
+                "rootFinderInstance": null,
+                "state": Object {
+                  "context": null,
+                  "mount": true,
+                  "props": Object {
+                    "children": <AuthenticatedRoute
+                      authenticated={true}
+                      component={[Function]}
+                      path="/dashboard"
+                    />,
+                  },
+                  "wrappingComponentProps": null,
+                },
+                "updater": Object {
+                  "enqueueForceUpdate": [Function],
+                  "enqueueReplaceState": [Function],
+                  "enqueueSetState": [Function],
+                  "isMounted": [Function],
+                },
+              },
+              "tag": 1,
+              "treeBaseDuration": 0,
+              "type": [Function],
+              "updateQueue": null,
+            },
+            "selfBaseDuration": 0,
+            "sibling": null,
+            "stateNode": BrowserRouter {
+              "_reactInternalFiber": [Circular],
+              "_reactInternalInstance": Object {},
+              "context": Object {},
+              "history": Object {
+                "action": "POP",
+                "block": [Function],
+                "createHref": [Function],
+                "go": [Function],
+                "goBack": [Function],
+                "goForward": [Function],
+                "length": 1,
+                "listen": [Function],
+                "location": Object {
+                  "hash": "",
+                  "pathname": "/",
+                  "search": "",
+                  "state": undefined,
+                },
+                "push": [Function],
+                "replace": [Function],
+              },
+              "props": Object {
+                "children": <AuthenticatedRoute
+                  authenticated={true}
+                  component={[Function]}
+                  path="/dashboard"
+                />,
+              },
+              "refs": Object {},
+              "state": null,
+              "updater": Object {
+                "enqueueForceUpdate": [Function],
+                "enqueueReplaceState": [Function],
+                "enqueueSetState": [Function],
+                "isMounted": [Function],
+              },
+            },
+            "tag": 1,
+            "treeBaseDuration": 0,
+            "type": [Function],
+            "updateQueue": null,
+          },
+          "selfBaseDuration": 0,
+          "sibling": null,
+          "stateNode": [Circular],
+          "tag": 1,
+          "treeBaseDuration": 0,
+          "type": [Function],
+          "updateQueue": null,
+        },
+        "_reactInternalInstance": Object {},
+        "context": Object {
+          "router": undefined,
+        },
+        "props": Object {
+          "children": <AuthenticatedRoute
+            authenticated={true}
+            component={[Function]}
+            path="/dashboard"
+          />,
+          "history": Object {
+            "action": "POP",
+            "block": [Function],
+            "createHref": [Function],
+            "go": [Function],
+            "goBack": [Function],
+            "goForward": [Function],
+            "length": 1,
+            "listen": [Function],
+            "location": Object {
+              "hash": "",
+              "pathname": "/",
+              "search": "",
+              "state": undefined,
+            },
+            "push": [Function],
+            "replace": [Function],
+          },
+        },
+        "refs": Object {},
+        "state": Object {
+          "match": Object {
+            "isExact": true,
+            "params": Object {},
+            "path": "/",
+            "url": "/",
+          },
+        },
+        "unlisten": [Function],
+        "updater": Object {
+          "enqueueForceUpdate": [Function],
+          "enqueueReplaceState": [Function],
+          "enqueueSetState": [Function],
+          "isMounted": [Function],
+        },
+      },
+      "key": undefined,
+      "nodeType": "class",
+      "props": Object {
+        "children": <AuthenticatedRoute
+          authenticated={true}
+          component={[Function]}
+          path="/dashboard"
+        />,
+        "history": Object {
+          "action": "POP",
+          "block": [Function],
+          "createHref": [Function],
+          "go": [Function],
+          "goBack": [Function],
+          "goForward": [Function],
+          "length": 1,
+          "listen": [Function],
+          "location": Object {
+            "hash": "",
+            "pathname": "/",
+            "search": "",
+            "state": undefined,
+          },
+          "push": [Function],
+          "replace": [Function],
+        },
+      },
+      "ref": null,
+      "rendered": Object {
+        "instance": null,
+        "key": undefined,
+        "nodeType": "function",
+        "props": Object {
+          "authenticated": true,
+          "component": [Function],
+          "path": "/dashboard",
+        },
+        "ref": null,
+        "rendered": Object {
+          "instance": Route {
+            "__reactInternalMemoizedMaskedChildContext": Object {
+              "router": Object {
+                "history": Object {
+                  "action": "POP",
+                  "block": [Function],
+                  "createHref": [Function],
+                  "go": [Function],
+                  "goBack": [Function],
+                  "goForward": [Function],
+                  "length": 1,
+                  "listen": [Function],
+                  "location": Object {
+                    "hash": "",
+                    "pathname": "/",
+                    "search": "",
+                    "state": undefined,
+                  },
+                  "push": [Function],
+                  "replace": [Function],
+                },
+                "route": Object {
+                  "location": Object {
+                    "hash": "",
+                    "pathname": "/",
+                    "search": "",
+                    "state": undefined,
+                  },
+                  "match": Object {
+                    "isExact": true,
+                    "params": Object {},
+                    "path": "/",
+                    "url": "/",
+                  },
+                },
+              },
+            },
+            "__reactInternalMemoizedMergedChildContext": Object {
+              "router": Object {
+                "history": Object {
+                  "action": "POP",
+                  "block": [Function],
+                  "createHref": [Function],
+                  "go": [Function],
+                  "goBack": [Function],
+                  "goForward": [Function],
+                  "length": 1,
+                  "listen": [Function],
+                  "location": Object {
+                    "hash": "",
+                    "pathname": "/",
+                    "search": "",
+                    "state": undefined,
+                  },
+                  "push": [Function],
+                  "replace": [Function],
+                },
+                "route": Object {
+                  "location": Object {
+                    "hash": "",
+                    "pathname": "/",
+                    "search": "",
+                    "state": undefined,
+                  },
+                  "match": null,
+                },
+              },
+            },
+            "__reactInternalMemoizedUnmaskedChildContext": Object {
+              "router": Object {
+                "history": Object {
+                  "action": "POP",
+                  "block": [Function],
+                  "createHref": [Function],
+                  "go": [Function],
+                  "goBack": [Function],
+                  "goForward": [Function],
+                  "length": 1,
+                  "listen": [Function],
+                  "location": Object {
+                    "hash": "",
+                    "pathname": "/",
+                    "search": "",
+                    "state": undefined,
+                  },
+                  "push": [Function],
+                  "replace": [Function],
+                },
+                "route": Object {
+                  "location": Object {
+                    "hash": "",
+                    "pathname": "/",
+                    "search": "",
+                    "state": undefined,
+                  },
+                  "match": Object {
+                    "isExact": true,
+                    "params": Object {},
+                    "path": "/",
+                    "url": "/",
+                  },
+                },
+              },
+            },
+            "_reactInternalFiber": FiberNode {
+              "_debugHookTypes": null,
+              "_debugID": 66,
+              "_debugIsCurrentlyTiming": false,
+              "_debugOwner": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 65,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": null,
+                "_debugSource": Object {
+                  "fileName": "/Users/home/Documents/Projects/javascript/Andela/bp-esa/bp-esa-frontend/src/App.test.jsx",
+                  "lineNumber": 123,
+                },
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": null,
+                "child": [Circular],
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 1,
+                "elementType": [Function],
+                "expirationTime": 0,
+                "firstEffect": null,
+                "index": 0,
+                "key": null,
+                "lastEffect": null,
+                "memoizedProps": Object {
+                  "authenticated": true,
+                  "component": [Function],
+                  "path": "/dashboard",
+                },
+                "memoizedState": null,
+                "mode": 0,
+                "nextEffect": null,
+                "pendingProps": Object {
+                  "authenticated": true,
+                  "component": [Function],
+                  "path": "/dashboard",
+                },
+                "ref": null,
+                "return": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 64,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 63,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": FiberNode {
+                      "_debugHookTypes": null,
+                      "_debugID": 62,
+                      "_debugIsCurrentlyTiming": false,
+                      "_debugOwner": null,
+                      "_debugSource": null,
+                      "actualDuration": 0,
+                      "actualStartTime": -1,
+                      "alternate": null,
+                      "child": [Circular],
+                      "childExpirationTime": 0,
+                      "contextDependencies": null,
+                      "effectTag": 1,
+                      "elementType": [Function],
+                      "expirationTime": 0,
+                      "firstEffect": null,
+                      "index": 0,
+                      "key": null,
+                      "lastEffect": null,
+                      "memoizedProps": Object {
+                        "Component": [Function],
+                        "context": null,
+                        "props": Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        },
+                        "wrappingComponentProps": null,
+                      },
+                      "memoizedState": Object {
+                        "context": null,
+                        "mount": true,
+                        "props": Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        },
+                        "wrappingComponentProps": null,
+                      },
+                      "mode": 0,
+                      "nextEffect": FiberNode {
+                        "_debugHookTypes": null,
+                        "_debugID": 60,
+                        "_debugIsCurrentlyTiming": false,
+                        "_debugOwner": null,
+                        "_debugSource": null,
+                        "actualDuration": 0,
+                        "actualStartTime": -1,
+                        "alternate": FiberNode {
+                          "_debugHookTypes": null,
+                          "_debugID": 60,
+                          "_debugIsCurrentlyTiming": false,
+                          "_debugOwner": null,
+                          "_debugSource": null,
+                          "actualDuration": 0,
+                          "actualStartTime": -1,
+                          "alternate": [Circular],
+                          "child": null,
+                          "childExpirationTime": 0,
+                          "contextDependencies": null,
+                          "effectTag": 0,
+                          "elementType": null,
+                          "expirationTime": 1073741823,
+                          "firstEffect": null,
+                          "index": 0,
+                          "key": null,
+                          "lastEffect": null,
+                          "memoizedProps": null,
+                          "memoizedState": null,
+                          "mode": 0,
+                          "nextEffect": null,
+                          "pendingProps": null,
+                          "ref": null,
+                          "return": null,
+                          "selfBaseDuration": 0,
+                          "sibling": null,
+                          "stateNode": Object {
+                            "containerInfo": <div />,
+                            "context": Object {},
+                            "current": [Circular],
+                            "didError": false,
+                            "earliestPendingTime": 0,
+                            "earliestSuspendedTime": 0,
+                            "expirationTime": 0,
+                            "finishedWork": null,
+                            "firstBatch": null,
+                            "hydrate": false,
+                            "interactionThreadID": 15,
+                            "latestPendingTime": 0,
+                            "latestPingedTime": 0,
+                            "latestSuspendedTime": 0,
+                            "memoizedInteractions": Set {},
+                            "nextExpirationTimeToWorkOn": 0,
+                            "nextScheduledRoot": null,
+                            "pendingChildren": null,
+                            "pendingCommitExpirationTime": 0,
+                            "pendingContext": null,
+                            "pendingInteractionMap": Map {},
+                            "pingCache": null,
+                            "timeoutHandle": -1,
+                          },
+                          "tag": 3,
+                          "treeBaseDuration": 0,
+                          "type": null,
+                          "updateQueue": Object {
+                            "baseState": null,
+                            "firstCapturedEffect": null,
+                            "firstCapturedUpdate": null,
+                            "firstEffect": null,
+                            "firstUpdate": Object {
+                              "callback": null,
+                              "expirationTime": 1073741823,
+                              "next": null,
+                              "nextEffect": null,
+                              "payload": Object {
+                                "element": <WrapperComponent
+                                  Component={[Function]}
+                                  context={null}
+                                  props={
+                                    Object {
+                                      "children": <AuthenticatedRoute
+                                        authenticated={true}
+                                        component={[Function]}
+                                        path="/dashboard"
+                                      />,
+                                    }
+                                  }
+                                  wrappingComponentProps={null}
+                                />,
+                              },
+                              "tag": 0,
+                            },
+                            "lastCapturedEffect": null,
+                            "lastCapturedUpdate": null,
+                            "lastEffect": null,
+                            "lastUpdate": Object {
+                              "callback": null,
+                              "expirationTime": 1073741823,
+                              "next": null,
+                              "nextEffect": null,
+                              "payload": Object {
+                                "element": <WrapperComponent
+                                  Component={[Function]}
+                                  context={null}
+                                  props={
+                                    Object {
+                                      "children": <AuthenticatedRoute
+                                        authenticated={true}
+                                        component={[Function]}
+                                        path="/dashboard"
+                                      />,
+                                    }
+                                  }
+                                  wrappingComponentProps={null}
+                                />,
+                              },
+                              "tag": 0,
+                            },
+                          },
+                        },
+                        "child": [Circular],
+                        "childExpirationTime": 0,
+                        "contextDependencies": null,
+                        "effectTag": 32,
+                        "elementType": null,
+                        "expirationTime": 0,
+                        "firstEffect": [Circular],
+                        "index": 0,
+                        "key": null,
+                        "lastEffect": [Circular],
+                        "memoizedProps": null,
+                        "memoizedState": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={
+                              Object {
+                                "children": <AuthenticatedRoute
+                                  authenticated={true}
+                                  component={[Function]}
+                                  path="/dashboard"
+                                />,
+                              }
+                            }
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "mode": 0,
+                        "nextEffect": null,
+                        "pendingProps": null,
+                        "ref": null,
+                        "return": null,
+                        "selfBaseDuration": 0,
+                        "sibling": null,
+                        "stateNode": Object {
+                          "containerInfo": <div />,
+                          "context": Object {},
+                          "current": [Circular],
+                          "didError": false,
+                          "earliestPendingTime": 0,
+                          "earliestSuspendedTime": 0,
+                          "expirationTime": 0,
+                          "finishedWork": null,
+                          "firstBatch": null,
+                          "hydrate": false,
+                          "interactionThreadID": 15,
+                          "latestPendingTime": 0,
+                          "latestPingedTime": 0,
+                          "latestSuspendedTime": 0,
+                          "memoizedInteractions": Set {},
+                          "nextExpirationTimeToWorkOn": 0,
+                          "nextScheduledRoot": null,
+                          "pendingChildren": null,
+                          "pendingCommitExpirationTime": 0,
+                          "pendingContext": null,
+                          "pendingInteractionMap": Map {},
+                          "pingCache": null,
+                          "timeoutHandle": -1,
+                        },
+                        "tag": 3,
+                        "treeBaseDuration": 0,
+                        "type": null,
+                        "updateQueue": Object {
+                          "baseState": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={
+                                Object {
+                                  "children": <AuthenticatedRoute
+                                    authenticated={true}
+                                    component={[Function]}
+                                    path="/dashboard"
+                                  />,
+                                }
+                              }
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "firstCapturedEffect": null,
+                          "firstCapturedUpdate": null,
+                          "firstEffect": null,
+                          "firstUpdate": null,
+                          "lastCapturedEffect": null,
+                          "lastCapturedUpdate": null,
+                          "lastEffect": null,
+                          "lastUpdate": null,
+                        },
+                      },
+                      "pendingProps": Object {
+                        "Component": [Function],
+                        "context": null,
+                        "props": Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        },
+                        "wrappingComponentProps": null,
+                      },
+                      "ref": null,
+                      "return": FiberNode {
+                        "_debugHookTypes": null,
+                        "_debugID": 60,
+                        "_debugIsCurrentlyTiming": false,
+                        "_debugOwner": null,
+                        "_debugSource": null,
+                        "actualDuration": 0,
+                        "actualStartTime": -1,
+                        "alternate": FiberNode {
+                          "_debugHookTypes": null,
+                          "_debugID": 60,
+                          "_debugIsCurrentlyTiming": false,
+                          "_debugOwner": null,
+                          "_debugSource": null,
+                          "actualDuration": 0,
+                          "actualStartTime": -1,
+                          "alternate": [Circular],
+                          "child": null,
+                          "childExpirationTime": 0,
+                          "contextDependencies": null,
+                          "effectTag": 0,
+                          "elementType": null,
+                          "expirationTime": 1073741823,
+                          "firstEffect": null,
+                          "index": 0,
+                          "key": null,
+                          "lastEffect": null,
+                          "memoizedProps": null,
+                          "memoizedState": null,
+                          "mode": 0,
+                          "nextEffect": null,
+                          "pendingProps": null,
+                          "ref": null,
+                          "return": null,
+                          "selfBaseDuration": 0,
+                          "sibling": null,
+                          "stateNode": Object {
+                            "containerInfo": <div />,
+                            "context": Object {},
+                            "current": [Circular],
+                            "didError": false,
+                            "earliestPendingTime": 0,
+                            "earliestSuspendedTime": 0,
+                            "expirationTime": 0,
+                            "finishedWork": null,
+                            "firstBatch": null,
+                            "hydrate": false,
+                            "interactionThreadID": 15,
+                            "latestPendingTime": 0,
+                            "latestPingedTime": 0,
+                            "latestSuspendedTime": 0,
+                            "memoizedInteractions": Set {},
+                            "nextExpirationTimeToWorkOn": 0,
+                            "nextScheduledRoot": null,
+                            "pendingChildren": null,
+                            "pendingCommitExpirationTime": 0,
+                            "pendingContext": null,
+                            "pendingInteractionMap": Map {},
+                            "pingCache": null,
+                            "timeoutHandle": -1,
+                          },
+                          "tag": 3,
+                          "treeBaseDuration": 0,
+                          "type": null,
+                          "updateQueue": Object {
+                            "baseState": null,
+                            "firstCapturedEffect": null,
+                            "firstCapturedUpdate": null,
+                            "firstEffect": null,
+                            "firstUpdate": Object {
+                              "callback": null,
+                              "expirationTime": 1073741823,
+                              "next": null,
+                              "nextEffect": null,
+                              "payload": Object {
+                                "element": <WrapperComponent
+                                  Component={[Function]}
+                                  context={null}
+                                  props={
+                                    Object {
+                                      "children": <AuthenticatedRoute
+                                        authenticated={true}
+                                        component={[Function]}
+                                        path="/dashboard"
+                                      />,
+                                    }
+                                  }
+                                  wrappingComponentProps={null}
+                                />,
+                              },
+                              "tag": 0,
+                            },
+                            "lastCapturedEffect": null,
+                            "lastCapturedUpdate": null,
+                            "lastEffect": null,
+                            "lastUpdate": Object {
+                              "callback": null,
+                              "expirationTime": 1073741823,
+                              "next": null,
+                              "nextEffect": null,
+                              "payload": Object {
+                                "element": <WrapperComponent
+                                  Component={[Function]}
+                                  context={null}
+                                  props={
+                                    Object {
+                                      "children": <AuthenticatedRoute
+                                        authenticated={true}
+                                        component={[Function]}
+                                        path="/dashboard"
+                                      />,
+                                    }
+                                  }
+                                  wrappingComponentProps={null}
+                                />,
+                              },
+                              "tag": 0,
+                            },
+                          },
+                        },
+                        "child": [Circular],
+                        "childExpirationTime": 0,
+                        "contextDependencies": null,
+                        "effectTag": 32,
+                        "elementType": null,
+                        "expirationTime": 0,
+                        "firstEffect": [Circular],
+                        "index": 0,
+                        "key": null,
+                        "lastEffect": [Circular],
+                        "memoizedProps": null,
+                        "memoizedState": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={
+                              Object {
+                                "children": <AuthenticatedRoute
+                                  authenticated={true}
+                                  component={[Function]}
+                                  path="/dashboard"
+                                />,
+                              }
+                            }
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "mode": 0,
+                        "nextEffect": null,
+                        "pendingProps": null,
+                        "ref": null,
+                        "return": null,
+                        "selfBaseDuration": 0,
+                        "sibling": null,
+                        "stateNode": Object {
+                          "containerInfo": <div />,
+                          "context": Object {},
+                          "current": [Circular],
+                          "didError": false,
+                          "earliestPendingTime": 0,
+                          "earliestSuspendedTime": 0,
+                          "expirationTime": 0,
+                          "finishedWork": null,
+                          "firstBatch": null,
+                          "hydrate": false,
+                          "interactionThreadID": 15,
+                          "latestPendingTime": 0,
+                          "latestPingedTime": 0,
+                          "latestSuspendedTime": 0,
+                          "memoizedInteractions": Set {},
+                          "nextExpirationTimeToWorkOn": 0,
+                          "nextScheduledRoot": null,
+                          "pendingChildren": null,
+                          "pendingCommitExpirationTime": 0,
+                          "pendingContext": null,
+                          "pendingInteractionMap": Map {},
+                          "pingCache": null,
+                          "timeoutHandle": -1,
+                        },
+                        "tag": 3,
+                        "treeBaseDuration": 0,
+                        "type": null,
+                        "updateQueue": Object {
+                          "baseState": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={
+                                Object {
+                                  "children": <AuthenticatedRoute
+                                    authenticated={true}
+                                    component={[Function]}
+                                    path="/dashboard"
+                                  />,
+                                }
+                              }
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "firstCapturedEffect": null,
+                          "firstCapturedUpdate": null,
+                          "firstEffect": null,
+                          "firstUpdate": null,
+                          "lastCapturedEffect": null,
+                          "lastCapturedUpdate": null,
+                          "lastEffect": null,
+                          "lastUpdate": null,
+                        },
+                      },
+                      "selfBaseDuration": 0,
+                      "sibling": null,
+                      "stateNode": WrapperComponent {
+                        "_reactInternalFiber": [Circular],
+                        "_reactInternalInstance": Object {},
+                        "context": Object {},
+                        "props": Object {
+                          "Component": [Function],
+                          "context": null,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "refs": Object {},
+                        "rootFinderInstance": null,
+                        "state": Object {
+                          "context": null,
+                          "mount": true,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "updater": Object {
+                          "enqueueForceUpdate": [Function],
+                          "enqueueReplaceState": [Function],
+                          "enqueueSetState": [Function],
+                          "isMounted": [Function],
+                        },
+                      },
+                      "tag": 1,
+                      "treeBaseDuration": 0,
+                      "type": [Function],
+                      "updateQueue": null,
+                    },
+                    "_debugSource": null,
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": null,
+                    "child": [Circular],
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 1,
+                    "elementType": [Function],
+                    "expirationTime": 0,
+                    "firstEffect": null,
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": null,
+                    "memoizedProps": Object {
+                      "children": <AuthenticatedRoute
+                        authenticated={true}
+                        component={[Function]}
+                        path="/dashboard"
+                      />,
+                    },
+                    "memoizedState": null,
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": Object {
+                      "children": <AuthenticatedRoute
+                        authenticated={true}
+                        component={[Function]}
+                        path="/dashboard"
+                      />,
+                    },
+                    "ref": null,
+                    "return": FiberNode {
+                      "_debugHookTypes": null,
+                      "_debugID": 62,
+                      "_debugIsCurrentlyTiming": false,
+                      "_debugOwner": null,
+                      "_debugSource": null,
+                      "actualDuration": 0,
+                      "actualStartTime": -1,
+                      "alternate": null,
+                      "child": [Circular],
+                      "childExpirationTime": 0,
+                      "contextDependencies": null,
+                      "effectTag": 1,
+                      "elementType": [Function],
+                      "expirationTime": 0,
+                      "firstEffect": null,
+                      "index": 0,
+                      "key": null,
+                      "lastEffect": null,
+                      "memoizedProps": Object {
+                        "Component": [Function],
+                        "context": null,
+                        "props": Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        },
+                        "wrappingComponentProps": null,
+                      },
+                      "memoizedState": Object {
+                        "context": null,
+                        "mount": true,
+                        "props": Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        },
+                        "wrappingComponentProps": null,
+                      },
+                      "mode": 0,
+                      "nextEffect": FiberNode {
+                        "_debugHookTypes": null,
+                        "_debugID": 60,
+                        "_debugIsCurrentlyTiming": false,
+                        "_debugOwner": null,
+                        "_debugSource": null,
+                        "actualDuration": 0,
+                        "actualStartTime": -1,
+                        "alternate": FiberNode {
+                          "_debugHookTypes": null,
+                          "_debugID": 60,
+                          "_debugIsCurrentlyTiming": false,
+                          "_debugOwner": null,
+                          "_debugSource": null,
+                          "actualDuration": 0,
+                          "actualStartTime": -1,
+                          "alternate": [Circular],
+                          "child": null,
+                          "childExpirationTime": 0,
+                          "contextDependencies": null,
+                          "effectTag": 0,
+                          "elementType": null,
+                          "expirationTime": 1073741823,
+                          "firstEffect": null,
+                          "index": 0,
+                          "key": null,
+                          "lastEffect": null,
+                          "memoizedProps": null,
+                          "memoizedState": null,
+                          "mode": 0,
+                          "nextEffect": null,
+                          "pendingProps": null,
+                          "ref": null,
+                          "return": null,
+                          "selfBaseDuration": 0,
+                          "sibling": null,
+                          "stateNode": Object {
+                            "containerInfo": <div />,
+                            "context": Object {},
+                            "current": [Circular],
+                            "didError": false,
+                            "earliestPendingTime": 0,
+                            "earliestSuspendedTime": 0,
+                            "expirationTime": 0,
+                            "finishedWork": null,
+                            "firstBatch": null,
+                            "hydrate": false,
+                            "interactionThreadID": 15,
+                            "latestPendingTime": 0,
+                            "latestPingedTime": 0,
+                            "latestSuspendedTime": 0,
+                            "memoizedInteractions": Set {},
+                            "nextExpirationTimeToWorkOn": 0,
+                            "nextScheduledRoot": null,
+                            "pendingChildren": null,
+                            "pendingCommitExpirationTime": 0,
+                            "pendingContext": null,
+                            "pendingInteractionMap": Map {},
+                            "pingCache": null,
+                            "timeoutHandle": -1,
+                          },
+                          "tag": 3,
+                          "treeBaseDuration": 0,
+                          "type": null,
+                          "updateQueue": Object {
+                            "baseState": null,
+                            "firstCapturedEffect": null,
+                            "firstCapturedUpdate": null,
+                            "firstEffect": null,
+                            "firstUpdate": Object {
+                              "callback": null,
+                              "expirationTime": 1073741823,
+                              "next": null,
+                              "nextEffect": null,
+                              "payload": Object {
+                                "element": <WrapperComponent
+                                  Component={[Function]}
+                                  context={null}
+                                  props={
+                                    Object {
+                                      "children": <AuthenticatedRoute
+                                        authenticated={true}
+                                        component={[Function]}
+                                        path="/dashboard"
+                                      />,
+                                    }
+                                  }
+                                  wrappingComponentProps={null}
+                                />,
+                              },
+                              "tag": 0,
+                            },
+                            "lastCapturedEffect": null,
+                            "lastCapturedUpdate": null,
+                            "lastEffect": null,
+                            "lastUpdate": Object {
+                              "callback": null,
+                              "expirationTime": 1073741823,
+                              "next": null,
+                              "nextEffect": null,
+                              "payload": Object {
+                                "element": <WrapperComponent
+                                  Component={[Function]}
+                                  context={null}
+                                  props={
+                                    Object {
+                                      "children": <AuthenticatedRoute
+                                        authenticated={true}
+                                        component={[Function]}
+                                        path="/dashboard"
+                                      />,
+                                    }
+                                  }
+                                  wrappingComponentProps={null}
+                                />,
+                              },
+                              "tag": 0,
+                            },
+                          },
+                        },
+                        "child": [Circular],
+                        "childExpirationTime": 0,
+                        "contextDependencies": null,
+                        "effectTag": 32,
+                        "elementType": null,
+                        "expirationTime": 0,
+                        "firstEffect": [Circular],
+                        "index": 0,
+                        "key": null,
+                        "lastEffect": [Circular],
+                        "memoizedProps": null,
+                        "memoizedState": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={
+                              Object {
+                                "children": <AuthenticatedRoute
+                                  authenticated={true}
+                                  component={[Function]}
+                                  path="/dashboard"
+                                />,
+                              }
+                            }
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "mode": 0,
+                        "nextEffect": null,
+                        "pendingProps": null,
+                        "ref": null,
+                        "return": null,
+                        "selfBaseDuration": 0,
+                        "sibling": null,
+                        "stateNode": Object {
+                          "containerInfo": <div />,
+                          "context": Object {},
+                          "current": [Circular],
+                          "didError": false,
+                          "earliestPendingTime": 0,
+                          "earliestSuspendedTime": 0,
+                          "expirationTime": 0,
+                          "finishedWork": null,
+                          "firstBatch": null,
+                          "hydrate": false,
+                          "interactionThreadID": 15,
+                          "latestPendingTime": 0,
+                          "latestPingedTime": 0,
+                          "latestSuspendedTime": 0,
+                          "memoizedInteractions": Set {},
+                          "nextExpirationTimeToWorkOn": 0,
+                          "nextScheduledRoot": null,
+                          "pendingChildren": null,
+                          "pendingCommitExpirationTime": 0,
+                          "pendingContext": null,
+                          "pendingInteractionMap": Map {},
+                          "pingCache": null,
+                          "timeoutHandle": -1,
+                        },
+                        "tag": 3,
+                        "treeBaseDuration": 0,
+                        "type": null,
+                        "updateQueue": Object {
+                          "baseState": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={
+                                Object {
+                                  "children": <AuthenticatedRoute
+                                    authenticated={true}
+                                    component={[Function]}
+                                    path="/dashboard"
+                                  />,
+                                }
+                              }
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "firstCapturedEffect": null,
+                          "firstCapturedUpdate": null,
+                          "firstEffect": null,
+                          "firstUpdate": null,
+                          "lastCapturedEffect": null,
+                          "lastCapturedUpdate": null,
+                          "lastEffect": null,
+                          "lastUpdate": null,
+                        },
+                      },
+                      "pendingProps": Object {
+                        "Component": [Function],
+                        "context": null,
+                        "props": Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        },
+                        "wrappingComponentProps": null,
+                      },
+                      "ref": null,
+                      "return": FiberNode {
+                        "_debugHookTypes": null,
+                        "_debugID": 60,
+                        "_debugIsCurrentlyTiming": false,
+                        "_debugOwner": null,
+                        "_debugSource": null,
+                        "actualDuration": 0,
+                        "actualStartTime": -1,
+                        "alternate": FiberNode {
+                          "_debugHookTypes": null,
+                          "_debugID": 60,
+                          "_debugIsCurrentlyTiming": false,
+                          "_debugOwner": null,
+                          "_debugSource": null,
+                          "actualDuration": 0,
+                          "actualStartTime": -1,
+                          "alternate": [Circular],
+                          "child": null,
+                          "childExpirationTime": 0,
+                          "contextDependencies": null,
+                          "effectTag": 0,
+                          "elementType": null,
+                          "expirationTime": 1073741823,
+                          "firstEffect": null,
+                          "index": 0,
+                          "key": null,
+                          "lastEffect": null,
+                          "memoizedProps": null,
+                          "memoizedState": null,
+                          "mode": 0,
+                          "nextEffect": null,
+                          "pendingProps": null,
+                          "ref": null,
+                          "return": null,
+                          "selfBaseDuration": 0,
+                          "sibling": null,
+                          "stateNode": Object {
+                            "containerInfo": <div />,
+                            "context": Object {},
+                            "current": [Circular],
+                            "didError": false,
+                            "earliestPendingTime": 0,
+                            "earliestSuspendedTime": 0,
+                            "expirationTime": 0,
+                            "finishedWork": null,
+                            "firstBatch": null,
+                            "hydrate": false,
+                            "interactionThreadID": 15,
+                            "latestPendingTime": 0,
+                            "latestPingedTime": 0,
+                            "latestSuspendedTime": 0,
+                            "memoizedInteractions": Set {},
+                            "nextExpirationTimeToWorkOn": 0,
+                            "nextScheduledRoot": null,
+                            "pendingChildren": null,
+                            "pendingCommitExpirationTime": 0,
+                            "pendingContext": null,
+                            "pendingInteractionMap": Map {},
+                            "pingCache": null,
+                            "timeoutHandle": -1,
+                          },
+                          "tag": 3,
+                          "treeBaseDuration": 0,
+                          "type": null,
+                          "updateQueue": Object {
+                            "baseState": null,
+                            "firstCapturedEffect": null,
+                            "firstCapturedUpdate": null,
+                            "firstEffect": null,
+                            "firstUpdate": Object {
+                              "callback": null,
+                              "expirationTime": 1073741823,
+                              "next": null,
+                              "nextEffect": null,
+                              "payload": Object {
+                                "element": <WrapperComponent
+                                  Component={[Function]}
+                                  context={null}
+                                  props={
+                                    Object {
+                                      "children": <AuthenticatedRoute
+                                        authenticated={true}
+                                        component={[Function]}
+                                        path="/dashboard"
+                                      />,
+                                    }
+                                  }
+                                  wrappingComponentProps={null}
+                                />,
+                              },
+                              "tag": 0,
+                            },
+                            "lastCapturedEffect": null,
+                            "lastCapturedUpdate": null,
+                            "lastEffect": null,
+                            "lastUpdate": Object {
+                              "callback": null,
+                              "expirationTime": 1073741823,
+                              "next": null,
+                              "nextEffect": null,
+                              "payload": Object {
+                                "element": <WrapperComponent
+                                  Component={[Function]}
+                                  context={null}
+                                  props={
+                                    Object {
+                                      "children": <AuthenticatedRoute
+                                        authenticated={true}
+                                        component={[Function]}
+                                        path="/dashboard"
+                                      />,
+                                    }
+                                  }
+                                  wrappingComponentProps={null}
+                                />,
+                              },
+                              "tag": 0,
+                            },
+                          },
+                        },
+                        "child": [Circular],
+                        "childExpirationTime": 0,
+                        "contextDependencies": null,
+                        "effectTag": 32,
+                        "elementType": null,
+                        "expirationTime": 0,
+                        "firstEffect": [Circular],
+                        "index": 0,
+                        "key": null,
+                        "lastEffect": [Circular],
+                        "memoizedProps": null,
+                        "memoizedState": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={
+                              Object {
+                                "children": <AuthenticatedRoute
+                                  authenticated={true}
+                                  component={[Function]}
+                                  path="/dashboard"
+                                />,
+                              }
+                            }
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "mode": 0,
+                        "nextEffect": null,
+                        "pendingProps": null,
+                        "ref": null,
+                        "return": null,
+                        "selfBaseDuration": 0,
+                        "sibling": null,
+                        "stateNode": Object {
+                          "containerInfo": <div />,
+                          "context": Object {},
+                          "current": [Circular],
+                          "didError": false,
+                          "earliestPendingTime": 0,
+                          "earliestSuspendedTime": 0,
+                          "expirationTime": 0,
+                          "finishedWork": null,
+                          "firstBatch": null,
+                          "hydrate": false,
+                          "interactionThreadID": 15,
+                          "latestPendingTime": 0,
+                          "latestPingedTime": 0,
+                          "latestSuspendedTime": 0,
+                          "memoizedInteractions": Set {},
+                          "nextExpirationTimeToWorkOn": 0,
+                          "nextScheduledRoot": null,
+                          "pendingChildren": null,
+                          "pendingCommitExpirationTime": 0,
+                          "pendingContext": null,
+                          "pendingInteractionMap": Map {},
+                          "pingCache": null,
+                          "timeoutHandle": -1,
+                        },
+                        "tag": 3,
+                        "treeBaseDuration": 0,
+                        "type": null,
+                        "updateQueue": Object {
+                          "baseState": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={
+                                Object {
+                                  "children": <AuthenticatedRoute
+                                    authenticated={true}
+                                    component={[Function]}
+                                    path="/dashboard"
+                                  />,
+                                }
+                              }
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "firstCapturedEffect": null,
+                          "firstCapturedUpdate": null,
+                          "firstEffect": null,
+                          "firstUpdate": null,
+                          "lastCapturedEffect": null,
+                          "lastCapturedUpdate": null,
+                          "lastEffect": null,
+                          "lastUpdate": null,
+                        },
+                      },
+                      "selfBaseDuration": 0,
+                      "sibling": null,
+                      "stateNode": WrapperComponent {
+                        "_reactInternalFiber": [Circular],
+                        "_reactInternalInstance": Object {},
+                        "context": Object {},
+                        "props": Object {
+                          "Component": [Function],
+                          "context": null,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "refs": Object {},
+                        "rootFinderInstance": null,
+                        "state": Object {
+                          "context": null,
+                          "mount": true,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "updater": Object {
+                          "enqueueForceUpdate": [Function],
+                          "enqueueReplaceState": [Function],
+                          "enqueueSetState": [Function],
+                          "isMounted": [Function],
+                        },
+                      },
+                      "tag": 1,
+                      "treeBaseDuration": 0,
+                      "type": [Function],
+                      "updateQueue": null,
+                    },
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": BrowserRouter {
+                      "_reactInternalFiber": [Circular],
+                      "_reactInternalInstance": Object {},
+                      "context": Object {},
+                      "history": Object {
+                        "action": "POP",
+                        "block": [Function],
+                        "createHref": [Function],
+                        "go": [Function],
+                        "goBack": [Function],
+                        "goForward": [Function],
+                        "length": 1,
+                        "listen": [Function],
+                        "location": Object {
+                          "hash": "",
+                          "pathname": "/",
+                          "search": "",
+                          "state": undefined,
+                        },
+                        "push": [Function],
+                        "replace": [Function],
+                      },
+                      "props": Object {
+                        "children": <AuthenticatedRoute
+                          authenticated={true}
+                          component={[Function]}
+                          path="/dashboard"
+                        />,
+                      },
+                      "refs": Object {},
+                      "state": null,
+                      "updater": Object {
+                        "enqueueForceUpdate": [Function],
+                        "enqueueReplaceState": [Function],
+                        "enqueueSetState": [Function],
+                        "isMounted": [Function],
+                      },
+                    },
+                    "tag": 1,
+                    "treeBaseDuration": 0,
+                    "type": [Function],
+                    "updateQueue": null,
+                  },
+                  "_debugSource": null,
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": null,
+                  "child": [Circular],
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 1,
+                  "elementType": [Function],
+                  "expirationTime": 0,
+                  "firstEffect": null,
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": null,
+                  "memoizedProps": Object {
+                    "children": <AuthenticatedRoute
+                      authenticated={true}
+                      component={[Function]}
+                      path="/dashboard"
+                    />,
+                    "history": Object {
+                      "action": "POP",
+                      "block": [Function],
+                      "createHref": [Function],
+                      "go": [Function],
+                      "goBack": [Function],
+                      "goForward": [Function],
+                      "length": 1,
+                      "listen": [Function],
+                      "location": Object {
+                        "hash": "",
+                        "pathname": "/",
+                        "search": "",
+                        "state": undefined,
+                      },
+                      "push": [Function],
+                      "replace": [Function],
+                    },
+                  },
+                  "memoizedState": Object {
+                    "match": Object {
+                      "isExact": true,
+                      "params": Object {},
+                      "path": "/",
+                      "url": "/",
+                    },
+                  },
+                  "mode": 0,
+                  "nextEffect": null,
+                  "pendingProps": Object {
+                    "children": <AuthenticatedRoute
+                      authenticated={true}
+                      component={[Function]}
+                      path="/dashboard"
+                    />,
+                    "history": Object {
+                      "action": "POP",
+                      "block": [Function],
+                      "createHref": [Function],
+                      "go": [Function],
+                      "goBack": [Function],
+                      "goForward": [Function],
+                      "length": 1,
+                      "listen": [Function],
+                      "location": Object {
+                        "hash": "",
+                        "pathname": "/",
+                        "search": "",
+                        "state": undefined,
+                      },
+                      "push": [Function],
+                      "replace": [Function],
+                    },
+                  },
+                  "ref": null,
+                  "return": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 63,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": FiberNode {
+                      "_debugHookTypes": null,
+                      "_debugID": 62,
+                      "_debugIsCurrentlyTiming": false,
+                      "_debugOwner": null,
+                      "_debugSource": null,
+                      "actualDuration": 0,
+                      "actualStartTime": -1,
+                      "alternate": null,
+                      "child": [Circular],
+                      "childExpirationTime": 0,
+                      "contextDependencies": null,
+                      "effectTag": 1,
+                      "elementType": [Function],
+                      "expirationTime": 0,
+                      "firstEffect": null,
+                      "index": 0,
+                      "key": null,
+                      "lastEffect": null,
+                      "memoizedProps": Object {
+                        "Component": [Function],
+                        "context": null,
+                        "props": Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        },
+                        "wrappingComponentProps": null,
+                      },
+                      "memoizedState": Object {
+                        "context": null,
+                        "mount": true,
+                        "props": Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        },
+                        "wrappingComponentProps": null,
+                      },
+                      "mode": 0,
+                      "nextEffect": FiberNode {
+                        "_debugHookTypes": null,
+                        "_debugID": 60,
+                        "_debugIsCurrentlyTiming": false,
+                        "_debugOwner": null,
+                        "_debugSource": null,
+                        "actualDuration": 0,
+                        "actualStartTime": -1,
+                        "alternate": FiberNode {
+                          "_debugHookTypes": null,
+                          "_debugID": 60,
+                          "_debugIsCurrentlyTiming": false,
+                          "_debugOwner": null,
+                          "_debugSource": null,
+                          "actualDuration": 0,
+                          "actualStartTime": -1,
+                          "alternate": [Circular],
+                          "child": null,
+                          "childExpirationTime": 0,
+                          "contextDependencies": null,
+                          "effectTag": 0,
+                          "elementType": null,
+                          "expirationTime": 1073741823,
+                          "firstEffect": null,
+                          "index": 0,
+                          "key": null,
+                          "lastEffect": null,
+                          "memoizedProps": null,
+                          "memoizedState": null,
+                          "mode": 0,
+                          "nextEffect": null,
+                          "pendingProps": null,
+                          "ref": null,
+                          "return": null,
+                          "selfBaseDuration": 0,
+                          "sibling": null,
+                          "stateNode": Object {
+                            "containerInfo": <div />,
+                            "context": Object {},
+                            "current": [Circular],
+                            "didError": false,
+                            "earliestPendingTime": 0,
+                            "earliestSuspendedTime": 0,
+                            "expirationTime": 0,
+                            "finishedWork": null,
+                            "firstBatch": null,
+                            "hydrate": false,
+                            "interactionThreadID": 15,
+                            "latestPendingTime": 0,
+                            "latestPingedTime": 0,
+                            "latestSuspendedTime": 0,
+                            "memoizedInteractions": Set {},
+                            "nextExpirationTimeToWorkOn": 0,
+                            "nextScheduledRoot": null,
+                            "pendingChildren": null,
+                            "pendingCommitExpirationTime": 0,
+                            "pendingContext": null,
+                            "pendingInteractionMap": Map {},
+                            "pingCache": null,
+                            "timeoutHandle": -1,
+                          },
+                          "tag": 3,
+                          "treeBaseDuration": 0,
+                          "type": null,
+                          "updateQueue": Object {
+                            "baseState": null,
+                            "firstCapturedEffect": null,
+                            "firstCapturedUpdate": null,
+                            "firstEffect": null,
+                            "firstUpdate": Object {
+                              "callback": null,
+                              "expirationTime": 1073741823,
+                              "next": null,
+                              "nextEffect": null,
+                              "payload": Object {
+                                "element": <WrapperComponent
+                                  Component={[Function]}
+                                  context={null}
+                                  props={
+                                    Object {
+                                      "children": <AuthenticatedRoute
+                                        authenticated={true}
+                                        component={[Function]}
+                                        path="/dashboard"
+                                      />,
+                                    }
+                                  }
+                                  wrappingComponentProps={null}
+                                />,
+                              },
+                              "tag": 0,
+                            },
+                            "lastCapturedEffect": null,
+                            "lastCapturedUpdate": null,
+                            "lastEffect": null,
+                            "lastUpdate": Object {
+                              "callback": null,
+                              "expirationTime": 1073741823,
+                              "next": null,
+                              "nextEffect": null,
+                              "payload": Object {
+                                "element": <WrapperComponent
+                                  Component={[Function]}
+                                  context={null}
+                                  props={
+                                    Object {
+                                      "children": <AuthenticatedRoute
+                                        authenticated={true}
+                                        component={[Function]}
+                                        path="/dashboard"
+                                      />,
+                                    }
+                                  }
+                                  wrappingComponentProps={null}
+                                />,
+                              },
+                              "tag": 0,
+                            },
+                          },
+                        },
+                        "child": [Circular],
+                        "childExpirationTime": 0,
+                        "contextDependencies": null,
+                        "effectTag": 32,
+                        "elementType": null,
+                        "expirationTime": 0,
+                        "firstEffect": [Circular],
+                        "index": 0,
+                        "key": null,
+                        "lastEffect": [Circular],
+                        "memoizedProps": null,
+                        "memoizedState": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={
+                              Object {
+                                "children": <AuthenticatedRoute
+                                  authenticated={true}
+                                  component={[Function]}
+                                  path="/dashboard"
+                                />,
+                              }
+                            }
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "mode": 0,
+                        "nextEffect": null,
+                        "pendingProps": null,
+                        "ref": null,
+                        "return": null,
+                        "selfBaseDuration": 0,
+                        "sibling": null,
+                        "stateNode": Object {
+                          "containerInfo": <div />,
+                          "context": Object {},
+                          "current": [Circular],
+                          "didError": false,
+                          "earliestPendingTime": 0,
+                          "earliestSuspendedTime": 0,
+                          "expirationTime": 0,
+                          "finishedWork": null,
+                          "firstBatch": null,
+                          "hydrate": false,
+                          "interactionThreadID": 15,
+                          "latestPendingTime": 0,
+                          "latestPingedTime": 0,
+                          "latestSuspendedTime": 0,
+                          "memoizedInteractions": Set {},
+                          "nextExpirationTimeToWorkOn": 0,
+                          "nextScheduledRoot": null,
+                          "pendingChildren": null,
+                          "pendingCommitExpirationTime": 0,
+                          "pendingContext": null,
+                          "pendingInteractionMap": Map {},
+                          "pingCache": null,
+                          "timeoutHandle": -1,
+                        },
+                        "tag": 3,
+                        "treeBaseDuration": 0,
+                        "type": null,
+                        "updateQueue": Object {
+                          "baseState": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={
+                                Object {
+                                  "children": <AuthenticatedRoute
+                                    authenticated={true}
+                                    component={[Function]}
+                                    path="/dashboard"
+                                  />,
+                                }
+                              }
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "firstCapturedEffect": null,
+                          "firstCapturedUpdate": null,
+                          "firstEffect": null,
+                          "firstUpdate": null,
+                          "lastCapturedEffect": null,
+                          "lastCapturedUpdate": null,
+                          "lastEffect": null,
+                          "lastUpdate": null,
+                        },
+                      },
+                      "pendingProps": Object {
+                        "Component": [Function],
+                        "context": null,
+                        "props": Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        },
+                        "wrappingComponentProps": null,
+                      },
+                      "ref": null,
+                      "return": FiberNode {
+                        "_debugHookTypes": null,
+                        "_debugID": 60,
+                        "_debugIsCurrentlyTiming": false,
+                        "_debugOwner": null,
+                        "_debugSource": null,
+                        "actualDuration": 0,
+                        "actualStartTime": -1,
+                        "alternate": FiberNode {
+                          "_debugHookTypes": null,
+                          "_debugID": 60,
+                          "_debugIsCurrentlyTiming": false,
+                          "_debugOwner": null,
+                          "_debugSource": null,
+                          "actualDuration": 0,
+                          "actualStartTime": -1,
+                          "alternate": [Circular],
+                          "child": null,
+                          "childExpirationTime": 0,
+                          "contextDependencies": null,
+                          "effectTag": 0,
+                          "elementType": null,
+                          "expirationTime": 1073741823,
+                          "firstEffect": null,
+                          "index": 0,
+                          "key": null,
+                          "lastEffect": null,
+                          "memoizedProps": null,
+                          "memoizedState": null,
+                          "mode": 0,
+                          "nextEffect": null,
+                          "pendingProps": null,
+                          "ref": null,
+                          "return": null,
+                          "selfBaseDuration": 0,
+                          "sibling": null,
+                          "stateNode": Object {
+                            "containerInfo": <div />,
+                            "context": Object {},
+                            "current": [Circular],
+                            "didError": false,
+                            "earliestPendingTime": 0,
+                            "earliestSuspendedTime": 0,
+                            "expirationTime": 0,
+                            "finishedWork": null,
+                            "firstBatch": null,
+                            "hydrate": false,
+                            "interactionThreadID": 15,
+                            "latestPendingTime": 0,
+                            "latestPingedTime": 0,
+                            "latestSuspendedTime": 0,
+                            "memoizedInteractions": Set {},
+                            "nextExpirationTimeToWorkOn": 0,
+                            "nextScheduledRoot": null,
+                            "pendingChildren": null,
+                            "pendingCommitExpirationTime": 0,
+                            "pendingContext": null,
+                            "pendingInteractionMap": Map {},
+                            "pingCache": null,
+                            "timeoutHandle": -1,
+                          },
+                          "tag": 3,
+                          "treeBaseDuration": 0,
+                          "type": null,
+                          "updateQueue": Object {
+                            "baseState": null,
+                            "firstCapturedEffect": null,
+                            "firstCapturedUpdate": null,
+                            "firstEffect": null,
+                            "firstUpdate": Object {
+                              "callback": null,
+                              "expirationTime": 1073741823,
+                              "next": null,
+                              "nextEffect": null,
+                              "payload": Object {
+                                "element": <WrapperComponent
+                                  Component={[Function]}
+                                  context={null}
+                                  props={
+                                    Object {
+                                      "children": <AuthenticatedRoute
+                                        authenticated={true}
+                                        component={[Function]}
+                                        path="/dashboard"
+                                      />,
+                                    }
+                                  }
+                                  wrappingComponentProps={null}
+                                />,
+                              },
+                              "tag": 0,
+                            },
+                            "lastCapturedEffect": null,
+                            "lastCapturedUpdate": null,
+                            "lastEffect": null,
+                            "lastUpdate": Object {
+                              "callback": null,
+                              "expirationTime": 1073741823,
+                              "next": null,
+                              "nextEffect": null,
+                              "payload": Object {
+                                "element": <WrapperComponent
+                                  Component={[Function]}
+                                  context={null}
+                                  props={
+                                    Object {
+                                      "children": <AuthenticatedRoute
+                                        authenticated={true}
+                                        component={[Function]}
+                                        path="/dashboard"
+                                      />,
+                                    }
+                                  }
+                                  wrappingComponentProps={null}
+                                />,
+                              },
+                              "tag": 0,
+                            },
+                          },
+                        },
+                        "child": [Circular],
+                        "childExpirationTime": 0,
+                        "contextDependencies": null,
+                        "effectTag": 32,
+                        "elementType": null,
+                        "expirationTime": 0,
+                        "firstEffect": [Circular],
+                        "index": 0,
+                        "key": null,
+                        "lastEffect": [Circular],
+                        "memoizedProps": null,
+                        "memoizedState": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={
+                              Object {
+                                "children": <AuthenticatedRoute
+                                  authenticated={true}
+                                  component={[Function]}
+                                  path="/dashboard"
+                                />,
+                              }
+                            }
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "mode": 0,
+                        "nextEffect": null,
+                        "pendingProps": null,
+                        "ref": null,
+                        "return": null,
+                        "selfBaseDuration": 0,
+                        "sibling": null,
+                        "stateNode": Object {
+                          "containerInfo": <div />,
+                          "context": Object {},
+                          "current": [Circular],
+                          "didError": false,
+                          "earliestPendingTime": 0,
+                          "earliestSuspendedTime": 0,
+                          "expirationTime": 0,
+                          "finishedWork": null,
+                          "firstBatch": null,
+                          "hydrate": false,
+                          "interactionThreadID": 15,
+                          "latestPendingTime": 0,
+                          "latestPingedTime": 0,
+                          "latestSuspendedTime": 0,
+                          "memoizedInteractions": Set {},
+                          "nextExpirationTimeToWorkOn": 0,
+                          "nextScheduledRoot": null,
+                          "pendingChildren": null,
+                          "pendingCommitExpirationTime": 0,
+                          "pendingContext": null,
+                          "pendingInteractionMap": Map {},
+                          "pingCache": null,
+                          "timeoutHandle": -1,
+                        },
+                        "tag": 3,
+                        "treeBaseDuration": 0,
+                        "type": null,
+                        "updateQueue": Object {
+                          "baseState": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={
+                                Object {
+                                  "children": <AuthenticatedRoute
+                                    authenticated={true}
+                                    component={[Function]}
+                                    path="/dashboard"
+                                  />,
+                                }
+                              }
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "firstCapturedEffect": null,
+                          "firstCapturedUpdate": null,
+                          "firstEffect": null,
+                          "firstUpdate": null,
+                          "lastCapturedEffect": null,
+                          "lastCapturedUpdate": null,
+                          "lastEffect": null,
+                          "lastUpdate": null,
+                        },
+                      },
+                      "selfBaseDuration": 0,
+                      "sibling": null,
+                      "stateNode": WrapperComponent {
+                        "_reactInternalFiber": [Circular],
+                        "_reactInternalInstance": Object {},
+                        "context": Object {},
+                        "props": Object {
+                          "Component": [Function],
+                          "context": null,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "refs": Object {},
+                        "rootFinderInstance": null,
+                        "state": Object {
+                          "context": null,
+                          "mount": true,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "updater": Object {
+                          "enqueueForceUpdate": [Function],
+                          "enqueueReplaceState": [Function],
+                          "enqueueSetState": [Function],
+                          "isMounted": [Function],
+                        },
+                      },
+                      "tag": 1,
+                      "treeBaseDuration": 0,
+                      "type": [Function],
+                      "updateQueue": null,
+                    },
+                    "_debugSource": null,
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": null,
+                    "child": [Circular],
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 1,
+                    "elementType": [Function],
+                    "expirationTime": 0,
+                    "firstEffect": null,
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": null,
+                    "memoizedProps": Object {
+                      "children": <AuthenticatedRoute
+                        authenticated={true}
+                        component={[Function]}
+                        path="/dashboard"
+                      />,
+                    },
+                    "memoizedState": null,
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": Object {
+                      "children": <AuthenticatedRoute
+                        authenticated={true}
+                        component={[Function]}
+                        path="/dashboard"
+                      />,
+                    },
+                    "ref": null,
+                    "return": FiberNode {
+                      "_debugHookTypes": null,
+                      "_debugID": 62,
+                      "_debugIsCurrentlyTiming": false,
+                      "_debugOwner": null,
+                      "_debugSource": null,
+                      "actualDuration": 0,
+                      "actualStartTime": -1,
+                      "alternate": null,
+                      "child": [Circular],
+                      "childExpirationTime": 0,
+                      "contextDependencies": null,
+                      "effectTag": 1,
+                      "elementType": [Function],
+                      "expirationTime": 0,
+                      "firstEffect": null,
+                      "index": 0,
+                      "key": null,
+                      "lastEffect": null,
+                      "memoizedProps": Object {
+                        "Component": [Function],
+                        "context": null,
+                        "props": Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        },
+                        "wrappingComponentProps": null,
+                      },
+                      "memoizedState": Object {
+                        "context": null,
+                        "mount": true,
+                        "props": Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        },
+                        "wrappingComponentProps": null,
+                      },
+                      "mode": 0,
+                      "nextEffect": FiberNode {
+                        "_debugHookTypes": null,
+                        "_debugID": 60,
+                        "_debugIsCurrentlyTiming": false,
+                        "_debugOwner": null,
+                        "_debugSource": null,
+                        "actualDuration": 0,
+                        "actualStartTime": -1,
+                        "alternate": FiberNode {
+                          "_debugHookTypes": null,
+                          "_debugID": 60,
+                          "_debugIsCurrentlyTiming": false,
+                          "_debugOwner": null,
+                          "_debugSource": null,
+                          "actualDuration": 0,
+                          "actualStartTime": -1,
+                          "alternate": [Circular],
+                          "child": null,
+                          "childExpirationTime": 0,
+                          "contextDependencies": null,
+                          "effectTag": 0,
+                          "elementType": null,
+                          "expirationTime": 1073741823,
+                          "firstEffect": null,
+                          "index": 0,
+                          "key": null,
+                          "lastEffect": null,
+                          "memoizedProps": null,
+                          "memoizedState": null,
+                          "mode": 0,
+                          "nextEffect": null,
+                          "pendingProps": null,
+                          "ref": null,
+                          "return": null,
+                          "selfBaseDuration": 0,
+                          "sibling": null,
+                          "stateNode": Object {
+                            "containerInfo": <div />,
+                            "context": Object {},
+                            "current": [Circular],
+                            "didError": false,
+                            "earliestPendingTime": 0,
+                            "earliestSuspendedTime": 0,
+                            "expirationTime": 0,
+                            "finishedWork": null,
+                            "firstBatch": null,
+                            "hydrate": false,
+                            "interactionThreadID": 15,
+                            "latestPendingTime": 0,
+                            "latestPingedTime": 0,
+                            "latestSuspendedTime": 0,
+                            "memoizedInteractions": Set {},
+                            "nextExpirationTimeToWorkOn": 0,
+                            "nextScheduledRoot": null,
+                            "pendingChildren": null,
+                            "pendingCommitExpirationTime": 0,
+                            "pendingContext": null,
+                            "pendingInteractionMap": Map {},
+                            "pingCache": null,
+                            "timeoutHandle": -1,
+                          },
+                          "tag": 3,
+                          "treeBaseDuration": 0,
+                          "type": null,
+                          "updateQueue": Object {
+                            "baseState": null,
+                            "firstCapturedEffect": null,
+                            "firstCapturedUpdate": null,
+                            "firstEffect": null,
+                            "firstUpdate": Object {
+                              "callback": null,
+                              "expirationTime": 1073741823,
+                              "next": null,
+                              "nextEffect": null,
+                              "payload": Object {
+                                "element": <WrapperComponent
+                                  Component={[Function]}
+                                  context={null}
+                                  props={
+                                    Object {
+                                      "children": <AuthenticatedRoute
+                                        authenticated={true}
+                                        component={[Function]}
+                                        path="/dashboard"
+                                      />,
+                                    }
+                                  }
+                                  wrappingComponentProps={null}
+                                />,
+                              },
+                              "tag": 0,
+                            },
+                            "lastCapturedEffect": null,
+                            "lastCapturedUpdate": null,
+                            "lastEffect": null,
+                            "lastUpdate": Object {
+                              "callback": null,
+                              "expirationTime": 1073741823,
+                              "next": null,
+                              "nextEffect": null,
+                              "payload": Object {
+                                "element": <WrapperComponent
+                                  Component={[Function]}
+                                  context={null}
+                                  props={
+                                    Object {
+                                      "children": <AuthenticatedRoute
+                                        authenticated={true}
+                                        component={[Function]}
+                                        path="/dashboard"
+                                      />,
+                                    }
+                                  }
+                                  wrappingComponentProps={null}
+                                />,
+                              },
+                              "tag": 0,
+                            },
+                          },
+                        },
+                        "child": [Circular],
+                        "childExpirationTime": 0,
+                        "contextDependencies": null,
+                        "effectTag": 32,
+                        "elementType": null,
+                        "expirationTime": 0,
+                        "firstEffect": [Circular],
+                        "index": 0,
+                        "key": null,
+                        "lastEffect": [Circular],
+                        "memoizedProps": null,
+                        "memoizedState": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={
+                              Object {
+                                "children": <AuthenticatedRoute
+                                  authenticated={true}
+                                  component={[Function]}
+                                  path="/dashboard"
+                                />,
+                              }
+                            }
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "mode": 0,
+                        "nextEffect": null,
+                        "pendingProps": null,
+                        "ref": null,
+                        "return": null,
+                        "selfBaseDuration": 0,
+                        "sibling": null,
+                        "stateNode": Object {
+                          "containerInfo": <div />,
+                          "context": Object {},
+                          "current": [Circular],
+                          "didError": false,
+                          "earliestPendingTime": 0,
+                          "earliestSuspendedTime": 0,
+                          "expirationTime": 0,
+                          "finishedWork": null,
+                          "firstBatch": null,
+                          "hydrate": false,
+                          "interactionThreadID": 15,
+                          "latestPendingTime": 0,
+                          "latestPingedTime": 0,
+                          "latestSuspendedTime": 0,
+                          "memoizedInteractions": Set {},
+                          "nextExpirationTimeToWorkOn": 0,
+                          "nextScheduledRoot": null,
+                          "pendingChildren": null,
+                          "pendingCommitExpirationTime": 0,
+                          "pendingContext": null,
+                          "pendingInteractionMap": Map {},
+                          "pingCache": null,
+                          "timeoutHandle": -1,
+                        },
+                        "tag": 3,
+                        "treeBaseDuration": 0,
+                        "type": null,
+                        "updateQueue": Object {
+                          "baseState": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={
+                                Object {
+                                  "children": <AuthenticatedRoute
+                                    authenticated={true}
+                                    component={[Function]}
+                                    path="/dashboard"
+                                  />,
+                                }
+                              }
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "firstCapturedEffect": null,
+                          "firstCapturedUpdate": null,
+                          "firstEffect": null,
+                          "firstUpdate": null,
+                          "lastCapturedEffect": null,
+                          "lastCapturedUpdate": null,
+                          "lastEffect": null,
+                          "lastUpdate": null,
+                        },
+                      },
+                      "pendingProps": Object {
+                        "Component": [Function],
+                        "context": null,
+                        "props": Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        },
+                        "wrappingComponentProps": null,
+                      },
+                      "ref": null,
+                      "return": FiberNode {
+                        "_debugHookTypes": null,
+                        "_debugID": 60,
+                        "_debugIsCurrentlyTiming": false,
+                        "_debugOwner": null,
+                        "_debugSource": null,
+                        "actualDuration": 0,
+                        "actualStartTime": -1,
+                        "alternate": FiberNode {
+                          "_debugHookTypes": null,
+                          "_debugID": 60,
+                          "_debugIsCurrentlyTiming": false,
+                          "_debugOwner": null,
+                          "_debugSource": null,
+                          "actualDuration": 0,
+                          "actualStartTime": -1,
+                          "alternate": [Circular],
+                          "child": null,
+                          "childExpirationTime": 0,
+                          "contextDependencies": null,
+                          "effectTag": 0,
+                          "elementType": null,
+                          "expirationTime": 1073741823,
+                          "firstEffect": null,
+                          "index": 0,
+                          "key": null,
+                          "lastEffect": null,
+                          "memoizedProps": null,
+                          "memoizedState": null,
+                          "mode": 0,
+                          "nextEffect": null,
+                          "pendingProps": null,
+                          "ref": null,
+                          "return": null,
+                          "selfBaseDuration": 0,
+                          "sibling": null,
+                          "stateNode": Object {
+                            "containerInfo": <div />,
+                            "context": Object {},
+                            "current": [Circular],
+                            "didError": false,
+                            "earliestPendingTime": 0,
+                            "earliestSuspendedTime": 0,
+                            "expirationTime": 0,
+                            "finishedWork": null,
+                            "firstBatch": null,
+                            "hydrate": false,
+                            "interactionThreadID": 15,
+                            "latestPendingTime": 0,
+                            "latestPingedTime": 0,
+                            "latestSuspendedTime": 0,
+                            "memoizedInteractions": Set {},
+                            "nextExpirationTimeToWorkOn": 0,
+                            "nextScheduledRoot": null,
+                            "pendingChildren": null,
+                            "pendingCommitExpirationTime": 0,
+                            "pendingContext": null,
+                            "pendingInteractionMap": Map {},
+                            "pingCache": null,
+                            "timeoutHandle": -1,
+                          },
+                          "tag": 3,
+                          "treeBaseDuration": 0,
+                          "type": null,
+                          "updateQueue": Object {
+                            "baseState": null,
+                            "firstCapturedEffect": null,
+                            "firstCapturedUpdate": null,
+                            "firstEffect": null,
+                            "firstUpdate": Object {
+                              "callback": null,
+                              "expirationTime": 1073741823,
+                              "next": null,
+                              "nextEffect": null,
+                              "payload": Object {
+                                "element": <WrapperComponent
+                                  Component={[Function]}
+                                  context={null}
+                                  props={
+                                    Object {
+                                      "children": <AuthenticatedRoute
+                                        authenticated={true}
+                                        component={[Function]}
+                                        path="/dashboard"
+                                      />,
+                                    }
+                                  }
+                                  wrappingComponentProps={null}
+                                />,
+                              },
+                              "tag": 0,
+                            },
+                            "lastCapturedEffect": null,
+                            "lastCapturedUpdate": null,
+                            "lastEffect": null,
+                            "lastUpdate": Object {
+                              "callback": null,
+                              "expirationTime": 1073741823,
+                              "next": null,
+                              "nextEffect": null,
+                              "payload": Object {
+                                "element": <WrapperComponent
+                                  Component={[Function]}
+                                  context={null}
+                                  props={
+                                    Object {
+                                      "children": <AuthenticatedRoute
+                                        authenticated={true}
+                                        component={[Function]}
+                                        path="/dashboard"
+                                      />,
+                                    }
+                                  }
+                                  wrappingComponentProps={null}
+                                />,
+                              },
+                              "tag": 0,
+                            },
+                          },
+                        },
+                        "child": [Circular],
+                        "childExpirationTime": 0,
+                        "contextDependencies": null,
+                        "effectTag": 32,
+                        "elementType": null,
+                        "expirationTime": 0,
+                        "firstEffect": [Circular],
+                        "index": 0,
+                        "key": null,
+                        "lastEffect": [Circular],
+                        "memoizedProps": null,
+                        "memoizedState": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={
+                              Object {
+                                "children": <AuthenticatedRoute
+                                  authenticated={true}
+                                  component={[Function]}
+                                  path="/dashboard"
+                                />,
+                              }
+                            }
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "mode": 0,
+                        "nextEffect": null,
+                        "pendingProps": null,
+                        "ref": null,
+                        "return": null,
+                        "selfBaseDuration": 0,
+                        "sibling": null,
+                        "stateNode": Object {
+                          "containerInfo": <div />,
+                          "context": Object {},
+                          "current": [Circular],
+                          "didError": false,
+                          "earliestPendingTime": 0,
+                          "earliestSuspendedTime": 0,
+                          "expirationTime": 0,
+                          "finishedWork": null,
+                          "firstBatch": null,
+                          "hydrate": false,
+                          "interactionThreadID": 15,
+                          "latestPendingTime": 0,
+                          "latestPingedTime": 0,
+                          "latestSuspendedTime": 0,
+                          "memoizedInteractions": Set {},
+                          "nextExpirationTimeToWorkOn": 0,
+                          "nextScheduledRoot": null,
+                          "pendingChildren": null,
+                          "pendingCommitExpirationTime": 0,
+                          "pendingContext": null,
+                          "pendingInteractionMap": Map {},
+                          "pingCache": null,
+                          "timeoutHandle": -1,
+                        },
+                        "tag": 3,
+                        "treeBaseDuration": 0,
+                        "type": null,
+                        "updateQueue": Object {
+                          "baseState": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={
+                                Object {
+                                  "children": <AuthenticatedRoute
+                                    authenticated={true}
+                                    component={[Function]}
+                                    path="/dashboard"
+                                  />,
+                                }
+                              }
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "firstCapturedEffect": null,
+                          "firstCapturedUpdate": null,
+                          "firstEffect": null,
+                          "firstUpdate": null,
+                          "lastCapturedEffect": null,
+                          "lastCapturedUpdate": null,
+                          "lastEffect": null,
+                          "lastUpdate": null,
+                        },
+                      },
+                      "selfBaseDuration": 0,
+                      "sibling": null,
+                      "stateNode": WrapperComponent {
+                        "_reactInternalFiber": [Circular],
+                        "_reactInternalInstance": Object {},
+                        "context": Object {},
+                        "props": Object {
+                          "Component": [Function],
+                          "context": null,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "refs": Object {},
+                        "rootFinderInstance": null,
+                        "state": Object {
+                          "context": null,
+                          "mount": true,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "updater": Object {
+                          "enqueueForceUpdate": [Function],
+                          "enqueueReplaceState": [Function],
+                          "enqueueSetState": [Function],
+                          "isMounted": [Function],
+                        },
+                      },
+                      "tag": 1,
+                      "treeBaseDuration": 0,
+                      "type": [Function],
+                      "updateQueue": null,
+                    },
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": BrowserRouter {
+                      "_reactInternalFiber": [Circular],
+                      "_reactInternalInstance": Object {},
+                      "context": Object {},
+                      "history": Object {
+                        "action": "POP",
+                        "block": [Function],
+                        "createHref": [Function],
+                        "go": [Function],
+                        "goBack": [Function],
+                        "goForward": [Function],
+                        "length": 1,
+                        "listen": [Function],
+                        "location": Object {
+                          "hash": "",
+                          "pathname": "/",
+                          "search": "",
+                          "state": undefined,
+                        },
+                        "push": [Function],
+                        "replace": [Function],
+                      },
+                      "props": Object {
+                        "children": <AuthenticatedRoute
+                          authenticated={true}
+                          component={[Function]}
+                          path="/dashboard"
+                        />,
+                      },
+                      "refs": Object {},
+                      "state": null,
+                      "updater": Object {
+                        "enqueueForceUpdate": [Function],
+                        "enqueueReplaceState": [Function],
+                        "enqueueSetState": [Function],
+                        "isMounted": [Function],
+                      },
+                    },
+                    "tag": 1,
+                    "treeBaseDuration": 0,
+                    "type": [Function],
+                    "updateQueue": null,
+                  },
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": Router {
+                    "__reactInternalMemoizedMaskedChildContext": Object {
+                      "router": undefined,
+                    },
+                    "__reactInternalMemoizedMergedChildContext": Object {
+                      "router": Object {
+                        "history": Object {
+                          "action": "POP",
+                          "block": [Function],
+                          "createHref": [Function],
+                          "go": [Function],
+                          "goBack": [Function],
+                          "goForward": [Function],
+                          "length": 1,
+                          "listen": [Function],
+                          "location": Object {
+                            "hash": "",
+                            "pathname": "/",
+                            "search": "",
+                            "state": undefined,
+                          },
+                          "push": [Function],
+                          "replace": [Function],
+                        },
+                        "route": Object {
+                          "location": Object {
+                            "hash": "",
+                            "pathname": "/",
+                            "search": "",
+                            "state": undefined,
+                          },
+                          "match": Object {
+                            "isExact": true,
+                            "params": Object {},
+                            "path": "/",
+                            "url": "/",
+                          },
+                        },
+                      },
+                    },
+                    "__reactInternalMemoizedUnmaskedChildContext": Object {},
+                    "_reactInternalFiber": [Circular],
+                    "_reactInternalInstance": Object {},
+                    "context": Object {
+                      "router": undefined,
+                    },
+                    "props": Object {
+                      "children": <AuthenticatedRoute
+                        authenticated={true}
+                        component={[Function]}
+                        path="/dashboard"
+                      />,
+                      "history": Object {
+                        "action": "POP",
+                        "block": [Function],
+                        "createHref": [Function],
+                        "go": [Function],
+                        "goBack": [Function],
+                        "goForward": [Function],
+                        "length": 1,
+                        "listen": [Function],
+                        "location": Object {
+                          "hash": "",
+                          "pathname": "/",
+                          "search": "",
+                          "state": undefined,
+                        },
+                        "push": [Function],
+                        "replace": [Function],
+                      },
+                    },
+                    "refs": Object {},
+                    "state": Object {
+                      "match": Object {
+                        "isExact": true,
+                        "params": Object {},
+                        "path": "/",
+                        "url": "/",
+                      },
+                    },
+                    "unlisten": [Function],
+                    "updater": Object {
+                      "enqueueForceUpdate": [Function],
+                      "enqueueReplaceState": [Function],
+                      "enqueueSetState": [Function],
+                      "isMounted": [Function],
+                    },
+                  },
+                  "tag": 1,
+                  "treeBaseDuration": 0,
+                  "type": [Function],
+                  "updateQueue": null,
+                },
+                "selfBaseDuration": 0,
+                "sibling": null,
+                "stateNode": null,
+                "tag": 0,
+                "treeBaseDuration": 0,
+                "type": [Function],
+                "updateQueue": null,
+              },
+              "_debugSource": Object {
+                "fileName": "/Users/home/Documents/Projects/javascript/Andela/bp-esa/bp-esa-frontend/src/App.jsx",
+                "lineNumber": 15,
+              },
+              "actualDuration": 0,
+              "actualStartTime": -1,
+              "alternate": null,
+              "child": null,
+              "childExpirationTime": 0,
+              "contextDependencies": null,
+              "effectTag": 1,
+              "elementType": [Function],
+              "expirationTime": 0,
+              "firstEffect": null,
+              "index": 0,
+              "key": null,
+              "lastEffect": null,
+              "memoizedProps": Object {
+                "path": "/dashboard",
+                "render": [Function],
+              },
+              "memoizedState": Object {
+                "match": null,
+              },
+              "mode": 0,
+              "nextEffect": null,
+              "pendingProps": Object {
+                "path": "/dashboard",
+                "render": [Function],
+              },
+              "ref": null,
+              "return": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 65,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": null,
+                "_debugSource": Object {
+                  "fileName": "/Users/home/Documents/Projects/javascript/Andela/bp-esa/bp-esa-frontend/src/App.test.jsx",
+                  "lineNumber": 123,
+                },
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": null,
+                "child": [Circular],
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 1,
+                "elementType": [Function],
+                "expirationTime": 0,
+                "firstEffect": null,
+                "index": 0,
+                "key": null,
+                "lastEffect": null,
+                "memoizedProps": Object {
+                  "authenticated": true,
+                  "component": [Function],
+                  "path": "/dashboard",
+                },
+                "memoizedState": null,
+                "mode": 0,
+                "nextEffect": null,
+                "pendingProps": Object {
+                  "authenticated": true,
+                  "component": [Function],
+                  "path": "/dashboard",
+                },
+                "ref": null,
+                "return": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 64,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 63,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": FiberNode {
+                      "_debugHookTypes": null,
+                      "_debugID": 62,
+                      "_debugIsCurrentlyTiming": false,
+                      "_debugOwner": null,
+                      "_debugSource": null,
+                      "actualDuration": 0,
+                      "actualStartTime": -1,
+                      "alternate": null,
+                      "child": [Circular],
+                      "childExpirationTime": 0,
+                      "contextDependencies": null,
+                      "effectTag": 1,
+                      "elementType": [Function],
+                      "expirationTime": 0,
+                      "firstEffect": null,
+                      "index": 0,
+                      "key": null,
+                      "lastEffect": null,
+                      "memoizedProps": Object {
+                        "Component": [Function],
+                        "context": null,
+                        "props": Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        },
+                        "wrappingComponentProps": null,
+                      },
+                      "memoizedState": Object {
+                        "context": null,
+                        "mount": true,
+                        "props": Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        },
+                        "wrappingComponentProps": null,
+                      },
+                      "mode": 0,
+                      "nextEffect": FiberNode {
+                        "_debugHookTypes": null,
+                        "_debugID": 60,
+                        "_debugIsCurrentlyTiming": false,
+                        "_debugOwner": null,
+                        "_debugSource": null,
+                        "actualDuration": 0,
+                        "actualStartTime": -1,
+                        "alternate": FiberNode {
+                          "_debugHookTypes": null,
+                          "_debugID": 60,
+                          "_debugIsCurrentlyTiming": false,
+                          "_debugOwner": null,
+                          "_debugSource": null,
+                          "actualDuration": 0,
+                          "actualStartTime": -1,
+                          "alternate": [Circular],
+                          "child": null,
+                          "childExpirationTime": 0,
+                          "contextDependencies": null,
+                          "effectTag": 0,
+                          "elementType": null,
+                          "expirationTime": 1073741823,
+                          "firstEffect": null,
+                          "index": 0,
+                          "key": null,
+                          "lastEffect": null,
+                          "memoizedProps": null,
+                          "memoizedState": null,
+                          "mode": 0,
+                          "nextEffect": null,
+                          "pendingProps": null,
+                          "ref": null,
+                          "return": null,
+                          "selfBaseDuration": 0,
+                          "sibling": null,
+                          "stateNode": Object {
+                            "containerInfo": <div />,
+                            "context": Object {},
+                            "current": [Circular],
+                            "didError": false,
+                            "earliestPendingTime": 0,
+                            "earliestSuspendedTime": 0,
+                            "expirationTime": 0,
+                            "finishedWork": null,
+                            "firstBatch": null,
+                            "hydrate": false,
+                            "interactionThreadID": 15,
+                            "latestPendingTime": 0,
+                            "latestPingedTime": 0,
+                            "latestSuspendedTime": 0,
+                            "memoizedInteractions": Set {},
+                            "nextExpirationTimeToWorkOn": 0,
+                            "nextScheduledRoot": null,
+                            "pendingChildren": null,
+                            "pendingCommitExpirationTime": 0,
+                            "pendingContext": null,
+                            "pendingInteractionMap": Map {},
+                            "pingCache": null,
+                            "timeoutHandle": -1,
+                          },
+                          "tag": 3,
+                          "treeBaseDuration": 0,
+                          "type": null,
+                          "updateQueue": Object {
+                            "baseState": null,
+                            "firstCapturedEffect": null,
+                            "firstCapturedUpdate": null,
+                            "firstEffect": null,
+                            "firstUpdate": Object {
+                              "callback": null,
+                              "expirationTime": 1073741823,
+                              "next": null,
+                              "nextEffect": null,
+                              "payload": Object {
+                                "element": <WrapperComponent
+                                  Component={[Function]}
+                                  context={null}
+                                  props={
+                                    Object {
+                                      "children": <AuthenticatedRoute
+                                        authenticated={true}
+                                        component={[Function]}
+                                        path="/dashboard"
+                                      />,
+                                    }
+                                  }
+                                  wrappingComponentProps={null}
+                                />,
+                              },
+                              "tag": 0,
+                            },
+                            "lastCapturedEffect": null,
+                            "lastCapturedUpdate": null,
+                            "lastEffect": null,
+                            "lastUpdate": Object {
+                              "callback": null,
+                              "expirationTime": 1073741823,
+                              "next": null,
+                              "nextEffect": null,
+                              "payload": Object {
+                                "element": <WrapperComponent
+                                  Component={[Function]}
+                                  context={null}
+                                  props={
+                                    Object {
+                                      "children": <AuthenticatedRoute
+                                        authenticated={true}
+                                        component={[Function]}
+                                        path="/dashboard"
+                                      />,
+                                    }
+                                  }
+                                  wrappingComponentProps={null}
+                                />,
+                              },
+                              "tag": 0,
+                            },
+                          },
+                        },
+                        "child": [Circular],
+                        "childExpirationTime": 0,
+                        "contextDependencies": null,
+                        "effectTag": 32,
+                        "elementType": null,
+                        "expirationTime": 0,
+                        "firstEffect": [Circular],
+                        "index": 0,
+                        "key": null,
+                        "lastEffect": [Circular],
+                        "memoizedProps": null,
+                        "memoizedState": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={
+                              Object {
+                                "children": <AuthenticatedRoute
+                                  authenticated={true}
+                                  component={[Function]}
+                                  path="/dashboard"
+                                />,
+                              }
+                            }
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "mode": 0,
+                        "nextEffect": null,
+                        "pendingProps": null,
+                        "ref": null,
+                        "return": null,
+                        "selfBaseDuration": 0,
+                        "sibling": null,
+                        "stateNode": Object {
+                          "containerInfo": <div />,
+                          "context": Object {},
+                          "current": [Circular],
+                          "didError": false,
+                          "earliestPendingTime": 0,
+                          "earliestSuspendedTime": 0,
+                          "expirationTime": 0,
+                          "finishedWork": null,
+                          "firstBatch": null,
+                          "hydrate": false,
+                          "interactionThreadID": 15,
+                          "latestPendingTime": 0,
+                          "latestPingedTime": 0,
+                          "latestSuspendedTime": 0,
+                          "memoizedInteractions": Set {},
+                          "nextExpirationTimeToWorkOn": 0,
+                          "nextScheduledRoot": null,
+                          "pendingChildren": null,
+                          "pendingCommitExpirationTime": 0,
+                          "pendingContext": null,
+                          "pendingInteractionMap": Map {},
+                          "pingCache": null,
+                          "timeoutHandle": -1,
+                        },
+                        "tag": 3,
+                        "treeBaseDuration": 0,
+                        "type": null,
+                        "updateQueue": Object {
+                          "baseState": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={
+                                Object {
+                                  "children": <AuthenticatedRoute
+                                    authenticated={true}
+                                    component={[Function]}
+                                    path="/dashboard"
+                                  />,
+                                }
+                              }
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "firstCapturedEffect": null,
+                          "firstCapturedUpdate": null,
+                          "firstEffect": null,
+                          "firstUpdate": null,
+                          "lastCapturedEffect": null,
+                          "lastCapturedUpdate": null,
+                          "lastEffect": null,
+                          "lastUpdate": null,
+                        },
+                      },
+                      "pendingProps": Object {
+                        "Component": [Function],
+                        "context": null,
+                        "props": Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        },
+                        "wrappingComponentProps": null,
+                      },
+                      "ref": null,
+                      "return": FiberNode {
+                        "_debugHookTypes": null,
+                        "_debugID": 60,
+                        "_debugIsCurrentlyTiming": false,
+                        "_debugOwner": null,
+                        "_debugSource": null,
+                        "actualDuration": 0,
+                        "actualStartTime": -1,
+                        "alternate": FiberNode {
+                          "_debugHookTypes": null,
+                          "_debugID": 60,
+                          "_debugIsCurrentlyTiming": false,
+                          "_debugOwner": null,
+                          "_debugSource": null,
+                          "actualDuration": 0,
+                          "actualStartTime": -1,
+                          "alternate": [Circular],
+                          "child": null,
+                          "childExpirationTime": 0,
+                          "contextDependencies": null,
+                          "effectTag": 0,
+                          "elementType": null,
+                          "expirationTime": 1073741823,
+                          "firstEffect": null,
+                          "index": 0,
+                          "key": null,
+                          "lastEffect": null,
+                          "memoizedProps": null,
+                          "memoizedState": null,
+                          "mode": 0,
+                          "nextEffect": null,
+                          "pendingProps": null,
+                          "ref": null,
+                          "return": null,
+                          "selfBaseDuration": 0,
+                          "sibling": null,
+                          "stateNode": Object {
+                            "containerInfo": <div />,
+                            "context": Object {},
+                            "current": [Circular],
+                            "didError": false,
+                            "earliestPendingTime": 0,
+                            "earliestSuspendedTime": 0,
+                            "expirationTime": 0,
+                            "finishedWork": null,
+                            "firstBatch": null,
+                            "hydrate": false,
+                            "interactionThreadID": 15,
+                            "latestPendingTime": 0,
+                            "latestPingedTime": 0,
+                            "latestSuspendedTime": 0,
+                            "memoizedInteractions": Set {},
+                            "nextExpirationTimeToWorkOn": 0,
+                            "nextScheduledRoot": null,
+                            "pendingChildren": null,
+                            "pendingCommitExpirationTime": 0,
+                            "pendingContext": null,
+                            "pendingInteractionMap": Map {},
+                            "pingCache": null,
+                            "timeoutHandle": -1,
+                          },
+                          "tag": 3,
+                          "treeBaseDuration": 0,
+                          "type": null,
+                          "updateQueue": Object {
+                            "baseState": null,
+                            "firstCapturedEffect": null,
+                            "firstCapturedUpdate": null,
+                            "firstEffect": null,
+                            "firstUpdate": Object {
+                              "callback": null,
+                              "expirationTime": 1073741823,
+                              "next": null,
+                              "nextEffect": null,
+                              "payload": Object {
+                                "element": <WrapperComponent
+                                  Component={[Function]}
+                                  context={null}
+                                  props={
+                                    Object {
+                                      "children": <AuthenticatedRoute
+                                        authenticated={true}
+                                        component={[Function]}
+                                        path="/dashboard"
+                                      />,
+                                    }
+                                  }
+                                  wrappingComponentProps={null}
+                                />,
+                              },
+                              "tag": 0,
+                            },
+                            "lastCapturedEffect": null,
+                            "lastCapturedUpdate": null,
+                            "lastEffect": null,
+                            "lastUpdate": Object {
+                              "callback": null,
+                              "expirationTime": 1073741823,
+                              "next": null,
+                              "nextEffect": null,
+                              "payload": Object {
+                                "element": <WrapperComponent
+                                  Component={[Function]}
+                                  context={null}
+                                  props={
+                                    Object {
+                                      "children": <AuthenticatedRoute
+                                        authenticated={true}
+                                        component={[Function]}
+                                        path="/dashboard"
+                                      />,
+                                    }
+                                  }
+                                  wrappingComponentProps={null}
+                                />,
+                              },
+                              "tag": 0,
+                            },
+                          },
+                        },
+                        "child": [Circular],
+                        "childExpirationTime": 0,
+                        "contextDependencies": null,
+                        "effectTag": 32,
+                        "elementType": null,
+                        "expirationTime": 0,
+                        "firstEffect": [Circular],
+                        "index": 0,
+                        "key": null,
+                        "lastEffect": [Circular],
+                        "memoizedProps": null,
+                        "memoizedState": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={
+                              Object {
+                                "children": <AuthenticatedRoute
+                                  authenticated={true}
+                                  component={[Function]}
+                                  path="/dashboard"
+                                />,
+                              }
+                            }
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "mode": 0,
+                        "nextEffect": null,
+                        "pendingProps": null,
+                        "ref": null,
+                        "return": null,
+                        "selfBaseDuration": 0,
+                        "sibling": null,
+                        "stateNode": Object {
+                          "containerInfo": <div />,
+                          "context": Object {},
+                          "current": [Circular],
+                          "didError": false,
+                          "earliestPendingTime": 0,
+                          "earliestSuspendedTime": 0,
+                          "expirationTime": 0,
+                          "finishedWork": null,
+                          "firstBatch": null,
+                          "hydrate": false,
+                          "interactionThreadID": 15,
+                          "latestPendingTime": 0,
+                          "latestPingedTime": 0,
+                          "latestSuspendedTime": 0,
+                          "memoizedInteractions": Set {},
+                          "nextExpirationTimeToWorkOn": 0,
+                          "nextScheduledRoot": null,
+                          "pendingChildren": null,
+                          "pendingCommitExpirationTime": 0,
+                          "pendingContext": null,
+                          "pendingInteractionMap": Map {},
+                          "pingCache": null,
+                          "timeoutHandle": -1,
+                        },
+                        "tag": 3,
+                        "treeBaseDuration": 0,
+                        "type": null,
+                        "updateQueue": Object {
+                          "baseState": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={
+                                Object {
+                                  "children": <AuthenticatedRoute
+                                    authenticated={true}
+                                    component={[Function]}
+                                    path="/dashboard"
+                                  />,
+                                }
+                              }
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "firstCapturedEffect": null,
+                          "firstCapturedUpdate": null,
+                          "firstEffect": null,
+                          "firstUpdate": null,
+                          "lastCapturedEffect": null,
+                          "lastCapturedUpdate": null,
+                          "lastEffect": null,
+                          "lastUpdate": null,
+                        },
+                      },
+                      "selfBaseDuration": 0,
+                      "sibling": null,
+                      "stateNode": WrapperComponent {
+                        "_reactInternalFiber": [Circular],
+                        "_reactInternalInstance": Object {},
+                        "context": Object {},
+                        "props": Object {
+                          "Component": [Function],
+                          "context": null,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "refs": Object {},
+                        "rootFinderInstance": null,
+                        "state": Object {
+                          "context": null,
+                          "mount": true,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "updater": Object {
+                          "enqueueForceUpdate": [Function],
+                          "enqueueReplaceState": [Function],
+                          "enqueueSetState": [Function],
+                          "isMounted": [Function],
+                        },
+                      },
+                      "tag": 1,
+                      "treeBaseDuration": 0,
+                      "type": [Function],
+                      "updateQueue": null,
+                    },
+                    "_debugSource": null,
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": null,
+                    "child": [Circular],
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 1,
+                    "elementType": [Function],
+                    "expirationTime": 0,
+                    "firstEffect": null,
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": null,
+                    "memoizedProps": Object {
+                      "children": <AuthenticatedRoute
+                        authenticated={true}
+                        component={[Function]}
+                        path="/dashboard"
+                      />,
+                    },
+                    "memoizedState": null,
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": Object {
+                      "children": <AuthenticatedRoute
+                        authenticated={true}
+                        component={[Function]}
+                        path="/dashboard"
+                      />,
+                    },
+                    "ref": null,
+                    "return": FiberNode {
+                      "_debugHookTypes": null,
+                      "_debugID": 62,
+                      "_debugIsCurrentlyTiming": false,
+                      "_debugOwner": null,
+                      "_debugSource": null,
+                      "actualDuration": 0,
+                      "actualStartTime": -1,
+                      "alternate": null,
+                      "child": [Circular],
+                      "childExpirationTime": 0,
+                      "contextDependencies": null,
+                      "effectTag": 1,
+                      "elementType": [Function],
+                      "expirationTime": 0,
+                      "firstEffect": null,
+                      "index": 0,
+                      "key": null,
+                      "lastEffect": null,
+                      "memoizedProps": Object {
+                        "Component": [Function],
+                        "context": null,
+                        "props": Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        },
+                        "wrappingComponentProps": null,
+                      },
+                      "memoizedState": Object {
+                        "context": null,
+                        "mount": true,
+                        "props": Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        },
+                        "wrappingComponentProps": null,
+                      },
+                      "mode": 0,
+                      "nextEffect": FiberNode {
+                        "_debugHookTypes": null,
+                        "_debugID": 60,
+                        "_debugIsCurrentlyTiming": false,
+                        "_debugOwner": null,
+                        "_debugSource": null,
+                        "actualDuration": 0,
+                        "actualStartTime": -1,
+                        "alternate": FiberNode {
+                          "_debugHookTypes": null,
+                          "_debugID": 60,
+                          "_debugIsCurrentlyTiming": false,
+                          "_debugOwner": null,
+                          "_debugSource": null,
+                          "actualDuration": 0,
+                          "actualStartTime": -1,
+                          "alternate": [Circular],
+                          "child": null,
+                          "childExpirationTime": 0,
+                          "contextDependencies": null,
+                          "effectTag": 0,
+                          "elementType": null,
+                          "expirationTime": 1073741823,
+                          "firstEffect": null,
+                          "index": 0,
+                          "key": null,
+                          "lastEffect": null,
+                          "memoizedProps": null,
+                          "memoizedState": null,
+                          "mode": 0,
+                          "nextEffect": null,
+                          "pendingProps": null,
+                          "ref": null,
+                          "return": null,
+                          "selfBaseDuration": 0,
+                          "sibling": null,
+                          "stateNode": Object {
+                            "containerInfo": <div />,
+                            "context": Object {},
+                            "current": [Circular],
+                            "didError": false,
+                            "earliestPendingTime": 0,
+                            "earliestSuspendedTime": 0,
+                            "expirationTime": 0,
+                            "finishedWork": null,
+                            "firstBatch": null,
+                            "hydrate": false,
+                            "interactionThreadID": 15,
+                            "latestPendingTime": 0,
+                            "latestPingedTime": 0,
+                            "latestSuspendedTime": 0,
+                            "memoizedInteractions": Set {},
+                            "nextExpirationTimeToWorkOn": 0,
+                            "nextScheduledRoot": null,
+                            "pendingChildren": null,
+                            "pendingCommitExpirationTime": 0,
+                            "pendingContext": null,
+                            "pendingInteractionMap": Map {},
+                            "pingCache": null,
+                            "timeoutHandle": -1,
+                          },
+                          "tag": 3,
+                          "treeBaseDuration": 0,
+                          "type": null,
+                          "updateQueue": Object {
+                            "baseState": null,
+                            "firstCapturedEffect": null,
+                            "firstCapturedUpdate": null,
+                            "firstEffect": null,
+                            "firstUpdate": Object {
+                              "callback": null,
+                              "expirationTime": 1073741823,
+                              "next": null,
+                              "nextEffect": null,
+                              "payload": Object {
+                                "element": <WrapperComponent
+                                  Component={[Function]}
+                                  context={null}
+                                  props={
+                                    Object {
+                                      "children": <AuthenticatedRoute
+                                        authenticated={true}
+                                        component={[Function]}
+                                        path="/dashboard"
+                                      />,
+                                    }
+                                  }
+                                  wrappingComponentProps={null}
+                                />,
+                              },
+                              "tag": 0,
+                            },
+                            "lastCapturedEffect": null,
+                            "lastCapturedUpdate": null,
+                            "lastEffect": null,
+                            "lastUpdate": Object {
+                              "callback": null,
+                              "expirationTime": 1073741823,
+                              "next": null,
+                              "nextEffect": null,
+                              "payload": Object {
+                                "element": <WrapperComponent
+                                  Component={[Function]}
+                                  context={null}
+                                  props={
+                                    Object {
+                                      "children": <AuthenticatedRoute
+                                        authenticated={true}
+                                        component={[Function]}
+                                        path="/dashboard"
+                                      />,
+                                    }
+                                  }
+                                  wrappingComponentProps={null}
+                                />,
+                              },
+                              "tag": 0,
+                            },
+                          },
+                        },
+                        "child": [Circular],
+                        "childExpirationTime": 0,
+                        "contextDependencies": null,
+                        "effectTag": 32,
+                        "elementType": null,
+                        "expirationTime": 0,
+                        "firstEffect": [Circular],
+                        "index": 0,
+                        "key": null,
+                        "lastEffect": [Circular],
+                        "memoizedProps": null,
+                        "memoizedState": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={
+                              Object {
+                                "children": <AuthenticatedRoute
+                                  authenticated={true}
+                                  component={[Function]}
+                                  path="/dashboard"
+                                />,
+                              }
+                            }
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "mode": 0,
+                        "nextEffect": null,
+                        "pendingProps": null,
+                        "ref": null,
+                        "return": null,
+                        "selfBaseDuration": 0,
+                        "sibling": null,
+                        "stateNode": Object {
+                          "containerInfo": <div />,
+                          "context": Object {},
+                          "current": [Circular],
+                          "didError": false,
+                          "earliestPendingTime": 0,
+                          "earliestSuspendedTime": 0,
+                          "expirationTime": 0,
+                          "finishedWork": null,
+                          "firstBatch": null,
+                          "hydrate": false,
+                          "interactionThreadID": 15,
+                          "latestPendingTime": 0,
+                          "latestPingedTime": 0,
+                          "latestSuspendedTime": 0,
+                          "memoizedInteractions": Set {},
+                          "nextExpirationTimeToWorkOn": 0,
+                          "nextScheduledRoot": null,
+                          "pendingChildren": null,
+                          "pendingCommitExpirationTime": 0,
+                          "pendingContext": null,
+                          "pendingInteractionMap": Map {},
+                          "pingCache": null,
+                          "timeoutHandle": -1,
+                        },
+                        "tag": 3,
+                        "treeBaseDuration": 0,
+                        "type": null,
+                        "updateQueue": Object {
+                          "baseState": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={
+                                Object {
+                                  "children": <AuthenticatedRoute
+                                    authenticated={true}
+                                    component={[Function]}
+                                    path="/dashboard"
+                                  />,
+                                }
+                              }
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "firstCapturedEffect": null,
+                          "firstCapturedUpdate": null,
+                          "firstEffect": null,
+                          "firstUpdate": null,
+                          "lastCapturedEffect": null,
+                          "lastCapturedUpdate": null,
+                          "lastEffect": null,
+                          "lastUpdate": null,
+                        },
+                      },
+                      "pendingProps": Object {
+                        "Component": [Function],
+                        "context": null,
+                        "props": Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        },
+                        "wrappingComponentProps": null,
+                      },
+                      "ref": null,
+                      "return": FiberNode {
+                        "_debugHookTypes": null,
+                        "_debugID": 60,
+                        "_debugIsCurrentlyTiming": false,
+                        "_debugOwner": null,
+                        "_debugSource": null,
+                        "actualDuration": 0,
+                        "actualStartTime": -1,
+                        "alternate": FiberNode {
+                          "_debugHookTypes": null,
+                          "_debugID": 60,
+                          "_debugIsCurrentlyTiming": false,
+                          "_debugOwner": null,
+                          "_debugSource": null,
+                          "actualDuration": 0,
+                          "actualStartTime": -1,
+                          "alternate": [Circular],
+                          "child": null,
+                          "childExpirationTime": 0,
+                          "contextDependencies": null,
+                          "effectTag": 0,
+                          "elementType": null,
+                          "expirationTime": 1073741823,
+                          "firstEffect": null,
+                          "index": 0,
+                          "key": null,
+                          "lastEffect": null,
+                          "memoizedProps": null,
+                          "memoizedState": null,
+                          "mode": 0,
+                          "nextEffect": null,
+                          "pendingProps": null,
+                          "ref": null,
+                          "return": null,
+                          "selfBaseDuration": 0,
+                          "sibling": null,
+                          "stateNode": Object {
+                            "containerInfo": <div />,
+                            "context": Object {},
+                            "current": [Circular],
+                            "didError": false,
+                            "earliestPendingTime": 0,
+                            "earliestSuspendedTime": 0,
+                            "expirationTime": 0,
+                            "finishedWork": null,
+                            "firstBatch": null,
+                            "hydrate": false,
+                            "interactionThreadID": 15,
+                            "latestPendingTime": 0,
+                            "latestPingedTime": 0,
+                            "latestSuspendedTime": 0,
+                            "memoizedInteractions": Set {},
+                            "nextExpirationTimeToWorkOn": 0,
+                            "nextScheduledRoot": null,
+                            "pendingChildren": null,
+                            "pendingCommitExpirationTime": 0,
+                            "pendingContext": null,
+                            "pendingInteractionMap": Map {},
+                            "pingCache": null,
+                            "timeoutHandle": -1,
+                          },
+                          "tag": 3,
+                          "treeBaseDuration": 0,
+                          "type": null,
+                          "updateQueue": Object {
+                            "baseState": null,
+                            "firstCapturedEffect": null,
+                            "firstCapturedUpdate": null,
+                            "firstEffect": null,
+                            "firstUpdate": Object {
+                              "callback": null,
+                              "expirationTime": 1073741823,
+                              "next": null,
+                              "nextEffect": null,
+                              "payload": Object {
+                                "element": <WrapperComponent
+                                  Component={[Function]}
+                                  context={null}
+                                  props={
+                                    Object {
+                                      "children": <AuthenticatedRoute
+                                        authenticated={true}
+                                        component={[Function]}
+                                        path="/dashboard"
+                                      />,
+                                    }
+                                  }
+                                  wrappingComponentProps={null}
+                                />,
+                              },
+                              "tag": 0,
+                            },
+                            "lastCapturedEffect": null,
+                            "lastCapturedUpdate": null,
+                            "lastEffect": null,
+                            "lastUpdate": Object {
+                              "callback": null,
+                              "expirationTime": 1073741823,
+                              "next": null,
+                              "nextEffect": null,
+                              "payload": Object {
+                                "element": <WrapperComponent
+                                  Component={[Function]}
+                                  context={null}
+                                  props={
+                                    Object {
+                                      "children": <AuthenticatedRoute
+                                        authenticated={true}
+                                        component={[Function]}
+                                        path="/dashboard"
+                                      />,
+                                    }
+                                  }
+                                  wrappingComponentProps={null}
+                                />,
+                              },
+                              "tag": 0,
+                            },
+                          },
+                        },
+                        "child": [Circular],
+                        "childExpirationTime": 0,
+                        "contextDependencies": null,
+                        "effectTag": 32,
+                        "elementType": null,
+                        "expirationTime": 0,
+                        "firstEffect": [Circular],
+                        "index": 0,
+                        "key": null,
+                        "lastEffect": [Circular],
+                        "memoizedProps": null,
+                        "memoizedState": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={
+                              Object {
+                                "children": <AuthenticatedRoute
+                                  authenticated={true}
+                                  component={[Function]}
+                                  path="/dashboard"
+                                />,
+                              }
+                            }
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "mode": 0,
+                        "nextEffect": null,
+                        "pendingProps": null,
+                        "ref": null,
+                        "return": null,
+                        "selfBaseDuration": 0,
+                        "sibling": null,
+                        "stateNode": Object {
+                          "containerInfo": <div />,
+                          "context": Object {},
+                          "current": [Circular],
+                          "didError": false,
+                          "earliestPendingTime": 0,
+                          "earliestSuspendedTime": 0,
+                          "expirationTime": 0,
+                          "finishedWork": null,
+                          "firstBatch": null,
+                          "hydrate": false,
+                          "interactionThreadID": 15,
+                          "latestPendingTime": 0,
+                          "latestPingedTime": 0,
+                          "latestSuspendedTime": 0,
+                          "memoizedInteractions": Set {},
+                          "nextExpirationTimeToWorkOn": 0,
+                          "nextScheduledRoot": null,
+                          "pendingChildren": null,
+                          "pendingCommitExpirationTime": 0,
+                          "pendingContext": null,
+                          "pendingInteractionMap": Map {},
+                          "pingCache": null,
+                          "timeoutHandle": -1,
+                        },
+                        "tag": 3,
+                        "treeBaseDuration": 0,
+                        "type": null,
+                        "updateQueue": Object {
+                          "baseState": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={
+                                Object {
+                                  "children": <AuthenticatedRoute
+                                    authenticated={true}
+                                    component={[Function]}
+                                    path="/dashboard"
+                                  />,
+                                }
+                              }
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "firstCapturedEffect": null,
+                          "firstCapturedUpdate": null,
+                          "firstEffect": null,
+                          "firstUpdate": null,
+                          "lastCapturedEffect": null,
+                          "lastCapturedUpdate": null,
+                          "lastEffect": null,
+                          "lastUpdate": null,
+                        },
+                      },
+                      "selfBaseDuration": 0,
+                      "sibling": null,
+                      "stateNode": WrapperComponent {
+                        "_reactInternalFiber": [Circular],
+                        "_reactInternalInstance": Object {},
+                        "context": Object {},
+                        "props": Object {
+                          "Component": [Function],
+                          "context": null,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "refs": Object {},
+                        "rootFinderInstance": null,
+                        "state": Object {
+                          "context": null,
+                          "mount": true,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "updater": Object {
+                          "enqueueForceUpdate": [Function],
+                          "enqueueReplaceState": [Function],
+                          "enqueueSetState": [Function],
+                          "isMounted": [Function],
+                        },
+                      },
+                      "tag": 1,
+                      "treeBaseDuration": 0,
+                      "type": [Function],
+                      "updateQueue": null,
+                    },
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": BrowserRouter {
+                      "_reactInternalFiber": [Circular],
+                      "_reactInternalInstance": Object {},
+                      "context": Object {},
+                      "history": Object {
+                        "action": "POP",
+                        "block": [Function],
+                        "createHref": [Function],
+                        "go": [Function],
+                        "goBack": [Function],
+                        "goForward": [Function],
+                        "length": 1,
+                        "listen": [Function],
+                        "location": Object {
+                          "hash": "",
+                          "pathname": "/",
+                          "search": "",
+                          "state": undefined,
+                        },
+                        "push": [Function],
+                        "replace": [Function],
+                      },
+                      "props": Object {
+                        "children": <AuthenticatedRoute
+                          authenticated={true}
+                          component={[Function]}
+                          path="/dashboard"
+                        />,
+                      },
+                      "refs": Object {},
+                      "state": null,
+                      "updater": Object {
+                        "enqueueForceUpdate": [Function],
+                        "enqueueReplaceState": [Function],
+                        "enqueueSetState": [Function],
+                        "isMounted": [Function],
+                      },
+                    },
+                    "tag": 1,
+                    "treeBaseDuration": 0,
+                    "type": [Function],
+                    "updateQueue": null,
+                  },
+                  "_debugSource": null,
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": null,
+                  "child": [Circular],
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 1,
+                  "elementType": [Function],
+                  "expirationTime": 0,
+                  "firstEffect": null,
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": null,
+                  "memoizedProps": Object {
+                    "children": <AuthenticatedRoute
+                      authenticated={true}
+                      component={[Function]}
+                      path="/dashboard"
+                    />,
+                    "history": Object {
+                      "action": "POP",
+                      "block": [Function],
+                      "createHref": [Function],
+                      "go": [Function],
+                      "goBack": [Function],
+                      "goForward": [Function],
+                      "length": 1,
+                      "listen": [Function],
+                      "location": Object {
+                        "hash": "",
+                        "pathname": "/",
+                        "search": "",
+                        "state": undefined,
+                      },
+                      "push": [Function],
+                      "replace": [Function],
+                    },
+                  },
+                  "memoizedState": Object {
+                    "match": Object {
+                      "isExact": true,
+                      "params": Object {},
+                      "path": "/",
+                      "url": "/",
+                    },
+                  },
+                  "mode": 0,
+                  "nextEffect": null,
+                  "pendingProps": Object {
+                    "children": <AuthenticatedRoute
+                      authenticated={true}
+                      component={[Function]}
+                      path="/dashboard"
+                    />,
+                    "history": Object {
+                      "action": "POP",
+                      "block": [Function],
+                      "createHref": [Function],
+                      "go": [Function],
+                      "goBack": [Function],
+                      "goForward": [Function],
+                      "length": 1,
+                      "listen": [Function],
+                      "location": Object {
+                        "hash": "",
+                        "pathname": "/",
+                        "search": "",
+                        "state": undefined,
+                      },
+                      "push": [Function],
+                      "replace": [Function],
+                    },
+                  },
+                  "ref": null,
+                  "return": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 63,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": FiberNode {
+                      "_debugHookTypes": null,
+                      "_debugID": 62,
+                      "_debugIsCurrentlyTiming": false,
+                      "_debugOwner": null,
+                      "_debugSource": null,
+                      "actualDuration": 0,
+                      "actualStartTime": -1,
+                      "alternate": null,
+                      "child": [Circular],
+                      "childExpirationTime": 0,
+                      "contextDependencies": null,
+                      "effectTag": 1,
+                      "elementType": [Function],
+                      "expirationTime": 0,
+                      "firstEffect": null,
+                      "index": 0,
+                      "key": null,
+                      "lastEffect": null,
+                      "memoizedProps": Object {
+                        "Component": [Function],
+                        "context": null,
+                        "props": Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        },
+                        "wrappingComponentProps": null,
+                      },
+                      "memoizedState": Object {
+                        "context": null,
+                        "mount": true,
+                        "props": Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        },
+                        "wrappingComponentProps": null,
+                      },
+                      "mode": 0,
+                      "nextEffect": FiberNode {
+                        "_debugHookTypes": null,
+                        "_debugID": 60,
+                        "_debugIsCurrentlyTiming": false,
+                        "_debugOwner": null,
+                        "_debugSource": null,
+                        "actualDuration": 0,
+                        "actualStartTime": -1,
+                        "alternate": FiberNode {
+                          "_debugHookTypes": null,
+                          "_debugID": 60,
+                          "_debugIsCurrentlyTiming": false,
+                          "_debugOwner": null,
+                          "_debugSource": null,
+                          "actualDuration": 0,
+                          "actualStartTime": -1,
+                          "alternate": [Circular],
+                          "child": null,
+                          "childExpirationTime": 0,
+                          "contextDependencies": null,
+                          "effectTag": 0,
+                          "elementType": null,
+                          "expirationTime": 1073741823,
+                          "firstEffect": null,
+                          "index": 0,
+                          "key": null,
+                          "lastEffect": null,
+                          "memoizedProps": null,
+                          "memoizedState": null,
+                          "mode": 0,
+                          "nextEffect": null,
+                          "pendingProps": null,
+                          "ref": null,
+                          "return": null,
+                          "selfBaseDuration": 0,
+                          "sibling": null,
+                          "stateNode": Object {
+                            "containerInfo": <div />,
+                            "context": Object {},
+                            "current": [Circular],
+                            "didError": false,
+                            "earliestPendingTime": 0,
+                            "earliestSuspendedTime": 0,
+                            "expirationTime": 0,
+                            "finishedWork": null,
+                            "firstBatch": null,
+                            "hydrate": false,
+                            "interactionThreadID": 15,
+                            "latestPendingTime": 0,
+                            "latestPingedTime": 0,
+                            "latestSuspendedTime": 0,
+                            "memoizedInteractions": Set {},
+                            "nextExpirationTimeToWorkOn": 0,
+                            "nextScheduledRoot": null,
+                            "pendingChildren": null,
+                            "pendingCommitExpirationTime": 0,
+                            "pendingContext": null,
+                            "pendingInteractionMap": Map {},
+                            "pingCache": null,
+                            "timeoutHandle": -1,
+                          },
+                          "tag": 3,
+                          "treeBaseDuration": 0,
+                          "type": null,
+                          "updateQueue": Object {
+                            "baseState": null,
+                            "firstCapturedEffect": null,
+                            "firstCapturedUpdate": null,
+                            "firstEffect": null,
+                            "firstUpdate": Object {
+                              "callback": null,
+                              "expirationTime": 1073741823,
+                              "next": null,
+                              "nextEffect": null,
+                              "payload": Object {
+                                "element": <WrapperComponent
+                                  Component={[Function]}
+                                  context={null}
+                                  props={
+                                    Object {
+                                      "children": <AuthenticatedRoute
+                                        authenticated={true}
+                                        component={[Function]}
+                                        path="/dashboard"
+                                      />,
+                                    }
+                                  }
+                                  wrappingComponentProps={null}
+                                />,
+                              },
+                              "tag": 0,
+                            },
+                            "lastCapturedEffect": null,
+                            "lastCapturedUpdate": null,
+                            "lastEffect": null,
+                            "lastUpdate": Object {
+                              "callback": null,
+                              "expirationTime": 1073741823,
+                              "next": null,
+                              "nextEffect": null,
+                              "payload": Object {
+                                "element": <WrapperComponent
+                                  Component={[Function]}
+                                  context={null}
+                                  props={
+                                    Object {
+                                      "children": <AuthenticatedRoute
+                                        authenticated={true}
+                                        component={[Function]}
+                                        path="/dashboard"
+                                      />,
+                                    }
+                                  }
+                                  wrappingComponentProps={null}
+                                />,
+                              },
+                              "tag": 0,
+                            },
+                          },
+                        },
+                        "child": [Circular],
+                        "childExpirationTime": 0,
+                        "contextDependencies": null,
+                        "effectTag": 32,
+                        "elementType": null,
+                        "expirationTime": 0,
+                        "firstEffect": [Circular],
+                        "index": 0,
+                        "key": null,
+                        "lastEffect": [Circular],
+                        "memoizedProps": null,
+                        "memoizedState": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={
+                              Object {
+                                "children": <AuthenticatedRoute
+                                  authenticated={true}
+                                  component={[Function]}
+                                  path="/dashboard"
+                                />,
+                              }
+                            }
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "mode": 0,
+                        "nextEffect": null,
+                        "pendingProps": null,
+                        "ref": null,
+                        "return": null,
+                        "selfBaseDuration": 0,
+                        "sibling": null,
+                        "stateNode": Object {
+                          "containerInfo": <div />,
+                          "context": Object {},
+                          "current": [Circular],
+                          "didError": false,
+                          "earliestPendingTime": 0,
+                          "earliestSuspendedTime": 0,
+                          "expirationTime": 0,
+                          "finishedWork": null,
+                          "firstBatch": null,
+                          "hydrate": false,
+                          "interactionThreadID": 15,
+                          "latestPendingTime": 0,
+                          "latestPingedTime": 0,
+                          "latestSuspendedTime": 0,
+                          "memoizedInteractions": Set {},
+                          "nextExpirationTimeToWorkOn": 0,
+                          "nextScheduledRoot": null,
+                          "pendingChildren": null,
+                          "pendingCommitExpirationTime": 0,
+                          "pendingContext": null,
+                          "pendingInteractionMap": Map {},
+                          "pingCache": null,
+                          "timeoutHandle": -1,
+                        },
+                        "tag": 3,
+                        "treeBaseDuration": 0,
+                        "type": null,
+                        "updateQueue": Object {
+                          "baseState": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={
+                                Object {
+                                  "children": <AuthenticatedRoute
+                                    authenticated={true}
+                                    component={[Function]}
+                                    path="/dashboard"
+                                  />,
+                                }
+                              }
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "firstCapturedEffect": null,
+                          "firstCapturedUpdate": null,
+                          "firstEffect": null,
+                          "firstUpdate": null,
+                          "lastCapturedEffect": null,
+                          "lastCapturedUpdate": null,
+                          "lastEffect": null,
+                          "lastUpdate": null,
+                        },
+                      },
+                      "pendingProps": Object {
+                        "Component": [Function],
+                        "context": null,
+                        "props": Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        },
+                        "wrappingComponentProps": null,
+                      },
+                      "ref": null,
+                      "return": FiberNode {
+                        "_debugHookTypes": null,
+                        "_debugID": 60,
+                        "_debugIsCurrentlyTiming": false,
+                        "_debugOwner": null,
+                        "_debugSource": null,
+                        "actualDuration": 0,
+                        "actualStartTime": -1,
+                        "alternate": FiberNode {
+                          "_debugHookTypes": null,
+                          "_debugID": 60,
+                          "_debugIsCurrentlyTiming": false,
+                          "_debugOwner": null,
+                          "_debugSource": null,
+                          "actualDuration": 0,
+                          "actualStartTime": -1,
+                          "alternate": [Circular],
+                          "child": null,
+                          "childExpirationTime": 0,
+                          "contextDependencies": null,
+                          "effectTag": 0,
+                          "elementType": null,
+                          "expirationTime": 1073741823,
+                          "firstEffect": null,
+                          "index": 0,
+                          "key": null,
+                          "lastEffect": null,
+                          "memoizedProps": null,
+                          "memoizedState": null,
+                          "mode": 0,
+                          "nextEffect": null,
+                          "pendingProps": null,
+                          "ref": null,
+                          "return": null,
+                          "selfBaseDuration": 0,
+                          "sibling": null,
+                          "stateNode": Object {
+                            "containerInfo": <div />,
+                            "context": Object {},
+                            "current": [Circular],
+                            "didError": false,
+                            "earliestPendingTime": 0,
+                            "earliestSuspendedTime": 0,
+                            "expirationTime": 0,
+                            "finishedWork": null,
+                            "firstBatch": null,
+                            "hydrate": false,
+                            "interactionThreadID": 15,
+                            "latestPendingTime": 0,
+                            "latestPingedTime": 0,
+                            "latestSuspendedTime": 0,
+                            "memoizedInteractions": Set {},
+                            "nextExpirationTimeToWorkOn": 0,
+                            "nextScheduledRoot": null,
+                            "pendingChildren": null,
+                            "pendingCommitExpirationTime": 0,
+                            "pendingContext": null,
+                            "pendingInteractionMap": Map {},
+                            "pingCache": null,
+                            "timeoutHandle": -1,
+                          },
+                          "tag": 3,
+                          "treeBaseDuration": 0,
+                          "type": null,
+                          "updateQueue": Object {
+                            "baseState": null,
+                            "firstCapturedEffect": null,
+                            "firstCapturedUpdate": null,
+                            "firstEffect": null,
+                            "firstUpdate": Object {
+                              "callback": null,
+                              "expirationTime": 1073741823,
+                              "next": null,
+                              "nextEffect": null,
+                              "payload": Object {
+                                "element": <WrapperComponent
+                                  Component={[Function]}
+                                  context={null}
+                                  props={
+                                    Object {
+                                      "children": <AuthenticatedRoute
+                                        authenticated={true}
+                                        component={[Function]}
+                                        path="/dashboard"
+                                      />,
+                                    }
+                                  }
+                                  wrappingComponentProps={null}
+                                />,
+                              },
+                              "tag": 0,
+                            },
+                            "lastCapturedEffect": null,
+                            "lastCapturedUpdate": null,
+                            "lastEffect": null,
+                            "lastUpdate": Object {
+                              "callback": null,
+                              "expirationTime": 1073741823,
+                              "next": null,
+                              "nextEffect": null,
+                              "payload": Object {
+                                "element": <WrapperComponent
+                                  Component={[Function]}
+                                  context={null}
+                                  props={
+                                    Object {
+                                      "children": <AuthenticatedRoute
+                                        authenticated={true}
+                                        component={[Function]}
+                                        path="/dashboard"
+                                      />,
+                                    }
+                                  }
+                                  wrappingComponentProps={null}
+                                />,
+                              },
+                              "tag": 0,
+                            },
+                          },
+                        },
+                        "child": [Circular],
+                        "childExpirationTime": 0,
+                        "contextDependencies": null,
+                        "effectTag": 32,
+                        "elementType": null,
+                        "expirationTime": 0,
+                        "firstEffect": [Circular],
+                        "index": 0,
+                        "key": null,
+                        "lastEffect": [Circular],
+                        "memoizedProps": null,
+                        "memoizedState": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={
+                              Object {
+                                "children": <AuthenticatedRoute
+                                  authenticated={true}
+                                  component={[Function]}
+                                  path="/dashboard"
+                                />,
+                              }
+                            }
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "mode": 0,
+                        "nextEffect": null,
+                        "pendingProps": null,
+                        "ref": null,
+                        "return": null,
+                        "selfBaseDuration": 0,
+                        "sibling": null,
+                        "stateNode": Object {
+                          "containerInfo": <div />,
+                          "context": Object {},
+                          "current": [Circular],
+                          "didError": false,
+                          "earliestPendingTime": 0,
+                          "earliestSuspendedTime": 0,
+                          "expirationTime": 0,
+                          "finishedWork": null,
+                          "firstBatch": null,
+                          "hydrate": false,
+                          "interactionThreadID": 15,
+                          "latestPendingTime": 0,
+                          "latestPingedTime": 0,
+                          "latestSuspendedTime": 0,
+                          "memoizedInteractions": Set {},
+                          "nextExpirationTimeToWorkOn": 0,
+                          "nextScheduledRoot": null,
+                          "pendingChildren": null,
+                          "pendingCommitExpirationTime": 0,
+                          "pendingContext": null,
+                          "pendingInteractionMap": Map {},
+                          "pingCache": null,
+                          "timeoutHandle": -1,
+                        },
+                        "tag": 3,
+                        "treeBaseDuration": 0,
+                        "type": null,
+                        "updateQueue": Object {
+                          "baseState": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={
+                                Object {
+                                  "children": <AuthenticatedRoute
+                                    authenticated={true}
+                                    component={[Function]}
+                                    path="/dashboard"
+                                  />,
+                                }
+                              }
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "firstCapturedEffect": null,
+                          "firstCapturedUpdate": null,
+                          "firstEffect": null,
+                          "firstUpdate": null,
+                          "lastCapturedEffect": null,
+                          "lastCapturedUpdate": null,
+                          "lastEffect": null,
+                          "lastUpdate": null,
+                        },
+                      },
+                      "selfBaseDuration": 0,
+                      "sibling": null,
+                      "stateNode": WrapperComponent {
+                        "_reactInternalFiber": [Circular],
+                        "_reactInternalInstance": Object {},
+                        "context": Object {},
+                        "props": Object {
+                          "Component": [Function],
+                          "context": null,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "refs": Object {},
+                        "rootFinderInstance": null,
+                        "state": Object {
+                          "context": null,
+                          "mount": true,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "updater": Object {
+                          "enqueueForceUpdate": [Function],
+                          "enqueueReplaceState": [Function],
+                          "enqueueSetState": [Function],
+                          "isMounted": [Function],
+                        },
+                      },
+                      "tag": 1,
+                      "treeBaseDuration": 0,
+                      "type": [Function],
+                      "updateQueue": null,
+                    },
+                    "_debugSource": null,
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": null,
+                    "child": [Circular],
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 1,
+                    "elementType": [Function],
+                    "expirationTime": 0,
+                    "firstEffect": null,
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": null,
+                    "memoizedProps": Object {
+                      "children": <AuthenticatedRoute
+                        authenticated={true}
+                        component={[Function]}
+                        path="/dashboard"
+                      />,
+                    },
+                    "memoizedState": null,
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": Object {
+                      "children": <AuthenticatedRoute
+                        authenticated={true}
+                        component={[Function]}
+                        path="/dashboard"
+                      />,
+                    },
+                    "ref": null,
+                    "return": FiberNode {
+                      "_debugHookTypes": null,
+                      "_debugID": 62,
+                      "_debugIsCurrentlyTiming": false,
+                      "_debugOwner": null,
+                      "_debugSource": null,
+                      "actualDuration": 0,
+                      "actualStartTime": -1,
+                      "alternate": null,
+                      "child": [Circular],
+                      "childExpirationTime": 0,
+                      "contextDependencies": null,
+                      "effectTag": 1,
+                      "elementType": [Function],
+                      "expirationTime": 0,
+                      "firstEffect": null,
+                      "index": 0,
+                      "key": null,
+                      "lastEffect": null,
+                      "memoizedProps": Object {
+                        "Component": [Function],
+                        "context": null,
+                        "props": Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        },
+                        "wrappingComponentProps": null,
+                      },
+                      "memoizedState": Object {
+                        "context": null,
+                        "mount": true,
+                        "props": Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        },
+                        "wrappingComponentProps": null,
+                      },
+                      "mode": 0,
+                      "nextEffect": FiberNode {
+                        "_debugHookTypes": null,
+                        "_debugID": 60,
+                        "_debugIsCurrentlyTiming": false,
+                        "_debugOwner": null,
+                        "_debugSource": null,
+                        "actualDuration": 0,
+                        "actualStartTime": -1,
+                        "alternate": FiberNode {
+                          "_debugHookTypes": null,
+                          "_debugID": 60,
+                          "_debugIsCurrentlyTiming": false,
+                          "_debugOwner": null,
+                          "_debugSource": null,
+                          "actualDuration": 0,
+                          "actualStartTime": -1,
+                          "alternate": [Circular],
+                          "child": null,
+                          "childExpirationTime": 0,
+                          "contextDependencies": null,
+                          "effectTag": 0,
+                          "elementType": null,
+                          "expirationTime": 1073741823,
+                          "firstEffect": null,
+                          "index": 0,
+                          "key": null,
+                          "lastEffect": null,
+                          "memoizedProps": null,
+                          "memoizedState": null,
+                          "mode": 0,
+                          "nextEffect": null,
+                          "pendingProps": null,
+                          "ref": null,
+                          "return": null,
+                          "selfBaseDuration": 0,
+                          "sibling": null,
+                          "stateNode": Object {
+                            "containerInfo": <div />,
+                            "context": Object {},
+                            "current": [Circular],
+                            "didError": false,
+                            "earliestPendingTime": 0,
+                            "earliestSuspendedTime": 0,
+                            "expirationTime": 0,
+                            "finishedWork": null,
+                            "firstBatch": null,
+                            "hydrate": false,
+                            "interactionThreadID": 15,
+                            "latestPendingTime": 0,
+                            "latestPingedTime": 0,
+                            "latestSuspendedTime": 0,
+                            "memoizedInteractions": Set {},
+                            "nextExpirationTimeToWorkOn": 0,
+                            "nextScheduledRoot": null,
+                            "pendingChildren": null,
+                            "pendingCommitExpirationTime": 0,
+                            "pendingContext": null,
+                            "pendingInteractionMap": Map {},
+                            "pingCache": null,
+                            "timeoutHandle": -1,
+                          },
+                          "tag": 3,
+                          "treeBaseDuration": 0,
+                          "type": null,
+                          "updateQueue": Object {
+                            "baseState": null,
+                            "firstCapturedEffect": null,
+                            "firstCapturedUpdate": null,
+                            "firstEffect": null,
+                            "firstUpdate": Object {
+                              "callback": null,
+                              "expirationTime": 1073741823,
+                              "next": null,
+                              "nextEffect": null,
+                              "payload": Object {
+                                "element": <WrapperComponent
+                                  Component={[Function]}
+                                  context={null}
+                                  props={
+                                    Object {
+                                      "children": <AuthenticatedRoute
+                                        authenticated={true}
+                                        component={[Function]}
+                                        path="/dashboard"
+                                      />,
+                                    }
+                                  }
+                                  wrappingComponentProps={null}
+                                />,
+                              },
+                              "tag": 0,
+                            },
+                            "lastCapturedEffect": null,
+                            "lastCapturedUpdate": null,
+                            "lastEffect": null,
+                            "lastUpdate": Object {
+                              "callback": null,
+                              "expirationTime": 1073741823,
+                              "next": null,
+                              "nextEffect": null,
+                              "payload": Object {
+                                "element": <WrapperComponent
+                                  Component={[Function]}
+                                  context={null}
+                                  props={
+                                    Object {
+                                      "children": <AuthenticatedRoute
+                                        authenticated={true}
+                                        component={[Function]}
+                                        path="/dashboard"
+                                      />,
+                                    }
+                                  }
+                                  wrappingComponentProps={null}
+                                />,
+                              },
+                              "tag": 0,
+                            },
+                          },
+                        },
+                        "child": [Circular],
+                        "childExpirationTime": 0,
+                        "contextDependencies": null,
+                        "effectTag": 32,
+                        "elementType": null,
+                        "expirationTime": 0,
+                        "firstEffect": [Circular],
+                        "index": 0,
+                        "key": null,
+                        "lastEffect": [Circular],
+                        "memoizedProps": null,
+                        "memoizedState": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={
+                              Object {
+                                "children": <AuthenticatedRoute
+                                  authenticated={true}
+                                  component={[Function]}
+                                  path="/dashboard"
+                                />,
+                              }
+                            }
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "mode": 0,
+                        "nextEffect": null,
+                        "pendingProps": null,
+                        "ref": null,
+                        "return": null,
+                        "selfBaseDuration": 0,
+                        "sibling": null,
+                        "stateNode": Object {
+                          "containerInfo": <div />,
+                          "context": Object {},
+                          "current": [Circular],
+                          "didError": false,
+                          "earliestPendingTime": 0,
+                          "earliestSuspendedTime": 0,
+                          "expirationTime": 0,
+                          "finishedWork": null,
+                          "firstBatch": null,
+                          "hydrate": false,
+                          "interactionThreadID": 15,
+                          "latestPendingTime": 0,
+                          "latestPingedTime": 0,
+                          "latestSuspendedTime": 0,
+                          "memoizedInteractions": Set {},
+                          "nextExpirationTimeToWorkOn": 0,
+                          "nextScheduledRoot": null,
+                          "pendingChildren": null,
+                          "pendingCommitExpirationTime": 0,
+                          "pendingContext": null,
+                          "pendingInteractionMap": Map {},
+                          "pingCache": null,
+                          "timeoutHandle": -1,
+                        },
+                        "tag": 3,
+                        "treeBaseDuration": 0,
+                        "type": null,
+                        "updateQueue": Object {
+                          "baseState": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={
+                                Object {
+                                  "children": <AuthenticatedRoute
+                                    authenticated={true}
+                                    component={[Function]}
+                                    path="/dashboard"
+                                  />,
+                                }
+                              }
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "firstCapturedEffect": null,
+                          "firstCapturedUpdate": null,
+                          "firstEffect": null,
+                          "firstUpdate": null,
+                          "lastCapturedEffect": null,
+                          "lastCapturedUpdate": null,
+                          "lastEffect": null,
+                          "lastUpdate": null,
+                        },
+                      },
+                      "pendingProps": Object {
+                        "Component": [Function],
+                        "context": null,
+                        "props": Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        },
+                        "wrappingComponentProps": null,
+                      },
+                      "ref": null,
+                      "return": FiberNode {
+                        "_debugHookTypes": null,
+                        "_debugID": 60,
+                        "_debugIsCurrentlyTiming": false,
+                        "_debugOwner": null,
+                        "_debugSource": null,
+                        "actualDuration": 0,
+                        "actualStartTime": -1,
+                        "alternate": FiberNode {
+                          "_debugHookTypes": null,
+                          "_debugID": 60,
+                          "_debugIsCurrentlyTiming": false,
+                          "_debugOwner": null,
+                          "_debugSource": null,
+                          "actualDuration": 0,
+                          "actualStartTime": -1,
+                          "alternate": [Circular],
+                          "child": null,
+                          "childExpirationTime": 0,
+                          "contextDependencies": null,
+                          "effectTag": 0,
+                          "elementType": null,
+                          "expirationTime": 1073741823,
+                          "firstEffect": null,
+                          "index": 0,
+                          "key": null,
+                          "lastEffect": null,
+                          "memoizedProps": null,
+                          "memoizedState": null,
+                          "mode": 0,
+                          "nextEffect": null,
+                          "pendingProps": null,
+                          "ref": null,
+                          "return": null,
+                          "selfBaseDuration": 0,
+                          "sibling": null,
+                          "stateNode": Object {
+                            "containerInfo": <div />,
+                            "context": Object {},
+                            "current": [Circular],
+                            "didError": false,
+                            "earliestPendingTime": 0,
+                            "earliestSuspendedTime": 0,
+                            "expirationTime": 0,
+                            "finishedWork": null,
+                            "firstBatch": null,
+                            "hydrate": false,
+                            "interactionThreadID": 15,
+                            "latestPendingTime": 0,
+                            "latestPingedTime": 0,
+                            "latestSuspendedTime": 0,
+                            "memoizedInteractions": Set {},
+                            "nextExpirationTimeToWorkOn": 0,
+                            "nextScheduledRoot": null,
+                            "pendingChildren": null,
+                            "pendingCommitExpirationTime": 0,
+                            "pendingContext": null,
+                            "pendingInteractionMap": Map {},
+                            "pingCache": null,
+                            "timeoutHandle": -1,
+                          },
+                          "tag": 3,
+                          "treeBaseDuration": 0,
+                          "type": null,
+                          "updateQueue": Object {
+                            "baseState": null,
+                            "firstCapturedEffect": null,
+                            "firstCapturedUpdate": null,
+                            "firstEffect": null,
+                            "firstUpdate": Object {
+                              "callback": null,
+                              "expirationTime": 1073741823,
+                              "next": null,
+                              "nextEffect": null,
+                              "payload": Object {
+                                "element": <WrapperComponent
+                                  Component={[Function]}
+                                  context={null}
+                                  props={
+                                    Object {
+                                      "children": <AuthenticatedRoute
+                                        authenticated={true}
+                                        component={[Function]}
+                                        path="/dashboard"
+                                      />,
+                                    }
+                                  }
+                                  wrappingComponentProps={null}
+                                />,
+                              },
+                              "tag": 0,
+                            },
+                            "lastCapturedEffect": null,
+                            "lastCapturedUpdate": null,
+                            "lastEffect": null,
+                            "lastUpdate": Object {
+                              "callback": null,
+                              "expirationTime": 1073741823,
+                              "next": null,
+                              "nextEffect": null,
+                              "payload": Object {
+                                "element": <WrapperComponent
+                                  Component={[Function]}
+                                  context={null}
+                                  props={
+                                    Object {
+                                      "children": <AuthenticatedRoute
+                                        authenticated={true}
+                                        component={[Function]}
+                                        path="/dashboard"
+                                      />,
+                                    }
+                                  }
+                                  wrappingComponentProps={null}
+                                />,
+                              },
+                              "tag": 0,
+                            },
+                          },
+                        },
+                        "child": [Circular],
+                        "childExpirationTime": 0,
+                        "contextDependencies": null,
+                        "effectTag": 32,
+                        "elementType": null,
+                        "expirationTime": 0,
+                        "firstEffect": [Circular],
+                        "index": 0,
+                        "key": null,
+                        "lastEffect": [Circular],
+                        "memoizedProps": null,
+                        "memoizedState": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={
+                              Object {
+                                "children": <AuthenticatedRoute
+                                  authenticated={true}
+                                  component={[Function]}
+                                  path="/dashboard"
+                                />,
+                              }
+                            }
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "mode": 0,
+                        "nextEffect": null,
+                        "pendingProps": null,
+                        "ref": null,
+                        "return": null,
+                        "selfBaseDuration": 0,
+                        "sibling": null,
+                        "stateNode": Object {
+                          "containerInfo": <div />,
+                          "context": Object {},
+                          "current": [Circular],
+                          "didError": false,
+                          "earliestPendingTime": 0,
+                          "earliestSuspendedTime": 0,
+                          "expirationTime": 0,
+                          "finishedWork": null,
+                          "firstBatch": null,
+                          "hydrate": false,
+                          "interactionThreadID": 15,
+                          "latestPendingTime": 0,
+                          "latestPingedTime": 0,
+                          "latestSuspendedTime": 0,
+                          "memoizedInteractions": Set {},
+                          "nextExpirationTimeToWorkOn": 0,
+                          "nextScheduledRoot": null,
+                          "pendingChildren": null,
+                          "pendingCommitExpirationTime": 0,
+                          "pendingContext": null,
+                          "pendingInteractionMap": Map {},
+                          "pingCache": null,
+                          "timeoutHandle": -1,
+                        },
+                        "tag": 3,
+                        "treeBaseDuration": 0,
+                        "type": null,
+                        "updateQueue": Object {
+                          "baseState": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={
+                                Object {
+                                  "children": <AuthenticatedRoute
+                                    authenticated={true}
+                                    component={[Function]}
+                                    path="/dashboard"
+                                  />,
+                                }
+                              }
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "firstCapturedEffect": null,
+                          "firstCapturedUpdate": null,
+                          "firstEffect": null,
+                          "firstUpdate": null,
+                          "lastCapturedEffect": null,
+                          "lastCapturedUpdate": null,
+                          "lastEffect": null,
+                          "lastUpdate": null,
+                        },
+                      },
+                      "selfBaseDuration": 0,
+                      "sibling": null,
+                      "stateNode": WrapperComponent {
+                        "_reactInternalFiber": [Circular],
+                        "_reactInternalInstance": Object {},
+                        "context": Object {},
+                        "props": Object {
+                          "Component": [Function],
+                          "context": null,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "refs": Object {},
+                        "rootFinderInstance": null,
+                        "state": Object {
+                          "context": null,
+                          "mount": true,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "updater": Object {
+                          "enqueueForceUpdate": [Function],
+                          "enqueueReplaceState": [Function],
+                          "enqueueSetState": [Function],
+                          "isMounted": [Function],
+                        },
+                      },
+                      "tag": 1,
+                      "treeBaseDuration": 0,
+                      "type": [Function],
+                      "updateQueue": null,
+                    },
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": BrowserRouter {
+                      "_reactInternalFiber": [Circular],
+                      "_reactInternalInstance": Object {},
+                      "context": Object {},
+                      "history": Object {
+                        "action": "POP",
+                        "block": [Function],
+                        "createHref": [Function],
+                        "go": [Function],
+                        "goBack": [Function],
+                        "goForward": [Function],
+                        "length": 1,
+                        "listen": [Function],
+                        "location": Object {
+                          "hash": "",
+                          "pathname": "/",
+                          "search": "",
+                          "state": undefined,
+                        },
+                        "push": [Function],
+                        "replace": [Function],
+                      },
+                      "props": Object {
+                        "children": <AuthenticatedRoute
+                          authenticated={true}
+                          component={[Function]}
+                          path="/dashboard"
+                        />,
+                      },
+                      "refs": Object {},
+                      "state": null,
+                      "updater": Object {
+                        "enqueueForceUpdate": [Function],
+                        "enqueueReplaceState": [Function],
+                        "enqueueSetState": [Function],
+                        "isMounted": [Function],
+                      },
+                    },
+                    "tag": 1,
+                    "treeBaseDuration": 0,
+                    "type": [Function],
+                    "updateQueue": null,
+                  },
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": Router {
+                    "__reactInternalMemoizedMaskedChildContext": Object {
+                      "router": undefined,
+                    },
+                    "__reactInternalMemoizedMergedChildContext": Object {
+                      "router": Object {
+                        "history": Object {
+                          "action": "POP",
+                          "block": [Function],
+                          "createHref": [Function],
+                          "go": [Function],
+                          "goBack": [Function],
+                          "goForward": [Function],
+                          "length": 1,
+                          "listen": [Function],
+                          "location": Object {
+                            "hash": "",
+                            "pathname": "/",
+                            "search": "",
+                            "state": undefined,
+                          },
+                          "push": [Function],
+                          "replace": [Function],
+                        },
+                        "route": Object {
+                          "location": Object {
+                            "hash": "",
+                            "pathname": "/",
+                            "search": "",
+                            "state": undefined,
+                          },
+                          "match": Object {
+                            "isExact": true,
+                            "params": Object {},
+                            "path": "/",
+                            "url": "/",
+                          },
+                        },
+                      },
+                    },
+                    "__reactInternalMemoizedUnmaskedChildContext": Object {},
+                    "_reactInternalFiber": [Circular],
+                    "_reactInternalInstance": Object {},
+                    "context": Object {
+                      "router": undefined,
+                    },
+                    "props": Object {
+                      "children": <AuthenticatedRoute
+                        authenticated={true}
+                        component={[Function]}
+                        path="/dashboard"
+                      />,
+                      "history": Object {
+                        "action": "POP",
+                        "block": [Function],
+                        "createHref": [Function],
+                        "go": [Function],
+                        "goBack": [Function],
+                        "goForward": [Function],
+                        "length": 1,
+                        "listen": [Function],
+                        "location": Object {
+                          "hash": "",
+                          "pathname": "/",
+                          "search": "",
+                          "state": undefined,
+                        },
+                        "push": [Function],
+                        "replace": [Function],
+                      },
+                    },
+                    "refs": Object {},
+                    "state": Object {
+                      "match": Object {
+                        "isExact": true,
+                        "params": Object {},
+                        "path": "/",
+                        "url": "/",
+                      },
+                    },
+                    "unlisten": [Function],
+                    "updater": Object {
+                      "enqueueForceUpdate": [Function],
+                      "enqueueReplaceState": [Function],
+                      "enqueueSetState": [Function],
+                      "isMounted": [Function],
+                    },
+                  },
+                  "tag": 1,
+                  "treeBaseDuration": 0,
+                  "type": [Function],
+                  "updateQueue": null,
+                },
+                "selfBaseDuration": 0,
+                "sibling": null,
+                "stateNode": null,
+                "tag": 0,
+                "treeBaseDuration": 0,
+                "type": [Function],
+                "updateQueue": null,
+              },
+              "selfBaseDuration": 0,
+              "sibling": null,
+              "stateNode": [Circular],
+              "tag": 1,
+              "treeBaseDuration": 0,
+              "type": [Function],
+              "updateQueue": null,
+            },
+            "_reactInternalInstance": Object {},
+            "context": Object {
+              "router": Object {
+                "history": Object {
+                  "action": "POP",
+                  "block": [Function],
+                  "createHref": [Function],
+                  "go": [Function],
+                  "goBack": [Function],
+                  "goForward": [Function],
+                  "length": 1,
+                  "listen": [Function],
+                  "location": Object {
+                    "hash": "",
+                    "pathname": "/",
+                    "search": "",
+                    "state": undefined,
+                  },
+                  "push": [Function],
+                  "replace": [Function],
+                },
+                "route": Object {
+                  "location": Object {
+                    "hash": "",
+                    "pathname": "/",
+                    "search": "",
+                    "state": undefined,
+                  },
+                  "match": Object {
+                    "isExact": true,
+                    "params": Object {},
+                    "path": "/",
+                    "url": "/",
+                  },
+                },
+              },
+            },
+            "props": Object {
+              "path": "/dashboard",
+              "render": [Function],
+            },
+            "refs": Object {},
+            "state": Object {
+              "match": null,
+            },
+            "updater": Object {
+              "enqueueForceUpdate": [Function],
+              "enqueueReplaceState": [Function],
+              "enqueueSetState": [Function],
+              "isMounted": [Function],
+            },
+          },
+          "key": undefined,
+          "nodeType": "class",
+          "props": Object {
+            "path": "/dashboard",
+            "render": [Function],
+          },
+          "ref": null,
+          "rendered": null,
+          "type": [Function],
+        },
+        "type": [Function],
+      },
+      "type": [Function],
+    },
+    "type": [Function],
+  },
+  Symbol(enzyme.__nodes__): Array [
+    Object {
+      "instance": BrowserRouter {
+        "_reactInternalFiber": FiberNode {
+          "_debugHookTypes": null,
+          "_debugID": 63,
+          "_debugIsCurrentlyTiming": false,
+          "_debugOwner": FiberNode {
+            "_debugHookTypes": null,
+            "_debugID": 62,
+            "_debugIsCurrentlyTiming": false,
+            "_debugOwner": null,
+            "_debugSource": null,
+            "actualDuration": 0,
+            "actualStartTime": -1,
+            "alternate": null,
+            "child": [Circular],
+            "childExpirationTime": 0,
+            "contextDependencies": null,
+            "effectTag": 1,
+            "elementType": [Function],
+            "expirationTime": 0,
+            "firstEffect": null,
+            "index": 0,
+            "key": null,
+            "lastEffect": null,
+            "memoizedProps": Object {
+              "Component": [Function],
+              "context": null,
+              "props": Object {
+                "children": <AuthenticatedRoute
+                  authenticated={true}
+                  component={[Function]}
+                  path="/dashboard"
+                />,
+              },
+              "wrappingComponentProps": null,
+            },
+            "memoizedState": Object {
+              "context": null,
+              "mount": true,
+              "props": Object {
+                "children": <AuthenticatedRoute
+                  authenticated={true}
+                  component={[Function]}
+                  path="/dashboard"
+                />,
+              },
+              "wrappingComponentProps": null,
+            },
+            "mode": 0,
+            "nextEffect": FiberNode {
+              "_debugHookTypes": null,
+              "_debugID": 60,
+              "_debugIsCurrentlyTiming": false,
+              "_debugOwner": null,
+              "_debugSource": null,
+              "actualDuration": 0,
+              "actualStartTime": -1,
+              "alternate": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 60,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": null,
+                "_debugSource": null,
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": [Circular],
+                "child": null,
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 0,
+                "elementType": null,
+                "expirationTime": 1073741823,
+                "firstEffect": null,
+                "index": 0,
+                "key": null,
+                "lastEffect": null,
+                "memoizedProps": null,
+                "memoizedState": null,
+                "mode": 0,
+                "nextEffect": null,
+                "pendingProps": null,
+                "ref": null,
+                "return": null,
+                "selfBaseDuration": 0,
+                "sibling": null,
+                "stateNode": Object {
+                  "containerInfo": <div />,
+                  "context": Object {},
+                  "current": [Circular],
+                  "didError": false,
+                  "earliestPendingTime": 0,
+                  "earliestSuspendedTime": 0,
+                  "expirationTime": 0,
+                  "finishedWork": null,
+                  "firstBatch": null,
+                  "hydrate": false,
+                  "interactionThreadID": 15,
+                  "latestPendingTime": 0,
+                  "latestPingedTime": 0,
+                  "latestSuspendedTime": 0,
+                  "memoizedInteractions": Set {},
+                  "nextExpirationTimeToWorkOn": 0,
+                  "nextScheduledRoot": null,
+                  "pendingChildren": null,
+                  "pendingCommitExpirationTime": 0,
+                  "pendingContext": null,
+                  "pendingInteractionMap": Map {},
+                  "pingCache": null,
+                  "timeoutHandle": -1,
+                },
+                "tag": 3,
+                "treeBaseDuration": 0,
+                "type": null,
+                "updateQueue": Object {
+                  "baseState": null,
+                  "firstCapturedEffect": null,
+                  "firstCapturedUpdate": null,
+                  "firstEffect": null,
+                  "firstUpdate": Object {
+                    "callback": null,
+                    "expirationTime": 1073741823,
+                    "next": null,
+                    "nextEffect": null,
+                    "payload": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={
+                          Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          }
+                        }
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "tag": 0,
+                  },
+                  "lastCapturedEffect": null,
+                  "lastCapturedUpdate": null,
+                  "lastEffect": null,
+                  "lastUpdate": Object {
+                    "callback": null,
+                    "expirationTime": 1073741823,
+                    "next": null,
+                    "nextEffect": null,
+                    "payload": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={
+                          Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          }
+                        }
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "tag": 0,
+                  },
+                },
+              },
+              "child": [Circular],
+              "childExpirationTime": 0,
+              "contextDependencies": null,
+              "effectTag": 32,
+              "elementType": null,
+              "expirationTime": 0,
+              "firstEffect": [Circular],
+              "index": 0,
+              "key": null,
+              "lastEffect": [Circular],
+              "memoizedProps": null,
+              "memoizedState": Object {
+                "element": <WrapperComponent
+                  Component={[Function]}
+                  context={null}
+                  props={
+                    Object {
+                      "children": <AuthenticatedRoute
+                        authenticated={true}
+                        component={[Function]}
+                        path="/dashboard"
+                      />,
+                    }
+                  }
+                  wrappingComponentProps={null}
+                />,
+              },
+              "mode": 0,
+              "nextEffect": null,
+              "pendingProps": null,
+              "ref": null,
+              "return": null,
+              "selfBaseDuration": 0,
+              "sibling": null,
+              "stateNode": Object {
+                "containerInfo": <div />,
+                "context": Object {},
+                "current": [Circular],
+                "didError": false,
+                "earliestPendingTime": 0,
+                "earliestSuspendedTime": 0,
+                "expirationTime": 0,
+                "finishedWork": null,
+                "firstBatch": null,
+                "hydrate": false,
+                "interactionThreadID": 15,
+                "latestPendingTime": 0,
+                "latestPingedTime": 0,
+                "latestSuspendedTime": 0,
+                "memoizedInteractions": Set {},
+                "nextExpirationTimeToWorkOn": 0,
+                "nextScheduledRoot": null,
+                "pendingChildren": null,
+                "pendingCommitExpirationTime": 0,
+                "pendingContext": null,
+                "pendingInteractionMap": Map {},
+                "pingCache": null,
+                "timeoutHandle": -1,
+              },
+              "tag": 3,
+              "treeBaseDuration": 0,
+              "type": null,
+              "updateQueue": Object {
+                "baseState": Object {
+                  "element": <WrapperComponent
+                    Component={[Function]}
+                    context={null}
+                    props={
+                      Object {
+                        "children": <AuthenticatedRoute
+                          authenticated={true}
+                          component={[Function]}
+                          path="/dashboard"
+                        />,
+                      }
+                    }
+                    wrappingComponentProps={null}
+                  />,
+                },
+                "firstCapturedEffect": null,
+                "firstCapturedUpdate": null,
+                "firstEffect": null,
+                "firstUpdate": null,
+                "lastCapturedEffect": null,
+                "lastCapturedUpdate": null,
+                "lastEffect": null,
+                "lastUpdate": null,
+              },
+            },
+            "pendingProps": Object {
+              "Component": [Function],
+              "context": null,
+              "props": Object {
+                "children": <AuthenticatedRoute
+                  authenticated={true}
+                  component={[Function]}
+                  path="/dashboard"
+                />,
+              },
+              "wrappingComponentProps": null,
+            },
+            "ref": null,
+            "return": FiberNode {
+              "_debugHookTypes": null,
+              "_debugID": 60,
+              "_debugIsCurrentlyTiming": false,
+              "_debugOwner": null,
+              "_debugSource": null,
+              "actualDuration": 0,
+              "actualStartTime": -1,
+              "alternate": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 60,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": null,
+                "_debugSource": null,
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": [Circular],
+                "child": null,
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 0,
+                "elementType": null,
+                "expirationTime": 1073741823,
+                "firstEffect": null,
+                "index": 0,
+                "key": null,
+                "lastEffect": null,
+                "memoizedProps": null,
+                "memoizedState": null,
+                "mode": 0,
+                "nextEffect": null,
+                "pendingProps": null,
+                "ref": null,
+                "return": null,
+                "selfBaseDuration": 0,
+                "sibling": null,
+                "stateNode": Object {
+                  "containerInfo": <div />,
+                  "context": Object {},
+                  "current": [Circular],
+                  "didError": false,
+                  "earliestPendingTime": 0,
+                  "earliestSuspendedTime": 0,
+                  "expirationTime": 0,
+                  "finishedWork": null,
+                  "firstBatch": null,
+                  "hydrate": false,
+                  "interactionThreadID": 15,
+                  "latestPendingTime": 0,
+                  "latestPingedTime": 0,
+                  "latestSuspendedTime": 0,
+                  "memoizedInteractions": Set {},
+                  "nextExpirationTimeToWorkOn": 0,
+                  "nextScheduledRoot": null,
+                  "pendingChildren": null,
+                  "pendingCommitExpirationTime": 0,
+                  "pendingContext": null,
+                  "pendingInteractionMap": Map {},
+                  "pingCache": null,
+                  "timeoutHandle": -1,
+                },
+                "tag": 3,
+                "treeBaseDuration": 0,
+                "type": null,
+                "updateQueue": Object {
+                  "baseState": null,
+                  "firstCapturedEffect": null,
+                  "firstCapturedUpdate": null,
+                  "firstEffect": null,
+                  "firstUpdate": Object {
+                    "callback": null,
+                    "expirationTime": 1073741823,
+                    "next": null,
+                    "nextEffect": null,
+                    "payload": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={
+                          Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          }
+                        }
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "tag": 0,
+                  },
+                  "lastCapturedEffect": null,
+                  "lastCapturedUpdate": null,
+                  "lastEffect": null,
+                  "lastUpdate": Object {
+                    "callback": null,
+                    "expirationTime": 1073741823,
+                    "next": null,
+                    "nextEffect": null,
+                    "payload": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={
+                          Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          }
+                        }
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "tag": 0,
+                  },
+                },
+              },
+              "child": [Circular],
+              "childExpirationTime": 0,
+              "contextDependencies": null,
+              "effectTag": 32,
+              "elementType": null,
+              "expirationTime": 0,
+              "firstEffect": [Circular],
+              "index": 0,
+              "key": null,
+              "lastEffect": [Circular],
+              "memoizedProps": null,
+              "memoizedState": Object {
+                "element": <WrapperComponent
+                  Component={[Function]}
+                  context={null}
+                  props={
+                    Object {
+                      "children": <AuthenticatedRoute
+                        authenticated={true}
+                        component={[Function]}
+                        path="/dashboard"
+                      />,
+                    }
+                  }
+                  wrappingComponentProps={null}
+                />,
+              },
+              "mode": 0,
+              "nextEffect": null,
+              "pendingProps": null,
+              "ref": null,
+              "return": null,
+              "selfBaseDuration": 0,
+              "sibling": null,
+              "stateNode": Object {
+                "containerInfo": <div />,
+                "context": Object {},
+                "current": [Circular],
+                "didError": false,
+                "earliestPendingTime": 0,
+                "earliestSuspendedTime": 0,
+                "expirationTime": 0,
+                "finishedWork": null,
+                "firstBatch": null,
+                "hydrate": false,
+                "interactionThreadID": 15,
+                "latestPendingTime": 0,
+                "latestPingedTime": 0,
+                "latestSuspendedTime": 0,
+                "memoizedInteractions": Set {},
+                "nextExpirationTimeToWorkOn": 0,
+                "nextScheduledRoot": null,
+                "pendingChildren": null,
+                "pendingCommitExpirationTime": 0,
+                "pendingContext": null,
+                "pendingInteractionMap": Map {},
+                "pingCache": null,
+                "timeoutHandle": -1,
+              },
+              "tag": 3,
+              "treeBaseDuration": 0,
+              "type": null,
+              "updateQueue": Object {
+                "baseState": Object {
+                  "element": <WrapperComponent
+                    Component={[Function]}
+                    context={null}
+                    props={
+                      Object {
+                        "children": <AuthenticatedRoute
+                          authenticated={true}
+                          component={[Function]}
+                          path="/dashboard"
+                        />,
+                      }
+                    }
+                    wrappingComponentProps={null}
+                  />,
+                },
+                "firstCapturedEffect": null,
+                "firstCapturedUpdate": null,
+                "firstEffect": null,
+                "firstUpdate": null,
+                "lastCapturedEffect": null,
+                "lastCapturedUpdate": null,
+                "lastEffect": null,
+                "lastUpdate": null,
+              },
+            },
+            "selfBaseDuration": 0,
+            "sibling": null,
+            "stateNode": WrapperComponent {
+              "_reactInternalFiber": [Circular],
+              "_reactInternalInstance": Object {},
+              "context": Object {},
+              "props": Object {
+                "Component": [Function],
+                "context": null,
+                "props": Object {
+                  "children": <AuthenticatedRoute
+                    authenticated={true}
+                    component={[Function]}
+                    path="/dashboard"
+                  />,
+                },
+                "wrappingComponentProps": null,
+              },
+              "refs": Object {},
+              "rootFinderInstance": null,
+              "state": Object {
+                "context": null,
+                "mount": true,
+                "props": Object {
+                  "children": <AuthenticatedRoute
+                    authenticated={true}
+                    component={[Function]}
+                    path="/dashboard"
+                  />,
+                },
+                "wrappingComponentProps": null,
+              },
+              "updater": Object {
+                "enqueueForceUpdate": [Function],
+                "enqueueReplaceState": [Function],
+                "enqueueSetState": [Function],
+                "isMounted": [Function],
+              },
+            },
+            "tag": 1,
+            "treeBaseDuration": 0,
+            "type": [Function],
+            "updateQueue": null,
+          },
+          "_debugSource": null,
+          "actualDuration": 0,
+          "actualStartTime": -1,
+          "alternate": null,
+          "child": FiberNode {
+            "_debugHookTypes": null,
+            "_debugID": 64,
+            "_debugIsCurrentlyTiming": false,
+            "_debugOwner": [Circular],
+            "_debugSource": null,
+            "actualDuration": 0,
+            "actualStartTime": -1,
+            "alternate": null,
+            "child": FiberNode {
+              "_debugHookTypes": null,
+              "_debugID": 65,
+              "_debugIsCurrentlyTiming": false,
+              "_debugOwner": null,
+              "_debugSource": Object {
+                "fileName": "/Users/home/Documents/Projects/javascript/Andela/bp-esa/bp-esa-frontend/src/App.test.jsx",
+                "lineNumber": 123,
+              },
+              "actualDuration": 0,
+              "actualStartTime": -1,
+              "alternate": null,
+              "child": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 66,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": [Circular],
+                "_debugSource": Object {
+                  "fileName": "/Users/home/Documents/Projects/javascript/Andela/bp-esa/bp-esa-frontend/src/App.jsx",
+                  "lineNumber": 15,
+                },
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": null,
+                "child": null,
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 1,
+                "elementType": [Function],
+                "expirationTime": 0,
+                "firstEffect": null,
+                "index": 0,
+                "key": null,
+                "lastEffect": null,
+                "memoizedProps": Object {
+                  "path": "/dashboard",
+                  "render": [Function],
+                },
+                "memoizedState": Object {
+                  "match": null,
+                },
+                "mode": 0,
+                "nextEffect": null,
+                "pendingProps": Object {
+                  "path": "/dashboard",
+                  "render": [Function],
+                },
+                "ref": null,
+                "return": [Circular],
+                "selfBaseDuration": 0,
+                "sibling": null,
+                "stateNode": Route {
+                  "__reactInternalMemoizedMaskedChildContext": Object {
+                    "router": Object {
+                      "history": Object {
+                        "action": "POP",
+                        "block": [Function],
+                        "createHref": [Function],
+                        "go": [Function],
+                        "goBack": [Function],
+                        "goForward": [Function],
+                        "length": 1,
+                        "listen": [Function],
+                        "location": Object {
+                          "hash": "",
+                          "pathname": "/",
+                          "search": "",
+                          "state": undefined,
+                        },
+                        "push": [Function],
+                        "replace": [Function],
+                      },
+                      "route": Object {
+                        "location": Object {
+                          "hash": "",
+                          "pathname": "/",
+                          "search": "",
+                          "state": undefined,
+                        },
+                        "match": Object {
+                          "isExact": true,
+                          "params": Object {},
+                          "path": "/",
+                          "url": "/",
+                        },
+                      },
+                    },
+                  },
+                  "__reactInternalMemoizedMergedChildContext": Object {
+                    "router": Object {
+                      "history": Object {
+                        "action": "POP",
+                        "block": [Function],
+                        "createHref": [Function],
+                        "go": [Function],
+                        "goBack": [Function],
+                        "goForward": [Function],
+                        "length": 1,
+                        "listen": [Function],
+                        "location": Object {
+                          "hash": "",
+                          "pathname": "/",
+                          "search": "",
+                          "state": undefined,
+                        },
+                        "push": [Function],
+                        "replace": [Function],
+                      },
+                      "route": Object {
+                        "location": Object {
+                          "hash": "",
+                          "pathname": "/",
+                          "search": "",
+                          "state": undefined,
+                        },
+                        "match": null,
+                      },
+                    },
+                  },
+                  "__reactInternalMemoizedUnmaskedChildContext": Object {
+                    "router": Object {
+                      "history": Object {
+                        "action": "POP",
+                        "block": [Function],
+                        "createHref": [Function],
+                        "go": [Function],
+                        "goBack": [Function],
+                        "goForward": [Function],
+                        "length": 1,
+                        "listen": [Function],
+                        "location": Object {
+                          "hash": "",
+                          "pathname": "/",
+                          "search": "",
+                          "state": undefined,
+                        },
+                        "push": [Function],
+                        "replace": [Function],
+                      },
+                      "route": Object {
+                        "location": Object {
+                          "hash": "",
+                          "pathname": "/",
+                          "search": "",
+                          "state": undefined,
+                        },
+                        "match": Object {
+                          "isExact": true,
+                          "params": Object {},
+                          "path": "/",
+                          "url": "/",
+                        },
+                      },
+                    },
+                  },
+                  "_reactInternalFiber": [Circular],
+                  "_reactInternalInstance": Object {},
+                  "context": Object {
+                    "router": Object {
+                      "history": Object {
+                        "action": "POP",
+                        "block": [Function],
+                        "createHref": [Function],
+                        "go": [Function],
+                        "goBack": [Function],
+                        "goForward": [Function],
+                        "length": 1,
+                        "listen": [Function],
+                        "location": Object {
+                          "hash": "",
+                          "pathname": "/",
+                          "search": "",
+                          "state": undefined,
+                        },
+                        "push": [Function],
+                        "replace": [Function],
+                      },
+                      "route": Object {
+                        "location": Object {
+                          "hash": "",
+                          "pathname": "/",
+                          "search": "",
+                          "state": undefined,
+                        },
+                        "match": Object {
+                          "isExact": true,
+                          "params": Object {},
+                          "path": "/",
+                          "url": "/",
+                        },
+                      },
+                    },
+                  },
+                  "props": Object {
+                    "path": "/dashboard",
+                    "render": [Function],
+                  },
+                  "refs": Object {},
+                  "state": Object {
+                    "match": null,
+                  },
+                  "updater": Object {
+                    "enqueueForceUpdate": [Function],
+                    "enqueueReplaceState": [Function],
+                    "enqueueSetState": [Function],
+                    "isMounted": [Function],
+                  },
+                },
+                "tag": 1,
+                "treeBaseDuration": 0,
+                "type": [Function],
+                "updateQueue": null,
+              },
+              "childExpirationTime": 0,
+              "contextDependencies": null,
+              "effectTag": 1,
+              "elementType": [Function],
+              "expirationTime": 0,
+              "firstEffect": null,
+              "index": 0,
+              "key": null,
+              "lastEffect": null,
+              "memoizedProps": Object {
+                "authenticated": true,
+                "component": [Function],
+                "path": "/dashboard",
+              },
+              "memoizedState": null,
+              "mode": 0,
+              "nextEffect": null,
+              "pendingProps": Object {
+                "authenticated": true,
+                "component": [Function],
+                "path": "/dashboard",
+              },
+              "ref": null,
+              "return": [Circular],
+              "selfBaseDuration": 0,
+              "sibling": null,
+              "stateNode": null,
+              "tag": 0,
+              "treeBaseDuration": 0,
+              "type": [Function],
+              "updateQueue": null,
+            },
+            "childExpirationTime": 0,
+            "contextDependencies": null,
+            "effectTag": 1,
+            "elementType": [Function],
+            "expirationTime": 0,
+            "firstEffect": null,
+            "index": 0,
+            "key": null,
+            "lastEffect": null,
+            "memoizedProps": Object {
+              "children": <AuthenticatedRoute
+                authenticated={true}
+                component={[Function]}
+                path="/dashboard"
+              />,
+              "history": Object {
+                "action": "POP",
+                "block": [Function],
+                "createHref": [Function],
+                "go": [Function],
+                "goBack": [Function],
+                "goForward": [Function],
+                "length": 1,
+                "listen": [Function],
+                "location": Object {
+                  "hash": "",
+                  "pathname": "/",
+                  "search": "",
+                  "state": undefined,
+                },
+                "push": [Function],
+                "replace": [Function],
+              },
+            },
+            "memoizedState": Object {
+              "match": Object {
+                "isExact": true,
+                "params": Object {},
+                "path": "/",
+                "url": "/",
+              },
+            },
+            "mode": 0,
+            "nextEffect": null,
+            "pendingProps": Object {
+              "children": <AuthenticatedRoute
+                authenticated={true}
+                component={[Function]}
+                path="/dashboard"
+              />,
+              "history": Object {
+                "action": "POP",
+                "block": [Function],
+                "createHref": [Function],
+                "go": [Function],
+                "goBack": [Function],
+                "goForward": [Function],
+                "length": 1,
+                "listen": [Function],
+                "location": Object {
+                  "hash": "",
+                  "pathname": "/",
+                  "search": "",
+                  "state": undefined,
+                },
+                "push": [Function],
+                "replace": [Function],
+              },
+            },
+            "ref": null,
+            "return": [Circular],
+            "selfBaseDuration": 0,
+            "sibling": null,
+            "stateNode": Router {
+              "__reactInternalMemoizedMaskedChildContext": Object {
+                "router": undefined,
+              },
+              "__reactInternalMemoizedMergedChildContext": Object {
+                "router": Object {
+                  "history": Object {
+                    "action": "POP",
+                    "block": [Function],
+                    "createHref": [Function],
+                    "go": [Function],
+                    "goBack": [Function],
+                    "goForward": [Function],
+                    "length": 1,
+                    "listen": [Function],
+                    "location": Object {
+                      "hash": "",
+                      "pathname": "/",
+                      "search": "",
+                      "state": undefined,
+                    },
+                    "push": [Function],
+                    "replace": [Function],
+                  },
+                  "route": Object {
+                    "location": Object {
+                      "hash": "",
+                      "pathname": "/",
+                      "search": "",
+                      "state": undefined,
+                    },
+                    "match": Object {
+                      "isExact": true,
+                      "params": Object {},
+                      "path": "/",
+                      "url": "/",
+                    },
+                  },
+                },
+              },
+              "__reactInternalMemoizedUnmaskedChildContext": Object {},
+              "_reactInternalFiber": [Circular],
+              "_reactInternalInstance": Object {},
+              "context": Object {
+                "router": undefined,
+              },
+              "props": Object {
+                "children": <AuthenticatedRoute
+                  authenticated={true}
+                  component={[Function]}
+                  path="/dashboard"
+                />,
+                "history": Object {
+                  "action": "POP",
+                  "block": [Function],
+                  "createHref": [Function],
+                  "go": [Function],
+                  "goBack": [Function],
+                  "goForward": [Function],
+                  "length": 1,
+                  "listen": [Function],
+                  "location": Object {
+                    "hash": "",
+                    "pathname": "/",
+                    "search": "",
+                    "state": undefined,
+                  },
+                  "push": [Function],
+                  "replace": [Function],
+                },
+              },
+              "refs": Object {},
+              "state": Object {
+                "match": Object {
+                  "isExact": true,
+                  "params": Object {},
+                  "path": "/",
+                  "url": "/",
+                },
+              },
+              "unlisten": [Function],
+              "updater": Object {
+                "enqueueForceUpdate": [Function],
+                "enqueueReplaceState": [Function],
+                "enqueueSetState": [Function],
+                "isMounted": [Function],
+              },
+            },
+            "tag": 1,
+            "treeBaseDuration": 0,
+            "type": [Function],
+            "updateQueue": null,
+          },
+          "childExpirationTime": 0,
+          "contextDependencies": null,
+          "effectTag": 1,
+          "elementType": [Function],
+          "expirationTime": 0,
+          "firstEffect": null,
+          "index": 0,
+          "key": null,
+          "lastEffect": null,
+          "memoizedProps": Object {
+            "children": <AuthenticatedRoute
+              authenticated={true}
+              component={[Function]}
+              path="/dashboard"
+            />,
+          },
+          "memoizedState": null,
+          "mode": 0,
+          "nextEffect": null,
+          "pendingProps": Object {
+            "children": <AuthenticatedRoute
+              authenticated={true}
+              component={[Function]}
+              path="/dashboard"
+            />,
+          },
+          "ref": null,
+          "return": FiberNode {
+            "_debugHookTypes": null,
+            "_debugID": 62,
+            "_debugIsCurrentlyTiming": false,
+            "_debugOwner": null,
+            "_debugSource": null,
+            "actualDuration": 0,
+            "actualStartTime": -1,
+            "alternate": null,
+            "child": [Circular],
+            "childExpirationTime": 0,
+            "contextDependencies": null,
+            "effectTag": 1,
+            "elementType": [Function],
+            "expirationTime": 0,
+            "firstEffect": null,
+            "index": 0,
+            "key": null,
+            "lastEffect": null,
+            "memoizedProps": Object {
+              "Component": [Function],
+              "context": null,
+              "props": Object {
+                "children": <AuthenticatedRoute
+                  authenticated={true}
+                  component={[Function]}
+                  path="/dashboard"
+                />,
+              },
+              "wrappingComponentProps": null,
+            },
+            "memoizedState": Object {
+              "context": null,
+              "mount": true,
+              "props": Object {
+                "children": <AuthenticatedRoute
+                  authenticated={true}
+                  component={[Function]}
+                  path="/dashboard"
+                />,
+              },
+              "wrappingComponentProps": null,
+            },
+            "mode": 0,
+            "nextEffect": FiberNode {
+              "_debugHookTypes": null,
+              "_debugID": 60,
+              "_debugIsCurrentlyTiming": false,
+              "_debugOwner": null,
+              "_debugSource": null,
+              "actualDuration": 0,
+              "actualStartTime": -1,
+              "alternate": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 60,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": null,
+                "_debugSource": null,
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": [Circular],
+                "child": null,
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 0,
+                "elementType": null,
+                "expirationTime": 1073741823,
+                "firstEffect": null,
+                "index": 0,
+                "key": null,
+                "lastEffect": null,
+                "memoizedProps": null,
+                "memoizedState": null,
+                "mode": 0,
+                "nextEffect": null,
+                "pendingProps": null,
+                "ref": null,
+                "return": null,
+                "selfBaseDuration": 0,
+                "sibling": null,
+                "stateNode": Object {
+                  "containerInfo": <div />,
+                  "context": Object {},
+                  "current": [Circular],
+                  "didError": false,
+                  "earliestPendingTime": 0,
+                  "earliestSuspendedTime": 0,
+                  "expirationTime": 0,
+                  "finishedWork": null,
+                  "firstBatch": null,
+                  "hydrate": false,
+                  "interactionThreadID": 15,
+                  "latestPendingTime": 0,
+                  "latestPingedTime": 0,
+                  "latestSuspendedTime": 0,
+                  "memoizedInteractions": Set {},
+                  "nextExpirationTimeToWorkOn": 0,
+                  "nextScheduledRoot": null,
+                  "pendingChildren": null,
+                  "pendingCommitExpirationTime": 0,
+                  "pendingContext": null,
+                  "pendingInteractionMap": Map {},
+                  "pingCache": null,
+                  "timeoutHandle": -1,
+                },
+                "tag": 3,
+                "treeBaseDuration": 0,
+                "type": null,
+                "updateQueue": Object {
+                  "baseState": null,
+                  "firstCapturedEffect": null,
+                  "firstCapturedUpdate": null,
+                  "firstEffect": null,
+                  "firstUpdate": Object {
+                    "callback": null,
+                    "expirationTime": 1073741823,
+                    "next": null,
+                    "nextEffect": null,
+                    "payload": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={
+                          Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          }
+                        }
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "tag": 0,
+                  },
+                  "lastCapturedEffect": null,
+                  "lastCapturedUpdate": null,
+                  "lastEffect": null,
+                  "lastUpdate": Object {
+                    "callback": null,
+                    "expirationTime": 1073741823,
+                    "next": null,
+                    "nextEffect": null,
+                    "payload": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={
+                          Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          }
+                        }
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "tag": 0,
+                  },
+                },
+              },
+              "child": [Circular],
+              "childExpirationTime": 0,
+              "contextDependencies": null,
+              "effectTag": 32,
+              "elementType": null,
+              "expirationTime": 0,
+              "firstEffect": [Circular],
+              "index": 0,
+              "key": null,
+              "lastEffect": [Circular],
+              "memoizedProps": null,
+              "memoizedState": Object {
+                "element": <WrapperComponent
+                  Component={[Function]}
+                  context={null}
+                  props={
+                    Object {
+                      "children": <AuthenticatedRoute
+                        authenticated={true}
+                        component={[Function]}
+                        path="/dashboard"
+                      />,
+                    }
+                  }
+                  wrappingComponentProps={null}
+                />,
+              },
+              "mode": 0,
+              "nextEffect": null,
+              "pendingProps": null,
+              "ref": null,
+              "return": null,
+              "selfBaseDuration": 0,
+              "sibling": null,
+              "stateNode": Object {
+                "containerInfo": <div />,
+                "context": Object {},
+                "current": [Circular],
+                "didError": false,
+                "earliestPendingTime": 0,
+                "earliestSuspendedTime": 0,
+                "expirationTime": 0,
+                "finishedWork": null,
+                "firstBatch": null,
+                "hydrate": false,
+                "interactionThreadID": 15,
+                "latestPendingTime": 0,
+                "latestPingedTime": 0,
+                "latestSuspendedTime": 0,
+                "memoizedInteractions": Set {},
+                "nextExpirationTimeToWorkOn": 0,
+                "nextScheduledRoot": null,
+                "pendingChildren": null,
+                "pendingCommitExpirationTime": 0,
+                "pendingContext": null,
+                "pendingInteractionMap": Map {},
+                "pingCache": null,
+                "timeoutHandle": -1,
+              },
+              "tag": 3,
+              "treeBaseDuration": 0,
+              "type": null,
+              "updateQueue": Object {
+                "baseState": Object {
+                  "element": <WrapperComponent
+                    Component={[Function]}
+                    context={null}
+                    props={
+                      Object {
+                        "children": <AuthenticatedRoute
+                          authenticated={true}
+                          component={[Function]}
+                          path="/dashboard"
+                        />,
+                      }
+                    }
+                    wrappingComponentProps={null}
+                  />,
+                },
+                "firstCapturedEffect": null,
+                "firstCapturedUpdate": null,
+                "firstEffect": null,
+                "firstUpdate": null,
+                "lastCapturedEffect": null,
+                "lastCapturedUpdate": null,
+                "lastEffect": null,
+                "lastUpdate": null,
+              },
+            },
+            "pendingProps": Object {
+              "Component": [Function],
+              "context": null,
+              "props": Object {
+                "children": <AuthenticatedRoute
+                  authenticated={true}
+                  component={[Function]}
+                  path="/dashboard"
+                />,
+              },
+              "wrappingComponentProps": null,
+            },
+            "ref": null,
+            "return": FiberNode {
+              "_debugHookTypes": null,
+              "_debugID": 60,
+              "_debugIsCurrentlyTiming": false,
+              "_debugOwner": null,
+              "_debugSource": null,
+              "actualDuration": 0,
+              "actualStartTime": -1,
+              "alternate": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 60,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": null,
+                "_debugSource": null,
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": [Circular],
+                "child": null,
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 0,
+                "elementType": null,
+                "expirationTime": 1073741823,
+                "firstEffect": null,
+                "index": 0,
+                "key": null,
+                "lastEffect": null,
+                "memoizedProps": null,
+                "memoizedState": null,
+                "mode": 0,
+                "nextEffect": null,
+                "pendingProps": null,
+                "ref": null,
+                "return": null,
+                "selfBaseDuration": 0,
+                "sibling": null,
+                "stateNode": Object {
+                  "containerInfo": <div />,
+                  "context": Object {},
+                  "current": [Circular],
+                  "didError": false,
+                  "earliestPendingTime": 0,
+                  "earliestSuspendedTime": 0,
+                  "expirationTime": 0,
+                  "finishedWork": null,
+                  "firstBatch": null,
+                  "hydrate": false,
+                  "interactionThreadID": 15,
+                  "latestPendingTime": 0,
+                  "latestPingedTime": 0,
+                  "latestSuspendedTime": 0,
+                  "memoizedInteractions": Set {},
+                  "nextExpirationTimeToWorkOn": 0,
+                  "nextScheduledRoot": null,
+                  "pendingChildren": null,
+                  "pendingCommitExpirationTime": 0,
+                  "pendingContext": null,
+                  "pendingInteractionMap": Map {},
+                  "pingCache": null,
+                  "timeoutHandle": -1,
+                },
+                "tag": 3,
+                "treeBaseDuration": 0,
+                "type": null,
+                "updateQueue": Object {
+                  "baseState": null,
+                  "firstCapturedEffect": null,
+                  "firstCapturedUpdate": null,
+                  "firstEffect": null,
+                  "firstUpdate": Object {
+                    "callback": null,
+                    "expirationTime": 1073741823,
+                    "next": null,
+                    "nextEffect": null,
+                    "payload": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={
+                          Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          }
+                        }
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "tag": 0,
+                  },
+                  "lastCapturedEffect": null,
+                  "lastCapturedUpdate": null,
+                  "lastEffect": null,
+                  "lastUpdate": Object {
+                    "callback": null,
+                    "expirationTime": 1073741823,
+                    "next": null,
+                    "nextEffect": null,
+                    "payload": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={
+                          Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          }
+                        }
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "tag": 0,
+                  },
+                },
+              },
+              "child": [Circular],
+              "childExpirationTime": 0,
+              "contextDependencies": null,
+              "effectTag": 32,
+              "elementType": null,
+              "expirationTime": 0,
+              "firstEffect": [Circular],
+              "index": 0,
+              "key": null,
+              "lastEffect": [Circular],
+              "memoizedProps": null,
+              "memoizedState": Object {
+                "element": <WrapperComponent
+                  Component={[Function]}
+                  context={null}
+                  props={
+                    Object {
+                      "children": <AuthenticatedRoute
+                        authenticated={true}
+                        component={[Function]}
+                        path="/dashboard"
+                      />,
+                    }
+                  }
+                  wrappingComponentProps={null}
+                />,
+              },
+              "mode": 0,
+              "nextEffect": null,
+              "pendingProps": null,
+              "ref": null,
+              "return": null,
+              "selfBaseDuration": 0,
+              "sibling": null,
+              "stateNode": Object {
+                "containerInfo": <div />,
+                "context": Object {},
+                "current": [Circular],
+                "didError": false,
+                "earliestPendingTime": 0,
+                "earliestSuspendedTime": 0,
+                "expirationTime": 0,
+                "finishedWork": null,
+                "firstBatch": null,
+                "hydrate": false,
+                "interactionThreadID": 15,
+                "latestPendingTime": 0,
+                "latestPingedTime": 0,
+                "latestSuspendedTime": 0,
+                "memoizedInteractions": Set {},
+                "nextExpirationTimeToWorkOn": 0,
+                "nextScheduledRoot": null,
+                "pendingChildren": null,
+                "pendingCommitExpirationTime": 0,
+                "pendingContext": null,
+                "pendingInteractionMap": Map {},
+                "pingCache": null,
+                "timeoutHandle": -1,
+              },
+              "tag": 3,
+              "treeBaseDuration": 0,
+              "type": null,
+              "updateQueue": Object {
+                "baseState": Object {
+                  "element": <WrapperComponent
+                    Component={[Function]}
+                    context={null}
+                    props={
+                      Object {
+                        "children": <AuthenticatedRoute
+                          authenticated={true}
+                          component={[Function]}
+                          path="/dashboard"
+                        />,
+                      }
+                    }
+                    wrappingComponentProps={null}
+                  />,
+                },
+                "firstCapturedEffect": null,
+                "firstCapturedUpdate": null,
+                "firstEffect": null,
+                "firstUpdate": null,
+                "lastCapturedEffect": null,
+                "lastCapturedUpdate": null,
+                "lastEffect": null,
+                "lastUpdate": null,
+              },
+            },
+            "selfBaseDuration": 0,
+            "sibling": null,
+            "stateNode": WrapperComponent {
+              "_reactInternalFiber": [Circular],
+              "_reactInternalInstance": Object {},
+              "context": Object {},
+              "props": Object {
+                "Component": [Function],
+                "context": null,
+                "props": Object {
+                  "children": <AuthenticatedRoute
+                    authenticated={true}
+                    component={[Function]}
+                    path="/dashboard"
+                  />,
+                },
+                "wrappingComponentProps": null,
+              },
+              "refs": Object {},
+              "rootFinderInstance": null,
+              "state": Object {
+                "context": null,
+                "mount": true,
+                "props": Object {
+                  "children": <AuthenticatedRoute
+                    authenticated={true}
+                    component={[Function]}
+                    path="/dashboard"
+                  />,
+                },
+                "wrappingComponentProps": null,
+              },
+              "updater": Object {
+                "enqueueForceUpdate": [Function],
+                "enqueueReplaceState": [Function],
+                "enqueueSetState": [Function],
+                "isMounted": [Function],
+              },
+            },
+            "tag": 1,
+            "treeBaseDuration": 0,
+            "type": [Function],
+            "updateQueue": null,
+          },
+          "selfBaseDuration": 0,
+          "sibling": null,
+          "stateNode": [Circular],
+          "tag": 1,
+          "treeBaseDuration": 0,
+          "type": [Function],
+          "updateQueue": null,
+        },
+        "_reactInternalInstance": Object {},
+        "context": Object {},
+        "history": Object {
+          "action": "POP",
+          "block": [Function],
+          "createHref": [Function],
+          "go": [Function],
+          "goBack": [Function],
+          "goForward": [Function],
+          "length": 1,
+          "listen": [Function],
+          "location": Object {
+            "hash": "",
+            "pathname": "/",
+            "search": "",
+            "state": undefined,
+          },
+          "push": [Function],
+          "replace": [Function],
+        },
+        "props": Object {
+          "children": <AuthenticatedRoute
+            authenticated={true}
+            component={[Function]}
+            path="/dashboard"
+          />,
+        },
+        "refs": Object {},
+        "state": null,
+        "updater": Object {
+          "enqueueForceUpdate": [Function],
+          "enqueueReplaceState": [Function],
+          "enqueueSetState": [Function],
+          "isMounted": [Function],
+        },
+      },
+      "key": undefined,
+      "nodeType": "class",
+      "props": Object {
+        "children": <AuthenticatedRoute
+          authenticated={true}
+          component={[Function]}
+          path="/dashboard"
+        />,
+      },
+      "ref": null,
+      "rendered": Object {
+        "instance": Router {
+          "__reactInternalMemoizedMaskedChildContext": Object {
+            "router": undefined,
+          },
+          "__reactInternalMemoizedMergedChildContext": Object {
+            "router": Object {
+              "history": Object {
+                "action": "POP",
+                "block": [Function],
+                "createHref": [Function],
+                "go": [Function],
+                "goBack": [Function],
+                "goForward": [Function],
+                "length": 1,
+                "listen": [Function],
+                "location": Object {
+                  "hash": "",
+                  "pathname": "/",
+                  "search": "",
+                  "state": undefined,
+                },
+                "push": [Function],
+                "replace": [Function],
+              },
+              "route": Object {
+                "location": Object {
+                  "hash": "",
+                  "pathname": "/",
+                  "search": "",
+                  "state": undefined,
+                },
+                "match": Object {
+                  "isExact": true,
+                  "params": Object {},
+                  "path": "/",
+                  "url": "/",
+                },
+              },
+            },
+          },
+          "__reactInternalMemoizedUnmaskedChildContext": Object {},
+          "_reactInternalFiber": FiberNode {
+            "_debugHookTypes": null,
+            "_debugID": 64,
+            "_debugIsCurrentlyTiming": false,
+            "_debugOwner": FiberNode {
+              "_debugHookTypes": null,
+              "_debugID": 63,
+              "_debugIsCurrentlyTiming": false,
+              "_debugOwner": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 62,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": null,
+                "_debugSource": null,
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": null,
+                "child": [Circular],
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 1,
+                "elementType": [Function],
+                "expirationTime": 0,
+                "firstEffect": null,
+                "index": 0,
+                "key": null,
+                "lastEffect": null,
+                "memoizedProps": Object {
+                  "Component": [Function],
+                  "context": null,
+                  "props": Object {
+                    "children": <AuthenticatedRoute
+                      authenticated={true}
+                      component={[Function]}
+                      path="/dashboard"
+                    />,
+                  },
+                  "wrappingComponentProps": null,
+                },
+                "memoizedState": Object {
+                  "context": null,
+                  "mount": true,
+                  "props": Object {
+                    "children": <AuthenticatedRoute
+                      authenticated={true}
+                      component={[Function]}
+                      path="/dashboard"
+                    />,
+                  },
+                  "wrappingComponentProps": null,
+                },
+                "mode": 0,
+                "nextEffect": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 60,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": null,
+                  "_debugSource": null,
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 60,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": null,
+                    "_debugSource": null,
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": [Circular],
+                    "child": null,
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 0,
+                    "elementType": null,
+                    "expirationTime": 1073741823,
+                    "firstEffect": null,
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": null,
+                    "memoizedProps": null,
+                    "memoizedState": null,
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": null,
+                    "ref": null,
+                    "return": null,
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": Object {
+                      "containerInfo": <div />,
+                      "context": Object {},
+                      "current": [Circular],
+                      "didError": false,
+                      "earliestPendingTime": 0,
+                      "earliestSuspendedTime": 0,
+                      "expirationTime": 0,
+                      "finishedWork": null,
+                      "firstBatch": null,
+                      "hydrate": false,
+                      "interactionThreadID": 15,
+                      "latestPendingTime": 0,
+                      "latestPingedTime": 0,
+                      "latestSuspendedTime": 0,
+                      "memoizedInteractions": Set {},
+                      "nextExpirationTimeToWorkOn": 0,
+                      "nextScheduledRoot": null,
+                      "pendingChildren": null,
+                      "pendingCommitExpirationTime": 0,
+                      "pendingContext": null,
+                      "pendingInteractionMap": Map {},
+                      "pingCache": null,
+                      "timeoutHandle": -1,
+                    },
+                    "tag": 3,
+                    "treeBaseDuration": 0,
+                    "type": null,
+                    "updateQueue": Object {
+                      "baseState": null,
+                      "firstCapturedEffect": null,
+                      "firstCapturedUpdate": null,
+                      "firstEffect": null,
+                      "firstUpdate": Object {
+                        "callback": null,
+                        "expirationTime": 1073741823,
+                        "next": null,
+                        "nextEffect": null,
+                        "payload": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={
+                              Object {
+                                "children": <AuthenticatedRoute
+                                  authenticated={true}
+                                  component={[Function]}
+                                  path="/dashboard"
+                                />,
+                              }
+                            }
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "tag": 0,
+                      },
+                      "lastCapturedEffect": null,
+                      "lastCapturedUpdate": null,
+                      "lastEffect": null,
+                      "lastUpdate": Object {
+                        "callback": null,
+                        "expirationTime": 1073741823,
+                        "next": null,
+                        "nextEffect": null,
+                        "payload": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={
+                              Object {
+                                "children": <AuthenticatedRoute
+                                  authenticated={true}
+                                  component={[Function]}
+                                  path="/dashboard"
+                                />,
+                              }
+                            }
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "tag": 0,
+                      },
+                    },
+                  },
+                  "child": [Circular],
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 32,
+                  "elementType": null,
+                  "expirationTime": 0,
+                  "firstEffect": [Circular],
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": [Circular],
+                  "memoizedProps": null,
+                  "memoizedState": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={
+                        Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        }
+                      }
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "mode": 0,
+                  "nextEffect": null,
+                  "pendingProps": null,
+                  "ref": null,
+                  "return": null,
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": Object {
+                    "containerInfo": <div />,
+                    "context": Object {},
+                    "current": [Circular],
+                    "didError": false,
+                    "earliestPendingTime": 0,
+                    "earliestSuspendedTime": 0,
+                    "expirationTime": 0,
+                    "finishedWork": null,
+                    "firstBatch": null,
+                    "hydrate": false,
+                    "interactionThreadID": 15,
+                    "latestPendingTime": 0,
+                    "latestPingedTime": 0,
+                    "latestSuspendedTime": 0,
+                    "memoizedInteractions": Set {},
+                    "nextExpirationTimeToWorkOn": 0,
+                    "nextScheduledRoot": null,
+                    "pendingChildren": null,
+                    "pendingCommitExpirationTime": 0,
+                    "pendingContext": null,
+                    "pendingInteractionMap": Map {},
+                    "pingCache": null,
+                    "timeoutHandle": -1,
+                  },
+                  "tag": 3,
+                  "treeBaseDuration": 0,
+                  "type": null,
+                  "updateQueue": Object {
+                    "baseState": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={
+                          Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          }
+                        }
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "firstCapturedEffect": null,
+                    "firstCapturedUpdate": null,
+                    "firstEffect": null,
+                    "firstUpdate": null,
+                    "lastCapturedEffect": null,
+                    "lastCapturedUpdate": null,
+                    "lastEffect": null,
+                    "lastUpdate": null,
+                  },
+                },
+                "pendingProps": Object {
+                  "Component": [Function],
+                  "context": null,
+                  "props": Object {
+                    "children": <AuthenticatedRoute
+                      authenticated={true}
+                      component={[Function]}
+                      path="/dashboard"
+                    />,
+                  },
+                  "wrappingComponentProps": null,
+                },
+                "ref": null,
+                "return": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 60,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": null,
+                  "_debugSource": null,
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 60,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": null,
+                    "_debugSource": null,
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": [Circular],
+                    "child": null,
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 0,
+                    "elementType": null,
+                    "expirationTime": 1073741823,
+                    "firstEffect": null,
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": null,
+                    "memoizedProps": null,
+                    "memoizedState": null,
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": null,
+                    "ref": null,
+                    "return": null,
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": Object {
+                      "containerInfo": <div />,
+                      "context": Object {},
+                      "current": [Circular],
+                      "didError": false,
+                      "earliestPendingTime": 0,
+                      "earliestSuspendedTime": 0,
+                      "expirationTime": 0,
+                      "finishedWork": null,
+                      "firstBatch": null,
+                      "hydrate": false,
+                      "interactionThreadID": 15,
+                      "latestPendingTime": 0,
+                      "latestPingedTime": 0,
+                      "latestSuspendedTime": 0,
+                      "memoizedInteractions": Set {},
+                      "nextExpirationTimeToWorkOn": 0,
+                      "nextScheduledRoot": null,
+                      "pendingChildren": null,
+                      "pendingCommitExpirationTime": 0,
+                      "pendingContext": null,
+                      "pendingInteractionMap": Map {},
+                      "pingCache": null,
+                      "timeoutHandle": -1,
+                    },
+                    "tag": 3,
+                    "treeBaseDuration": 0,
+                    "type": null,
+                    "updateQueue": Object {
+                      "baseState": null,
+                      "firstCapturedEffect": null,
+                      "firstCapturedUpdate": null,
+                      "firstEffect": null,
+                      "firstUpdate": Object {
+                        "callback": null,
+                        "expirationTime": 1073741823,
+                        "next": null,
+                        "nextEffect": null,
+                        "payload": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={
+                              Object {
+                                "children": <AuthenticatedRoute
+                                  authenticated={true}
+                                  component={[Function]}
+                                  path="/dashboard"
+                                />,
+                              }
+                            }
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "tag": 0,
+                      },
+                      "lastCapturedEffect": null,
+                      "lastCapturedUpdate": null,
+                      "lastEffect": null,
+                      "lastUpdate": Object {
+                        "callback": null,
+                        "expirationTime": 1073741823,
+                        "next": null,
+                        "nextEffect": null,
+                        "payload": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={
+                              Object {
+                                "children": <AuthenticatedRoute
+                                  authenticated={true}
+                                  component={[Function]}
+                                  path="/dashboard"
+                                />,
+                              }
+                            }
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "tag": 0,
+                      },
+                    },
+                  },
+                  "child": [Circular],
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 32,
+                  "elementType": null,
+                  "expirationTime": 0,
+                  "firstEffect": [Circular],
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": [Circular],
+                  "memoizedProps": null,
+                  "memoizedState": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={
+                        Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        }
+                      }
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "mode": 0,
+                  "nextEffect": null,
+                  "pendingProps": null,
+                  "ref": null,
+                  "return": null,
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": Object {
+                    "containerInfo": <div />,
+                    "context": Object {},
+                    "current": [Circular],
+                    "didError": false,
+                    "earliestPendingTime": 0,
+                    "earliestSuspendedTime": 0,
+                    "expirationTime": 0,
+                    "finishedWork": null,
+                    "firstBatch": null,
+                    "hydrate": false,
+                    "interactionThreadID": 15,
+                    "latestPendingTime": 0,
+                    "latestPingedTime": 0,
+                    "latestSuspendedTime": 0,
+                    "memoizedInteractions": Set {},
+                    "nextExpirationTimeToWorkOn": 0,
+                    "nextScheduledRoot": null,
+                    "pendingChildren": null,
+                    "pendingCommitExpirationTime": 0,
+                    "pendingContext": null,
+                    "pendingInteractionMap": Map {},
+                    "pingCache": null,
+                    "timeoutHandle": -1,
+                  },
+                  "tag": 3,
+                  "treeBaseDuration": 0,
+                  "type": null,
+                  "updateQueue": Object {
+                    "baseState": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={
+                          Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          }
+                        }
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "firstCapturedEffect": null,
+                    "firstCapturedUpdate": null,
+                    "firstEffect": null,
+                    "firstUpdate": null,
+                    "lastCapturedEffect": null,
+                    "lastCapturedUpdate": null,
+                    "lastEffect": null,
+                    "lastUpdate": null,
+                  },
+                },
+                "selfBaseDuration": 0,
+                "sibling": null,
+                "stateNode": WrapperComponent {
+                  "_reactInternalFiber": [Circular],
+                  "_reactInternalInstance": Object {},
+                  "context": Object {},
+                  "props": Object {
+                    "Component": [Function],
+                    "context": null,
+                    "props": Object {
+                      "children": <AuthenticatedRoute
+                        authenticated={true}
+                        component={[Function]}
+                        path="/dashboard"
+                      />,
+                    },
+                    "wrappingComponentProps": null,
+                  },
+                  "refs": Object {},
+                  "rootFinderInstance": null,
+                  "state": Object {
+                    "context": null,
+                    "mount": true,
+                    "props": Object {
+                      "children": <AuthenticatedRoute
+                        authenticated={true}
+                        component={[Function]}
+                        path="/dashboard"
+                      />,
+                    },
+                    "wrappingComponentProps": null,
+                  },
+                  "updater": Object {
+                    "enqueueForceUpdate": [Function],
+                    "enqueueReplaceState": [Function],
+                    "enqueueSetState": [Function],
+                    "isMounted": [Function],
+                  },
+                },
+                "tag": 1,
+                "treeBaseDuration": 0,
+                "type": [Function],
+                "updateQueue": null,
+              },
+              "_debugSource": null,
+              "actualDuration": 0,
+              "actualStartTime": -1,
+              "alternate": null,
+              "child": [Circular],
+              "childExpirationTime": 0,
+              "contextDependencies": null,
+              "effectTag": 1,
+              "elementType": [Function],
+              "expirationTime": 0,
+              "firstEffect": null,
+              "index": 0,
+              "key": null,
+              "lastEffect": null,
+              "memoizedProps": Object {
+                "children": <AuthenticatedRoute
+                  authenticated={true}
+                  component={[Function]}
+                  path="/dashboard"
+                />,
+              },
+              "memoizedState": null,
+              "mode": 0,
+              "nextEffect": null,
+              "pendingProps": Object {
+                "children": <AuthenticatedRoute
+                  authenticated={true}
+                  component={[Function]}
+                  path="/dashboard"
+                />,
+              },
+              "ref": null,
+              "return": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 62,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": null,
+                "_debugSource": null,
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": null,
+                "child": [Circular],
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 1,
+                "elementType": [Function],
+                "expirationTime": 0,
+                "firstEffect": null,
+                "index": 0,
+                "key": null,
+                "lastEffect": null,
+                "memoizedProps": Object {
+                  "Component": [Function],
+                  "context": null,
+                  "props": Object {
+                    "children": <AuthenticatedRoute
+                      authenticated={true}
+                      component={[Function]}
+                      path="/dashboard"
+                    />,
+                  },
+                  "wrappingComponentProps": null,
+                },
+                "memoizedState": Object {
+                  "context": null,
+                  "mount": true,
+                  "props": Object {
+                    "children": <AuthenticatedRoute
+                      authenticated={true}
+                      component={[Function]}
+                      path="/dashboard"
+                    />,
+                  },
+                  "wrappingComponentProps": null,
+                },
+                "mode": 0,
+                "nextEffect": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 60,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": null,
+                  "_debugSource": null,
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 60,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": null,
+                    "_debugSource": null,
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": [Circular],
+                    "child": null,
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 0,
+                    "elementType": null,
+                    "expirationTime": 1073741823,
+                    "firstEffect": null,
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": null,
+                    "memoizedProps": null,
+                    "memoizedState": null,
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": null,
+                    "ref": null,
+                    "return": null,
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": Object {
+                      "containerInfo": <div />,
+                      "context": Object {},
+                      "current": [Circular],
+                      "didError": false,
+                      "earliestPendingTime": 0,
+                      "earliestSuspendedTime": 0,
+                      "expirationTime": 0,
+                      "finishedWork": null,
+                      "firstBatch": null,
+                      "hydrate": false,
+                      "interactionThreadID": 15,
+                      "latestPendingTime": 0,
+                      "latestPingedTime": 0,
+                      "latestSuspendedTime": 0,
+                      "memoizedInteractions": Set {},
+                      "nextExpirationTimeToWorkOn": 0,
+                      "nextScheduledRoot": null,
+                      "pendingChildren": null,
+                      "pendingCommitExpirationTime": 0,
+                      "pendingContext": null,
+                      "pendingInteractionMap": Map {},
+                      "pingCache": null,
+                      "timeoutHandle": -1,
+                    },
+                    "tag": 3,
+                    "treeBaseDuration": 0,
+                    "type": null,
+                    "updateQueue": Object {
+                      "baseState": null,
+                      "firstCapturedEffect": null,
+                      "firstCapturedUpdate": null,
+                      "firstEffect": null,
+                      "firstUpdate": Object {
+                        "callback": null,
+                        "expirationTime": 1073741823,
+                        "next": null,
+                        "nextEffect": null,
+                        "payload": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={
+                              Object {
+                                "children": <AuthenticatedRoute
+                                  authenticated={true}
+                                  component={[Function]}
+                                  path="/dashboard"
+                                />,
+                              }
+                            }
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "tag": 0,
+                      },
+                      "lastCapturedEffect": null,
+                      "lastCapturedUpdate": null,
+                      "lastEffect": null,
+                      "lastUpdate": Object {
+                        "callback": null,
+                        "expirationTime": 1073741823,
+                        "next": null,
+                        "nextEffect": null,
+                        "payload": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={
+                              Object {
+                                "children": <AuthenticatedRoute
+                                  authenticated={true}
+                                  component={[Function]}
+                                  path="/dashboard"
+                                />,
+                              }
+                            }
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "tag": 0,
+                      },
+                    },
+                  },
+                  "child": [Circular],
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 32,
+                  "elementType": null,
+                  "expirationTime": 0,
+                  "firstEffect": [Circular],
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": [Circular],
+                  "memoizedProps": null,
+                  "memoizedState": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={
+                        Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        }
+                      }
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "mode": 0,
+                  "nextEffect": null,
+                  "pendingProps": null,
+                  "ref": null,
+                  "return": null,
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": Object {
+                    "containerInfo": <div />,
+                    "context": Object {},
+                    "current": [Circular],
+                    "didError": false,
+                    "earliestPendingTime": 0,
+                    "earliestSuspendedTime": 0,
+                    "expirationTime": 0,
+                    "finishedWork": null,
+                    "firstBatch": null,
+                    "hydrate": false,
+                    "interactionThreadID": 15,
+                    "latestPendingTime": 0,
+                    "latestPingedTime": 0,
+                    "latestSuspendedTime": 0,
+                    "memoizedInteractions": Set {},
+                    "nextExpirationTimeToWorkOn": 0,
+                    "nextScheduledRoot": null,
+                    "pendingChildren": null,
+                    "pendingCommitExpirationTime": 0,
+                    "pendingContext": null,
+                    "pendingInteractionMap": Map {},
+                    "pingCache": null,
+                    "timeoutHandle": -1,
+                  },
+                  "tag": 3,
+                  "treeBaseDuration": 0,
+                  "type": null,
+                  "updateQueue": Object {
+                    "baseState": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={
+                          Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          }
+                        }
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "firstCapturedEffect": null,
+                    "firstCapturedUpdate": null,
+                    "firstEffect": null,
+                    "firstUpdate": null,
+                    "lastCapturedEffect": null,
+                    "lastCapturedUpdate": null,
+                    "lastEffect": null,
+                    "lastUpdate": null,
+                  },
+                },
+                "pendingProps": Object {
+                  "Component": [Function],
+                  "context": null,
+                  "props": Object {
+                    "children": <AuthenticatedRoute
+                      authenticated={true}
+                      component={[Function]}
+                      path="/dashboard"
+                    />,
+                  },
+                  "wrappingComponentProps": null,
+                },
+                "ref": null,
+                "return": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 60,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": null,
+                  "_debugSource": null,
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 60,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": null,
+                    "_debugSource": null,
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": [Circular],
+                    "child": null,
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 0,
+                    "elementType": null,
+                    "expirationTime": 1073741823,
+                    "firstEffect": null,
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": null,
+                    "memoizedProps": null,
+                    "memoizedState": null,
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": null,
+                    "ref": null,
+                    "return": null,
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": Object {
+                      "containerInfo": <div />,
+                      "context": Object {},
+                      "current": [Circular],
+                      "didError": false,
+                      "earliestPendingTime": 0,
+                      "earliestSuspendedTime": 0,
+                      "expirationTime": 0,
+                      "finishedWork": null,
+                      "firstBatch": null,
+                      "hydrate": false,
+                      "interactionThreadID": 15,
+                      "latestPendingTime": 0,
+                      "latestPingedTime": 0,
+                      "latestSuspendedTime": 0,
+                      "memoizedInteractions": Set {},
+                      "nextExpirationTimeToWorkOn": 0,
+                      "nextScheduledRoot": null,
+                      "pendingChildren": null,
+                      "pendingCommitExpirationTime": 0,
+                      "pendingContext": null,
+                      "pendingInteractionMap": Map {},
+                      "pingCache": null,
+                      "timeoutHandle": -1,
+                    },
+                    "tag": 3,
+                    "treeBaseDuration": 0,
+                    "type": null,
+                    "updateQueue": Object {
+                      "baseState": null,
+                      "firstCapturedEffect": null,
+                      "firstCapturedUpdate": null,
+                      "firstEffect": null,
+                      "firstUpdate": Object {
+                        "callback": null,
+                        "expirationTime": 1073741823,
+                        "next": null,
+                        "nextEffect": null,
+                        "payload": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={
+                              Object {
+                                "children": <AuthenticatedRoute
+                                  authenticated={true}
+                                  component={[Function]}
+                                  path="/dashboard"
+                                />,
+                              }
+                            }
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "tag": 0,
+                      },
+                      "lastCapturedEffect": null,
+                      "lastCapturedUpdate": null,
+                      "lastEffect": null,
+                      "lastUpdate": Object {
+                        "callback": null,
+                        "expirationTime": 1073741823,
+                        "next": null,
+                        "nextEffect": null,
+                        "payload": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={
+                              Object {
+                                "children": <AuthenticatedRoute
+                                  authenticated={true}
+                                  component={[Function]}
+                                  path="/dashboard"
+                                />,
+                              }
+                            }
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "tag": 0,
+                      },
+                    },
+                  },
+                  "child": [Circular],
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 32,
+                  "elementType": null,
+                  "expirationTime": 0,
+                  "firstEffect": [Circular],
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": [Circular],
+                  "memoizedProps": null,
+                  "memoizedState": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={
+                        Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        }
+                      }
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "mode": 0,
+                  "nextEffect": null,
+                  "pendingProps": null,
+                  "ref": null,
+                  "return": null,
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": Object {
+                    "containerInfo": <div />,
+                    "context": Object {},
+                    "current": [Circular],
+                    "didError": false,
+                    "earliestPendingTime": 0,
+                    "earliestSuspendedTime": 0,
+                    "expirationTime": 0,
+                    "finishedWork": null,
+                    "firstBatch": null,
+                    "hydrate": false,
+                    "interactionThreadID": 15,
+                    "latestPendingTime": 0,
+                    "latestPingedTime": 0,
+                    "latestSuspendedTime": 0,
+                    "memoizedInteractions": Set {},
+                    "nextExpirationTimeToWorkOn": 0,
+                    "nextScheduledRoot": null,
+                    "pendingChildren": null,
+                    "pendingCommitExpirationTime": 0,
+                    "pendingContext": null,
+                    "pendingInteractionMap": Map {},
+                    "pingCache": null,
+                    "timeoutHandle": -1,
+                  },
+                  "tag": 3,
+                  "treeBaseDuration": 0,
+                  "type": null,
+                  "updateQueue": Object {
+                    "baseState": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={
+                          Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          }
+                        }
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "firstCapturedEffect": null,
+                    "firstCapturedUpdate": null,
+                    "firstEffect": null,
+                    "firstUpdate": null,
+                    "lastCapturedEffect": null,
+                    "lastCapturedUpdate": null,
+                    "lastEffect": null,
+                    "lastUpdate": null,
+                  },
+                },
+                "selfBaseDuration": 0,
+                "sibling": null,
+                "stateNode": WrapperComponent {
+                  "_reactInternalFiber": [Circular],
+                  "_reactInternalInstance": Object {},
+                  "context": Object {},
+                  "props": Object {
+                    "Component": [Function],
+                    "context": null,
+                    "props": Object {
+                      "children": <AuthenticatedRoute
+                        authenticated={true}
+                        component={[Function]}
+                        path="/dashboard"
+                      />,
+                    },
+                    "wrappingComponentProps": null,
+                  },
+                  "refs": Object {},
+                  "rootFinderInstance": null,
+                  "state": Object {
+                    "context": null,
+                    "mount": true,
+                    "props": Object {
+                      "children": <AuthenticatedRoute
+                        authenticated={true}
+                        component={[Function]}
+                        path="/dashboard"
+                      />,
+                    },
+                    "wrappingComponentProps": null,
+                  },
+                  "updater": Object {
+                    "enqueueForceUpdate": [Function],
+                    "enqueueReplaceState": [Function],
+                    "enqueueSetState": [Function],
+                    "isMounted": [Function],
+                  },
+                },
+                "tag": 1,
+                "treeBaseDuration": 0,
+                "type": [Function],
+                "updateQueue": null,
+              },
+              "selfBaseDuration": 0,
+              "sibling": null,
+              "stateNode": BrowserRouter {
+                "_reactInternalFiber": [Circular],
+                "_reactInternalInstance": Object {},
+                "context": Object {},
+                "history": Object {
+                  "action": "POP",
+                  "block": [Function],
+                  "createHref": [Function],
+                  "go": [Function],
+                  "goBack": [Function],
+                  "goForward": [Function],
+                  "length": 1,
+                  "listen": [Function],
+                  "location": Object {
+                    "hash": "",
+                    "pathname": "/",
+                    "search": "",
+                    "state": undefined,
+                  },
+                  "push": [Function],
+                  "replace": [Function],
+                },
+                "props": Object {
+                  "children": <AuthenticatedRoute
+                    authenticated={true}
+                    component={[Function]}
+                    path="/dashboard"
+                  />,
+                },
+                "refs": Object {},
+                "state": null,
+                "updater": Object {
+                  "enqueueForceUpdate": [Function],
+                  "enqueueReplaceState": [Function],
+                  "enqueueSetState": [Function],
+                  "isMounted": [Function],
+                },
+              },
+              "tag": 1,
+              "treeBaseDuration": 0,
+              "type": [Function],
+              "updateQueue": null,
+            },
+            "_debugSource": null,
+            "actualDuration": 0,
+            "actualStartTime": -1,
+            "alternate": null,
+            "child": FiberNode {
+              "_debugHookTypes": null,
+              "_debugID": 65,
+              "_debugIsCurrentlyTiming": false,
+              "_debugOwner": null,
+              "_debugSource": Object {
+                "fileName": "/Users/home/Documents/Projects/javascript/Andela/bp-esa/bp-esa-frontend/src/App.test.jsx",
+                "lineNumber": 123,
+              },
+              "actualDuration": 0,
+              "actualStartTime": -1,
+              "alternate": null,
+              "child": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 66,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": [Circular],
+                "_debugSource": Object {
+                  "fileName": "/Users/home/Documents/Projects/javascript/Andela/bp-esa/bp-esa-frontend/src/App.jsx",
+                  "lineNumber": 15,
+                },
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": null,
+                "child": null,
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 1,
+                "elementType": [Function],
+                "expirationTime": 0,
+                "firstEffect": null,
+                "index": 0,
+                "key": null,
+                "lastEffect": null,
+                "memoizedProps": Object {
+                  "path": "/dashboard",
+                  "render": [Function],
+                },
+                "memoizedState": Object {
+                  "match": null,
+                },
+                "mode": 0,
+                "nextEffect": null,
+                "pendingProps": Object {
+                  "path": "/dashboard",
+                  "render": [Function],
+                },
+                "ref": null,
+                "return": [Circular],
+                "selfBaseDuration": 0,
+                "sibling": null,
+                "stateNode": Route {
+                  "__reactInternalMemoizedMaskedChildContext": Object {
+                    "router": Object {
+                      "history": Object {
+                        "action": "POP",
+                        "block": [Function],
+                        "createHref": [Function],
+                        "go": [Function],
+                        "goBack": [Function],
+                        "goForward": [Function],
+                        "length": 1,
+                        "listen": [Function],
+                        "location": Object {
+                          "hash": "",
+                          "pathname": "/",
+                          "search": "",
+                          "state": undefined,
+                        },
+                        "push": [Function],
+                        "replace": [Function],
+                      },
+                      "route": Object {
+                        "location": Object {
+                          "hash": "",
+                          "pathname": "/",
+                          "search": "",
+                          "state": undefined,
+                        },
+                        "match": Object {
+                          "isExact": true,
+                          "params": Object {},
+                          "path": "/",
+                          "url": "/",
+                        },
+                      },
+                    },
+                  },
+                  "__reactInternalMemoizedMergedChildContext": Object {
+                    "router": Object {
+                      "history": Object {
+                        "action": "POP",
+                        "block": [Function],
+                        "createHref": [Function],
+                        "go": [Function],
+                        "goBack": [Function],
+                        "goForward": [Function],
+                        "length": 1,
+                        "listen": [Function],
+                        "location": Object {
+                          "hash": "",
+                          "pathname": "/",
+                          "search": "",
+                          "state": undefined,
+                        },
+                        "push": [Function],
+                        "replace": [Function],
+                      },
+                      "route": Object {
+                        "location": Object {
+                          "hash": "",
+                          "pathname": "/",
+                          "search": "",
+                          "state": undefined,
+                        },
+                        "match": null,
+                      },
+                    },
+                  },
+                  "__reactInternalMemoizedUnmaskedChildContext": Object {
+                    "router": Object {
+                      "history": Object {
+                        "action": "POP",
+                        "block": [Function],
+                        "createHref": [Function],
+                        "go": [Function],
+                        "goBack": [Function],
+                        "goForward": [Function],
+                        "length": 1,
+                        "listen": [Function],
+                        "location": Object {
+                          "hash": "",
+                          "pathname": "/",
+                          "search": "",
+                          "state": undefined,
+                        },
+                        "push": [Function],
+                        "replace": [Function],
+                      },
+                      "route": Object {
+                        "location": Object {
+                          "hash": "",
+                          "pathname": "/",
+                          "search": "",
+                          "state": undefined,
+                        },
+                        "match": Object {
+                          "isExact": true,
+                          "params": Object {},
+                          "path": "/",
+                          "url": "/",
+                        },
+                      },
+                    },
+                  },
+                  "_reactInternalFiber": [Circular],
+                  "_reactInternalInstance": Object {},
+                  "context": Object {
+                    "router": Object {
+                      "history": Object {
+                        "action": "POP",
+                        "block": [Function],
+                        "createHref": [Function],
+                        "go": [Function],
+                        "goBack": [Function],
+                        "goForward": [Function],
+                        "length": 1,
+                        "listen": [Function],
+                        "location": Object {
+                          "hash": "",
+                          "pathname": "/",
+                          "search": "",
+                          "state": undefined,
+                        },
+                        "push": [Function],
+                        "replace": [Function],
+                      },
+                      "route": Object {
+                        "location": Object {
+                          "hash": "",
+                          "pathname": "/",
+                          "search": "",
+                          "state": undefined,
+                        },
+                        "match": Object {
+                          "isExact": true,
+                          "params": Object {},
+                          "path": "/",
+                          "url": "/",
+                        },
+                      },
+                    },
+                  },
+                  "props": Object {
+                    "path": "/dashboard",
+                    "render": [Function],
+                  },
+                  "refs": Object {},
+                  "state": Object {
+                    "match": null,
+                  },
+                  "updater": Object {
+                    "enqueueForceUpdate": [Function],
+                    "enqueueReplaceState": [Function],
+                    "enqueueSetState": [Function],
+                    "isMounted": [Function],
+                  },
+                },
+                "tag": 1,
+                "treeBaseDuration": 0,
+                "type": [Function],
+                "updateQueue": null,
+              },
+              "childExpirationTime": 0,
+              "contextDependencies": null,
+              "effectTag": 1,
+              "elementType": [Function],
+              "expirationTime": 0,
+              "firstEffect": null,
+              "index": 0,
+              "key": null,
+              "lastEffect": null,
+              "memoizedProps": Object {
+                "authenticated": true,
+                "component": [Function],
+                "path": "/dashboard",
+              },
+              "memoizedState": null,
+              "mode": 0,
+              "nextEffect": null,
+              "pendingProps": Object {
+                "authenticated": true,
+                "component": [Function],
+                "path": "/dashboard",
+              },
+              "ref": null,
+              "return": [Circular],
+              "selfBaseDuration": 0,
+              "sibling": null,
+              "stateNode": null,
+              "tag": 0,
+              "treeBaseDuration": 0,
+              "type": [Function],
+              "updateQueue": null,
+            },
+            "childExpirationTime": 0,
+            "contextDependencies": null,
+            "effectTag": 1,
+            "elementType": [Function],
+            "expirationTime": 0,
+            "firstEffect": null,
+            "index": 0,
+            "key": null,
+            "lastEffect": null,
+            "memoizedProps": Object {
+              "children": <AuthenticatedRoute
+                authenticated={true}
+                component={[Function]}
+                path="/dashboard"
+              />,
+              "history": Object {
+                "action": "POP",
+                "block": [Function],
+                "createHref": [Function],
+                "go": [Function],
+                "goBack": [Function],
+                "goForward": [Function],
+                "length": 1,
+                "listen": [Function],
+                "location": Object {
+                  "hash": "",
+                  "pathname": "/",
+                  "search": "",
+                  "state": undefined,
+                },
+                "push": [Function],
+                "replace": [Function],
+              },
+            },
+            "memoizedState": Object {
+              "match": Object {
+                "isExact": true,
+                "params": Object {},
+                "path": "/",
+                "url": "/",
+              },
+            },
+            "mode": 0,
+            "nextEffect": null,
+            "pendingProps": Object {
+              "children": <AuthenticatedRoute
+                authenticated={true}
+                component={[Function]}
+                path="/dashboard"
+              />,
+              "history": Object {
+                "action": "POP",
+                "block": [Function],
+                "createHref": [Function],
+                "go": [Function],
+                "goBack": [Function],
+                "goForward": [Function],
+                "length": 1,
+                "listen": [Function],
+                "location": Object {
+                  "hash": "",
+                  "pathname": "/",
+                  "search": "",
+                  "state": undefined,
+                },
+                "push": [Function],
+                "replace": [Function],
+              },
+            },
+            "ref": null,
+            "return": FiberNode {
+              "_debugHookTypes": null,
+              "_debugID": 63,
+              "_debugIsCurrentlyTiming": false,
+              "_debugOwner": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 62,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": null,
+                "_debugSource": null,
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": null,
+                "child": [Circular],
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 1,
+                "elementType": [Function],
+                "expirationTime": 0,
+                "firstEffect": null,
+                "index": 0,
+                "key": null,
+                "lastEffect": null,
+                "memoizedProps": Object {
+                  "Component": [Function],
+                  "context": null,
+                  "props": Object {
+                    "children": <AuthenticatedRoute
+                      authenticated={true}
+                      component={[Function]}
+                      path="/dashboard"
+                    />,
+                  },
+                  "wrappingComponentProps": null,
+                },
+                "memoizedState": Object {
+                  "context": null,
+                  "mount": true,
+                  "props": Object {
+                    "children": <AuthenticatedRoute
+                      authenticated={true}
+                      component={[Function]}
+                      path="/dashboard"
+                    />,
+                  },
+                  "wrappingComponentProps": null,
+                },
+                "mode": 0,
+                "nextEffect": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 60,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": null,
+                  "_debugSource": null,
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 60,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": null,
+                    "_debugSource": null,
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": [Circular],
+                    "child": null,
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 0,
+                    "elementType": null,
+                    "expirationTime": 1073741823,
+                    "firstEffect": null,
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": null,
+                    "memoizedProps": null,
+                    "memoizedState": null,
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": null,
+                    "ref": null,
+                    "return": null,
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": Object {
+                      "containerInfo": <div />,
+                      "context": Object {},
+                      "current": [Circular],
+                      "didError": false,
+                      "earliestPendingTime": 0,
+                      "earliestSuspendedTime": 0,
+                      "expirationTime": 0,
+                      "finishedWork": null,
+                      "firstBatch": null,
+                      "hydrate": false,
+                      "interactionThreadID": 15,
+                      "latestPendingTime": 0,
+                      "latestPingedTime": 0,
+                      "latestSuspendedTime": 0,
+                      "memoizedInteractions": Set {},
+                      "nextExpirationTimeToWorkOn": 0,
+                      "nextScheduledRoot": null,
+                      "pendingChildren": null,
+                      "pendingCommitExpirationTime": 0,
+                      "pendingContext": null,
+                      "pendingInteractionMap": Map {},
+                      "pingCache": null,
+                      "timeoutHandle": -1,
+                    },
+                    "tag": 3,
+                    "treeBaseDuration": 0,
+                    "type": null,
+                    "updateQueue": Object {
+                      "baseState": null,
+                      "firstCapturedEffect": null,
+                      "firstCapturedUpdate": null,
+                      "firstEffect": null,
+                      "firstUpdate": Object {
+                        "callback": null,
+                        "expirationTime": 1073741823,
+                        "next": null,
+                        "nextEffect": null,
+                        "payload": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={
+                              Object {
+                                "children": <AuthenticatedRoute
+                                  authenticated={true}
+                                  component={[Function]}
+                                  path="/dashboard"
+                                />,
+                              }
+                            }
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "tag": 0,
+                      },
+                      "lastCapturedEffect": null,
+                      "lastCapturedUpdate": null,
+                      "lastEffect": null,
+                      "lastUpdate": Object {
+                        "callback": null,
+                        "expirationTime": 1073741823,
+                        "next": null,
+                        "nextEffect": null,
+                        "payload": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={
+                              Object {
+                                "children": <AuthenticatedRoute
+                                  authenticated={true}
+                                  component={[Function]}
+                                  path="/dashboard"
+                                />,
+                              }
+                            }
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "tag": 0,
+                      },
+                    },
+                  },
+                  "child": [Circular],
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 32,
+                  "elementType": null,
+                  "expirationTime": 0,
+                  "firstEffect": [Circular],
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": [Circular],
+                  "memoizedProps": null,
+                  "memoizedState": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={
+                        Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        }
+                      }
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "mode": 0,
+                  "nextEffect": null,
+                  "pendingProps": null,
+                  "ref": null,
+                  "return": null,
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": Object {
+                    "containerInfo": <div />,
+                    "context": Object {},
+                    "current": [Circular],
+                    "didError": false,
+                    "earliestPendingTime": 0,
+                    "earliestSuspendedTime": 0,
+                    "expirationTime": 0,
+                    "finishedWork": null,
+                    "firstBatch": null,
+                    "hydrate": false,
+                    "interactionThreadID": 15,
+                    "latestPendingTime": 0,
+                    "latestPingedTime": 0,
+                    "latestSuspendedTime": 0,
+                    "memoizedInteractions": Set {},
+                    "nextExpirationTimeToWorkOn": 0,
+                    "nextScheduledRoot": null,
+                    "pendingChildren": null,
+                    "pendingCommitExpirationTime": 0,
+                    "pendingContext": null,
+                    "pendingInteractionMap": Map {},
+                    "pingCache": null,
+                    "timeoutHandle": -1,
+                  },
+                  "tag": 3,
+                  "treeBaseDuration": 0,
+                  "type": null,
+                  "updateQueue": Object {
+                    "baseState": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={
+                          Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          }
+                        }
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "firstCapturedEffect": null,
+                    "firstCapturedUpdate": null,
+                    "firstEffect": null,
+                    "firstUpdate": null,
+                    "lastCapturedEffect": null,
+                    "lastCapturedUpdate": null,
+                    "lastEffect": null,
+                    "lastUpdate": null,
+                  },
+                },
+                "pendingProps": Object {
+                  "Component": [Function],
+                  "context": null,
+                  "props": Object {
+                    "children": <AuthenticatedRoute
+                      authenticated={true}
+                      component={[Function]}
+                      path="/dashboard"
+                    />,
+                  },
+                  "wrappingComponentProps": null,
+                },
+                "ref": null,
+                "return": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 60,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": null,
+                  "_debugSource": null,
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 60,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": null,
+                    "_debugSource": null,
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": [Circular],
+                    "child": null,
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 0,
+                    "elementType": null,
+                    "expirationTime": 1073741823,
+                    "firstEffect": null,
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": null,
+                    "memoizedProps": null,
+                    "memoizedState": null,
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": null,
+                    "ref": null,
+                    "return": null,
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": Object {
+                      "containerInfo": <div />,
+                      "context": Object {},
+                      "current": [Circular],
+                      "didError": false,
+                      "earliestPendingTime": 0,
+                      "earliestSuspendedTime": 0,
+                      "expirationTime": 0,
+                      "finishedWork": null,
+                      "firstBatch": null,
+                      "hydrate": false,
+                      "interactionThreadID": 15,
+                      "latestPendingTime": 0,
+                      "latestPingedTime": 0,
+                      "latestSuspendedTime": 0,
+                      "memoizedInteractions": Set {},
+                      "nextExpirationTimeToWorkOn": 0,
+                      "nextScheduledRoot": null,
+                      "pendingChildren": null,
+                      "pendingCommitExpirationTime": 0,
+                      "pendingContext": null,
+                      "pendingInteractionMap": Map {},
+                      "pingCache": null,
+                      "timeoutHandle": -1,
+                    },
+                    "tag": 3,
+                    "treeBaseDuration": 0,
+                    "type": null,
+                    "updateQueue": Object {
+                      "baseState": null,
+                      "firstCapturedEffect": null,
+                      "firstCapturedUpdate": null,
+                      "firstEffect": null,
+                      "firstUpdate": Object {
+                        "callback": null,
+                        "expirationTime": 1073741823,
+                        "next": null,
+                        "nextEffect": null,
+                        "payload": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={
+                              Object {
+                                "children": <AuthenticatedRoute
+                                  authenticated={true}
+                                  component={[Function]}
+                                  path="/dashboard"
+                                />,
+                              }
+                            }
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "tag": 0,
+                      },
+                      "lastCapturedEffect": null,
+                      "lastCapturedUpdate": null,
+                      "lastEffect": null,
+                      "lastUpdate": Object {
+                        "callback": null,
+                        "expirationTime": 1073741823,
+                        "next": null,
+                        "nextEffect": null,
+                        "payload": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={
+                              Object {
+                                "children": <AuthenticatedRoute
+                                  authenticated={true}
+                                  component={[Function]}
+                                  path="/dashboard"
+                                />,
+                              }
+                            }
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "tag": 0,
+                      },
+                    },
+                  },
+                  "child": [Circular],
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 32,
+                  "elementType": null,
+                  "expirationTime": 0,
+                  "firstEffect": [Circular],
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": [Circular],
+                  "memoizedProps": null,
+                  "memoizedState": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={
+                        Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        }
+                      }
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "mode": 0,
+                  "nextEffect": null,
+                  "pendingProps": null,
+                  "ref": null,
+                  "return": null,
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": Object {
+                    "containerInfo": <div />,
+                    "context": Object {},
+                    "current": [Circular],
+                    "didError": false,
+                    "earliestPendingTime": 0,
+                    "earliestSuspendedTime": 0,
+                    "expirationTime": 0,
+                    "finishedWork": null,
+                    "firstBatch": null,
+                    "hydrate": false,
+                    "interactionThreadID": 15,
+                    "latestPendingTime": 0,
+                    "latestPingedTime": 0,
+                    "latestSuspendedTime": 0,
+                    "memoizedInteractions": Set {},
+                    "nextExpirationTimeToWorkOn": 0,
+                    "nextScheduledRoot": null,
+                    "pendingChildren": null,
+                    "pendingCommitExpirationTime": 0,
+                    "pendingContext": null,
+                    "pendingInteractionMap": Map {},
+                    "pingCache": null,
+                    "timeoutHandle": -1,
+                  },
+                  "tag": 3,
+                  "treeBaseDuration": 0,
+                  "type": null,
+                  "updateQueue": Object {
+                    "baseState": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={
+                          Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          }
+                        }
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "firstCapturedEffect": null,
+                    "firstCapturedUpdate": null,
+                    "firstEffect": null,
+                    "firstUpdate": null,
+                    "lastCapturedEffect": null,
+                    "lastCapturedUpdate": null,
+                    "lastEffect": null,
+                    "lastUpdate": null,
+                  },
+                },
+                "selfBaseDuration": 0,
+                "sibling": null,
+                "stateNode": WrapperComponent {
+                  "_reactInternalFiber": [Circular],
+                  "_reactInternalInstance": Object {},
+                  "context": Object {},
+                  "props": Object {
+                    "Component": [Function],
+                    "context": null,
+                    "props": Object {
+                      "children": <AuthenticatedRoute
+                        authenticated={true}
+                        component={[Function]}
+                        path="/dashboard"
+                      />,
+                    },
+                    "wrappingComponentProps": null,
+                  },
+                  "refs": Object {},
+                  "rootFinderInstance": null,
+                  "state": Object {
+                    "context": null,
+                    "mount": true,
+                    "props": Object {
+                      "children": <AuthenticatedRoute
+                        authenticated={true}
+                        component={[Function]}
+                        path="/dashboard"
+                      />,
+                    },
+                    "wrappingComponentProps": null,
+                  },
+                  "updater": Object {
+                    "enqueueForceUpdate": [Function],
+                    "enqueueReplaceState": [Function],
+                    "enqueueSetState": [Function],
+                    "isMounted": [Function],
+                  },
+                },
+                "tag": 1,
+                "treeBaseDuration": 0,
+                "type": [Function],
+                "updateQueue": null,
+              },
+              "_debugSource": null,
+              "actualDuration": 0,
+              "actualStartTime": -1,
+              "alternate": null,
+              "child": [Circular],
+              "childExpirationTime": 0,
+              "contextDependencies": null,
+              "effectTag": 1,
+              "elementType": [Function],
+              "expirationTime": 0,
+              "firstEffect": null,
+              "index": 0,
+              "key": null,
+              "lastEffect": null,
+              "memoizedProps": Object {
+                "children": <AuthenticatedRoute
+                  authenticated={true}
+                  component={[Function]}
+                  path="/dashboard"
+                />,
+              },
+              "memoizedState": null,
+              "mode": 0,
+              "nextEffect": null,
+              "pendingProps": Object {
+                "children": <AuthenticatedRoute
+                  authenticated={true}
+                  component={[Function]}
+                  path="/dashboard"
+                />,
+              },
+              "ref": null,
+              "return": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 62,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": null,
+                "_debugSource": null,
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": null,
+                "child": [Circular],
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 1,
+                "elementType": [Function],
+                "expirationTime": 0,
+                "firstEffect": null,
+                "index": 0,
+                "key": null,
+                "lastEffect": null,
+                "memoizedProps": Object {
+                  "Component": [Function],
+                  "context": null,
+                  "props": Object {
+                    "children": <AuthenticatedRoute
+                      authenticated={true}
+                      component={[Function]}
+                      path="/dashboard"
+                    />,
+                  },
+                  "wrappingComponentProps": null,
+                },
+                "memoizedState": Object {
+                  "context": null,
+                  "mount": true,
+                  "props": Object {
+                    "children": <AuthenticatedRoute
+                      authenticated={true}
+                      component={[Function]}
+                      path="/dashboard"
+                    />,
+                  },
+                  "wrappingComponentProps": null,
+                },
+                "mode": 0,
+                "nextEffect": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 60,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": null,
+                  "_debugSource": null,
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 60,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": null,
+                    "_debugSource": null,
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": [Circular],
+                    "child": null,
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 0,
+                    "elementType": null,
+                    "expirationTime": 1073741823,
+                    "firstEffect": null,
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": null,
+                    "memoizedProps": null,
+                    "memoizedState": null,
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": null,
+                    "ref": null,
+                    "return": null,
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": Object {
+                      "containerInfo": <div />,
+                      "context": Object {},
+                      "current": [Circular],
+                      "didError": false,
+                      "earliestPendingTime": 0,
+                      "earliestSuspendedTime": 0,
+                      "expirationTime": 0,
+                      "finishedWork": null,
+                      "firstBatch": null,
+                      "hydrate": false,
+                      "interactionThreadID": 15,
+                      "latestPendingTime": 0,
+                      "latestPingedTime": 0,
+                      "latestSuspendedTime": 0,
+                      "memoizedInteractions": Set {},
+                      "nextExpirationTimeToWorkOn": 0,
+                      "nextScheduledRoot": null,
+                      "pendingChildren": null,
+                      "pendingCommitExpirationTime": 0,
+                      "pendingContext": null,
+                      "pendingInteractionMap": Map {},
+                      "pingCache": null,
+                      "timeoutHandle": -1,
+                    },
+                    "tag": 3,
+                    "treeBaseDuration": 0,
+                    "type": null,
+                    "updateQueue": Object {
+                      "baseState": null,
+                      "firstCapturedEffect": null,
+                      "firstCapturedUpdate": null,
+                      "firstEffect": null,
+                      "firstUpdate": Object {
+                        "callback": null,
+                        "expirationTime": 1073741823,
+                        "next": null,
+                        "nextEffect": null,
+                        "payload": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={
+                              Object {
+                                "children": <AuthenticatedRoute
+                                  authenticated={true}
+                                  component={[Function]}
+                                  path="/dashboard"
+                                />,
+                              }
+                            }
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "tag": 0,
+                      },
+                      "lastCapturedEffect": null,
+                      "lastCapturedUpdate": null,
+                      "lastEffect": null,
+                      "lastUpdate": Object {
+                        "callback": null,
+                        "expirationTime": 1073741823,
+                        "next": null,
+                        "nextEffect": null,
+                        "payload": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={
+                              Object {
+                                "children": <AuthenticatedRoute
+                                  authenticated={true}
+                                  component={[Function]}
+                                  path="/dashboard"
+                                />,
+                              }
+                            }
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "tag": 0,
+                      },
+                    },
+                  },
+                  "child": [Circular],
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 32,
+                  "elementType": null,
+                  "expirationTime": 0,
+                  "firstEffect": [Circular],
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": [Circular],
+                  "memoizedProps": null,
+                  "memoizedState": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={
+                        Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        }
+                      }
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "mode": 0,
+                  "nextEffect": null,
+                  "pendingProps": null,
+                  "ref": null,
+                  "return": null,
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": Object {
+                    "containerInfo": <div />,
+                    "context": Object {},
+                    "current": [Circular],
+                    "didError": false,
+                    "earliestPendingTime": 0,
+                    "earliestSuspendedTime": 0,
+                    "expirationTime": 0,
+                    "finishedWork": null,
+                    "firstBatch": null,
+                    "hydrate": false,
+                    "interactionThreadID": 15,
+                    "latestPendingTime": 0,
+                    "latestPingedTime": 0,
+                    "latestSuspendedTime": 0,
+                    "memoizedInteractions": Set {},
+                    "nextExpirationTimeToWorkOn": 0,
+                    "nextScheduledRoot": null,
+                    "pendingChildren": null,
+                    "pendingCommitExpirationTime": 0,
+                    "pendingContext": null,
+                    "pendingInteractionMap": Map {},
+                    "pingCache": null,
+                    "timeoutHandle": -1,
+                  },
+                  "tag": 3,
+                  "treeBaseDuration": 0,
+                  "type": null,
+                  "updateQueue": Object {
+                    "baseState": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={
+                          Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          }
+                        }
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "firstCapturedEffect": null,
+                    "firstCapturedUpdate": null,
+                    "firstEffect": null,
+                    "firstUpdate": null,
+                    "lastCapturedEffect": null,
+                    "lastCapturedUpdate": null,
+                    "lastEffect": null,
+                    "lastUpdate": null,
+                  },
+                },
+                "pendingProps": Object {
+                  "Component": [Function],
+                  "context": null,
+                  "props": Object {
+                    "children": <AuthenticatedRoute
+                      authenticated={true}
+                      component={[Function]}
+                      path="/dashboard"
+                    />,
+                  },
+                  "wrappingComponentProps": null,
+                },
+                "ref": null,
+                "return": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 60,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": null,
+                  "_debugSource": null,
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 60,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": null,
+                    "_debugSource": null,
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": [Circular],
+                    "child": null,
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 0,
+                    "elementType": null,
+                    "expirationTime": 1073741823,
+                    "firstEffect": null,
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": null,
+                    "memoizedProps": null,
+                    "memoizedState": null,
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": null,
+                    "ref": null,
+                    "return": null,
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": Object {
+                      "containerInfo": <div />,
+                      "context": Object {},
+                      "current": [Circular],
+                      "didError": false,
+                      "earliestPendingTime": 0,
+                      "earliestSuspendedTime": 0,
+                      "expirationTime": 0,
+                      "finishedWork": null,
+                      "firstBatch": null,
+                      "hydrate": false,
+                      "interactionThreadID": 15,
+                      "latestPendingTime": 0,
+                      "latestPingedTime": 0,
+                      "latestSuspendedTime": 0,
+                      "memoizedInteractions": Set {},
+                      "nextExpirationTimeToWorkOn": 0,
+                      "nextScheduledRoot": null,
+                      "pendingChildren": null,
+                      "pendingCommitExpirationTime": 0,
+                      "pendingContext": null,
+                      "pendingInteractionMap": Map {},
+                      "pingCache": null,
+                      "timeoutHandle": -1,
+                    },
+                    "tag": 3,
+                    "treeBaseDuration": 0,
+                    "type": null,
+                    "updateQueue": Object {
+                      "baseState": null,
+                      "firstCapturedEffect": null,
+                      "firstCapturedUpdate": null,
+                      "firstEffect": null,
+                      "firstUpdate": Object {
+                        "callback": null,
+                        "expirationTime": 1073741823,
+                        "next": null,
+                        "nextEffect": null,
+                        "payload": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={
+                              Object {
+                                "children": <AuthenticatedRoute
+                                  authenticated={true}
+                                  component={[Function]}
+                                  path="/dashboard"
+                                />,
+                              }
+                            }
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "tag": 0,
+                      },
+                      "lastCapturedEffect": null,
+                      "lastCapturedUpdate": null,
+                      "lastEffect": null,
+                      "lastUpdate": Object {
+                        "callback": null,
+                        "expirationTime": 1073741823,
+                        "next": null,
+                        "nextEffect": null,
+                        "payload": Object {
+                          "element": <WrapperComponent
+                            Component={[Function]}
+                            context={null}
+                            props={
+                              Object {
+                                "children": <AuthenticatedRoute
+                                  authenticated={true}
+                                  component={[Function]}
+                                  path="/dashboard"
+                                />,
+                              }
+                            }
+                            wrappingComponentProps={null}
+                          />,
+                        },
+                        "tag": 0,
+                      },
+                    },
+                  },
+                  "child": [Circular],
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 32,
+                  "elementType": null,
+                  "expirationTime": 0,
+                  "firstEffect": [Circular],
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": [Circular],
+                  "memoizedProps": null,
+                  "memoizedState": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={
+                        Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        }
+                      }
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "mode": 0,
+                  "nextEffect": null,
+                  "pendingProps": null,
+                  "ref": null,
+                  "return": null,
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": Object {
+                    "containerInfo": <div />,
+                    "context": Object {},
+                    "current": [Circular],
+                    "didError": false,
+                    "earliestPendingTime": 0,
+                    "earliestSuspendedTime": 0,
+                    "expirationTime": 0,
+                    "finishedWork": null,
+                    "firstBatch": null,
+                    "hydrate": false,
+                    "interactionThreadID": 15,
+                    "latestPendingTime": 0,
+                    "latestPingedTime": 0,
+                    "latestSuspendedTime": 0,
+                    "memoizedInteractions": Set {},
+                    "nextExpirationTimeToWorkOn": 0,
+                    "nextScheduledRoot": null,
+                    "pendingChildren": null,
+                    "pendingCommitExpirationTime": 0,
+                    "pendingContext": null,
+                    "pendingInteractionMap": Map {},
+                    "pingCache": null,
+                    "timeoutHandle": -1,
+                  },
+                  "tag": 3,
+                  "treeBaseDuration": 0,
+                  "type": null,
+                  "updateQueue": Object {
+                    "baseState": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={
+                          Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          }
+                        }
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "firstCapturedEffect": null,
+                    "firstCapturedUpdate": null,
+                    "firstEffect": null,
+                    "firstUpdate": null,
+                    "lastCapturedEffect": null,
+                    "lastCapturedUpdate": null,
+                    "lastEffect": null,
+                    "lastUpdate": null,
+                  },
+                },
+                "selfBaseDuration": 0,
+                "sibling": null,
+                "stateNode": WrapperComponent {
+                  "_reactInternalFiber": [Circular],
+                  "_reactInternalInstance": Object {},
+                  "context": Object {},
+                  "props": Object {
+                    "Component": [Function],
+                    "context": null,
+                    "props": Object {
+                      "children": <AuthenticatedRoute
+                        authenticated={true}
+                        component={[Function]}
+                        path="/dashboard"
+                      />,
+                    },
+                    "wrappingComponentProps": null,
+                  },
+                  "refs": Object {},
+                  "rootFinderInstance": null,
+                  "state": Object {
+                    "context": null,
+                    "mount": true,
+                    "props": Object {
+                      "children": <AuthenticatedRoute
+                        authenticated={true}
+                        component={[Function]}
+                        path="/dashboard"
+                      />,
+                    },
+                    "wrappingComponentProps": null,
+                  },
+                  "updater": Object {
+                    "enqueueForceUpdate": [Function],
+                    "enqueueReplaceState": [Function],
+                    "enqueueSetState": [Function],
+                    "isMounted": [Function],
+                  },
+                },
+                "tag": 1,
+                "treeBaseDuration": 0,
+                "type": [Function],
+                "updateQueue": null,
+              },
+              "selfBaseDuration": 0,
+              "sibling": null,
+              "stateNode": BrowserRouter {
+                "_reactInternalFiber": [Circular],
+                "_reactInternalInstance": Object {},
+                "context": Object {},
+                "history": Object {
+                  "action": "POP",
+                  "block": [Function],
+                  "createHref": [Function],
+                  "go": [Function],
+                  "goBack": [Function],
+                  "goForward": [Function],
+                  "length": 1,
+                  "listen": [Function],
+                  "location": Object {
+                    "hash": "",
+                    "pathname": "/",
+                    "search": "",
+                    "state": undefined,
+                  },
+                  "push": [Function],
+                  "replace": [Function],
+                },
+                "props": Object {
+                  "children": <AuthenticatedRoute
+                    authenticated={true}
+                    component={[Function]}
+                    path="/dashboard"
+                  />,
+                },
+                "refs": Object {},
+                "state": null,
+                "updater": Object {
+                  "enqueueForceUpdate": [Function],
+                  "enqueueReplaceState": [Function],
+                  "enqueueSetState": [Function],
+                  "isMounted": [Function],
+                },
+              },
+              "tag": 1,
+              "treeBaseDuration": 0,
+              "type": [Function],
+              "updateQueue": null,
+            },
+            "selfBaseDuration": 0,
+            "sibling": null,
+            "stateNode": [Circular],
+            "tag": 1,
+            "treeBaseDuration": 0,
+            "type": [Function],
+            "updateQueue": null,
+          },
+          "_reactInternalInstance": Object {},
+          "context": Object {
+            "router": undefined,
+          },
+          "props": Object {
+            "children": <AuthenticatedRoute
+              authenticated={true}
+              component={[Function]}
+              path="/dashboard"
+            />,
+            "history": Object {
+              "action": "POP",
+              "block": [Function],
+              "createHref": [Function],
+              "go": [Function],
+              "goBack": [Function],
+              "goForward": [Function],
+              "length": 1,
+              "listen": [Function],
+              "location": Object {
+                "hash": "",
+                "pathname": "/",
+                "search": "",
+                "state": undefined,
+              },
+              "push": [Function],
+              "replace": [Function],
+            },
+          },
+          "refs": Object {},
+          "state": Object {
+            "match": Object {
+              "isExact": true,
+              "params": Object {},
+              "path": "/",
+              "url": "/",
+            },
+          },
+          "unlisten": [Function],
+          "updater": Object {
+            "enqueueForceUpdate": [Function],
+            "enqueueReplaceState": [Function],
+            "enqueueSetState": [Function],
+            "isMounted": [Function],
+          },
+        },
+        "key": undefined,
+        "nodeType": "class",
+        "props": Object {
+          "children": <AuthenticatedRoute
+            authenticated={true}
+            component={[Function]}
+            path="/dashboard"
+          />,
+          "history": Object {
+            "action": "POP",
+            "block": [Function],
+            "createHref": [Function],
+            "go": [Function],
+            "goBack": [Function],
+            "goForward": [Function],
+            "length": 1,
+            "listen": [Function],
+            "location": Object {
+              "hash": "",
+              "pathname": "/",
+              "search": "",
+              "state": undefined,
+            },
+            "push": [Function],
+            "replace": [Function],
+          },
+        },
+        "ref": null,
+        "rendered": Object {
+          "instance": null,
+          "key": undefined,
+          "nodeType": "function",
+          "props": Object {
+            "authenticated": true,
+            "component": [Function],
+            "path": "/dashboard",
+          },
+          "ref": null,
+          "rendered": Object {
+            "instance": Route {
+              "__reactInternalMemoizedMaskedChildContext": Object {
+                "router": Object {
+                  "history": Object {
+                    "action": "POP",
+                    "block": [Function],
+                    "createHref": [Function],
+                    "go": [Function],
+                    "goBack": [Function],
+                    "goForward": [Function],
+                    "length": 1,
+                    "listen": [Function],
+                    "location": Object {
+                      "hash": "",
+                      "pathname": "/",
+                      "search": "",
+                      "state": undefined,
+                    },
+                    "push": [Function],
+                    "replace": [Function],
+                  },
+                  "route": Object {
+                    "location": Object {
+                      "hash": "",
+                      "pathname": "/",
+                      "search": "",
+                      "state": undefined,
+                    },
+                    "match": Object {
+                      "isExact": true,
+                      "params": Object {},
+                      "path": "/",
+                      "url": "/",
+                    },
+                  },
+                },
+              },
+              "__reactInternalMemoizedMergedChildContext": Object {
+                "router": Object {
+                  "history": Object {
+                    "action": "POP",
+                    "block": [Function],
+                    "createHref": [Function],
+                    "go": [Function],
+                    "goBack": [Function],
+                    "goForward": [Function],
+                    "length": 1,
+                    "listen": [Function],
+                    "location": Object {
+                      "hash": "",
+                      "pathname": "/",
+                      "search": "",
+                      "state": undefined,
+                    },
+                    "push": [Function],
+                    "replace": [Function],
+                  },
+                  "route": Object {
+                    "location": Object {
+                      "hash": "",
+                      "pathname": "/",
+                      "search": "",
+                      "state": undefined,
+                    },
+                    "match": null,
+                  },
+                },
+              },
+              "__reactInternalMemoizedUnmaskedChildContext": Object {
+                "router": Object {
+                  "history": Object {
+                    "action": "POP",
+                    "block": [Function],
+                    "createHref": [Function],
+                    "go": [Function],
+                    "goBack": [Function],
+                    "goForward": [Function],
+                    "length": 1,
+                    "listen": [Function],
+                    "location": Object {
+                      "hash": "",
+                      "pathname": "/",
+                      "search": "",
+                      "state": undefined,
+                    },
+                    "push": [Function],
+                    "replace": [Function],
+                  },
+                  "route": Object {
+                    "location": Object {
+                      "hash": "",
+                      "pathname": "/",
+                      "search": "",
+                      "state": undefined,
+                    },
+                    "match": Object {
+                      "isExact": true,
+                      "params": Object {},
+                      "path": "/",
+                      "url": "/",
+                    },
+                  },
+                },
+              },
+              "_reactInternalFiber": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 66,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 65,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": null,
+                  "_debugSource": Object {
+                    "fileName": "/Users/home/Documents/Projects/javascript/Andela/bp-esa/bp-esa-frontend/src/App.test.jsx",
+                    "lineNumber": 123,
+                  },
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": null,
+                  "child": [Circular],
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 1,
+                  "elementType": [Function],
+                  "expirationTime": 0,
+                  "firstEffect": null,
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": null,
+                  "memoizedProps": Object {
+                    "authenticated": true,
+                    "component": [Function],
+                    "path": "/dashboard",
+                  },
+                  "memoizedState": null,
+                  "mode": 0,
+                  "nextEffect": null,
+                  "pendingProps": Object {
+                    "authenticated": true,
+                    "component": [Function],
+                    "path": "/dashboard",
+                  },
+                  "ref": null,
+                  "return": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 64,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": FiberNode {
+                      "_debugHookTypes": null,
+                      "_debugID": 63,
+                      "_debugIsCurrentlyTiming": false,
+                      "_debugOwner": FiberNode {
+                        "_debugHookTypes": null,
+                        "_debugID": 62,
+                        "_debugIsCurrentlyTiming": false,
+                        "_debugOwner": null,
+                        "_debugSource": null,
+                        "actualDuration": 0,
+                        "actualStartTime": -1,
+                        "alternate": null,
+                        "child": [Circular],
+                        "childExpirationTime": 0,
+                        "contextDependencies": null,
+                        "effectTag": 1,
+                        "elementType": [Function],
+                        "expirationTime": 0,
+                        "firstEffect": null,
+                        "index": 0,
+                        "key": null,
+                        "lastEffect": null,
+                        "memoizedProps": Object {
+                          "Component": [Function],
+                          "context": null,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "memoizedState": Object {
+                          "context": null,
+                          "mount": true,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "mode": 0,
+                        "nextEffect": FiberNode {
+                          "_debugHookTypes": null,
+                          "_debugID": 60,
+                          "_debugIsCurrentlyTiming": false,
+                          "_debugOwner": null,
+                          "_debugSource": null,
+                          "actualDuration": 0,
+                          "actualStartTime": -1,
+                          "alternate": FiberNode {
+                            "_debugHookTypes": null,
+                            "_debugID": 60,
+                            "_debugIsCurrentlyTiming": false,
+                            "_debugOwner": null,
+                            "_debugSource": null,
+                            "actualDuration": 0,
+                            "actualStartTime": -1,
+                            "alternate": [Circular],
+                            "child": null,
+                            "childExpirationTime": 0,
+                            "contextDependencies": null,
+                            "effectTag": 0,
+                            "elementType": null,
+                            "expirationTime": 1073741823,
+                            "firstEffect": null,
+                            "index": 0,
+                            "key": null,
+                            "lastEffect": null,
+                            "memoizedProps": null,
+                            "memoizedState": null,
+                            "mode": 0,
+                            "nextEffect": null,
+                            "pendingProps": null,
+                            "ref": null,
+                            "return": null,
+                            "selfBaseDuration": 0,
+                            "sibling": null,
+                            "stateNode": Object {
+                              "containerInfo": <div />,
+                              "context": Object {},
+                              "current": [Circular],
+                              "didError": false,
+                              "earliestPendingTime": 0,
+                              "earliestSuspendedTime": 0,
+                              "expirationTime": 0,
+                              "finishedWork": null,
+                              "firstBatch": null,
+                              "hydrate": false,
+                              "interactionThreadID": 15,
+                              "latestPendingTime": 0,
+                              "latestPingedTime": 0,
+                              "latestSuspendedTime": 0,
+                              "memoizedInteractions": Set {},
+                              "nextExpirationTimeToWorkOn": 0,
+                              "nextScheduledRoot": null,
+                              "pendingChildren": null,
+                              "pendingCommitExpirationTime": 0,
+                              "pendingContext": null,
+                              "pendingInteractionMap": Map {},
+                              "pingCache": null,
+                              "timeoutHandle": -1,
+                            },
+                            "tag": 3,
+                            "treeBaseDuration": 0,
+                            "type": null,
+                            "updateQueue": Object {
+                              "baseState": null,
+                              "firstCapturedEffect": null,
+                              "firstCapturedUpdate": null,
+                              "firstEffect": null,
+                              "firstUpdate": Object {
+                                "callback": null,
+                                "expirationTime": 1073741823,
+                                "next": null,
+                                "nextEffect": null,
+                                "payload": Object {
+                                  "element": <WrapperComponent
+                                    Component={[Function]}
+                                    context={null}
+                                    props={
+                                      Object {
+                                        "children": <AuthenticatedRoute
+                                          authenticated={true}
+                                          component={[Function]}
+                                          path="/dashboard"
+                                        />,
+                                      }
+                                    }
+                                    wrappingComponentProps={null}
+                                  />,
+                                },
+                                "tag": 0,
+                              },
+                              "lastCapturedEffect": null,
+                              "lastCapturedUpdate": null,
+                              "lastEffect": null,
+                              "lastUpdate": Object {
+                                "callback": null,
+                                "expirationTime": 1073741823,
+                                "next": null,
+                                "nextEffect": null,
+                                "payload": Object {
+                                  "element": <WrapperComponent
+                                    Component={[Function]}
+                                    context={null}
+                                    props={
+                                      Object {
+                                        "children": <AuthenticatedRoute
+                                          authenticated={true}
+                                          component={[Function]}
+                                          path="/dashboard"
+                                        />,
+                                      }
+                                    }
+                                    wrappingComponentProps={null}
+                                  />,
+                                },
+                                "tag": 0,
+                              },
+                            },
+                          },
+                          "child": [Circular],
+                          "childExpirationTime": 0,
+                          "contextDependencies": null,
+                          "effectTag": 32,
+                          "elementType": null,
+                          "expirationTime": 0,
+                          "firstEffect": [Circular],
+                          "index": 0,
+                          "key": null,
+                          "lastEffect": [Circular],
+                          "memoizedProps": null,
+                          "memoizedState": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={
+                                Object {
+                                  "children": <AuthenticatedRoute
+                                    authenticated={true}
+                                    component={[Function]}
+                                    path="/dashboard"
+                                  />,
+                                }
+                              }
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "mode": 0,
+                          "nextEffect": null,
+                          "pendingProps": null,
+                          "ref": null,
+                          "return": null,
+                          "selfBaseDuration": 0,
+                          "sibling": null,
+                          "stateNode": Object {
+                            "containerInfo": <div />,
+                            "context": Object {},
+                            "current": [Circular],
+                            "didError": false,
+                            "earliestPendingTime": 0,
+                            "earliestSuspendedTime": 0,
+                            "expirationTime": 0,
+                            "finishedWork": null,
+                            "firstBatch": null,
+                            "hydrate": false,
+                            "interactionThreadID": 15,
+                            "latestPendingTime": 0,
+                            "latestPingedTime": 0,
+                            "latestSuspendedTime": 0,
+                            "memoizedInteractions": Set {},
+                            "nextExpirationTimeToWorkOn": 0,
+                            "nextScheduledRoot": null,
+                            "pendingChildren": null,
+                            "pendingCommitExpirationTime": 0,
+                            "pendingContext": null,
+                            "pendingInteractionMap": Map {},
+                            "pingCache": null,
+                            "timeoutHandle": -1,
+                          },
+                          "tag": 3,
+                          "treeBaseDuration": 0,
+                          "type": null,
+                          "updateQueue": Object {
+                            "baseState": Object {
+                              "element": <WrapperComponent
+                                Component={[Function]}
+                                context={null}
+                                props={
+                                  Object {
+                                    "children": <AuthenticatedRoute
+                                      authenticated={true}
+                                      component={[Function]}
+                                      path="/dashboard"
+                                    />,
+                                  }
+                                }
+                                wrappingComponentProps={null}
+                              />,
+                            },
+                            "firstCapturedEffect": null,
+                            "firstCapturedUpdate": null,
+                            "firstEffect": null,
+                            "firstUpdate": null,
+                            "lastCapturedEffect": null,
+                            "lastCapturedUpdate": null,
+                            "lastEffect": null,
+                            "lastUpdate": null,
+                          },
+                        },
+                        "pendingProps": Object {
+                          "Component": [Function],
+                          "context": null,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "ref": null,
+                        "return": FiberNode {
+                          "_debugHookTypes": null,
+                          "_debugID": 60,
+                          "_debugIsCurrentlyTiming": false,
+                          "_debugOwner": null,
+                          "_debugSource": null,
+                          "actualDuration": 0,
+                          "actualStartTime": -1,
+                          "alternate": FiberNode {
+                            "_debugHookTypes": null,
+                            "_debugID": 60,
+                            "_debugIsCurrentlyTiming": false,
+                            "_debugOwner": null,
+                            "_debugSource": null,
+                            "actualDuration": 0,
+                            "actualStartTime": -1,
+                            "alternate": [Circular],
+                            "child": null,
+                            "childExpirationTime": 0,
+                            "contextDependencies": null,
+                            "effectTag": 0,
+                            "elementType": null,
+                            "expirationTime": 1073741823,
+                            "firstEffect": null,
+                            "index": 0,
+                            "key": null,
+                            "lastEffect": null,
+                            "memoizedProps": null,
+                            "memoizedState": null,
+                            "mode": 0,
+                            "nextEffect": null,
+                            "pendingProps": null,
+                            "ref": null,
+                            "return": null,
+                            "selfBaseDuration": 0,
+                            "sibling": null,
+                            "stateNode": Object {
+                              "containerInfo": <div />,
+                              "context": Object {},
+                              "current": [Circular],
+                              "didError": false,
+                              "earliestPendingTime": 0,
+                              "earliestSuspendedTime": 0,
+                              "expirationTime": 0,
+                              "finishedWork": null,
+                              "firstBatch": null,
+                              "hydrate": false,
+                              "interactionThreadID": 15,
+                              "latestPendingTime": 0,
+                              "latestPingedTime": 0,
+                              "latestSuspendedTime": 0,
+                              "memoizedInteractions": Set {},
+                              "nextExpirationTimeToWorkOn": 0,
+                              "nextScheduledRoot": null,
+                              "pendingChildren": null,
+                              "pendingCommitExpirationTime": 0,
+                              "pendingContext": null,
+                              "pendingInteractionMap": Map {},
+                              "pingCache": null,
+                              "timeoutHandle": -1,
+                            },
+                            "tag": 3,
+                            "treeBaseDuration": 0,
+                            "type": null,
+                            "updateQueue": Object {
+                              "baseState": null,
+                              "firstCapturedEffect": null,
+                              "firstCapturedUpdate": null,
+                              "firstEffect": null,
+                              "firstUpdate": Object {
+                                "callback": null,
+                                "expirationTime": 1073741823,
+                                "next": null,
+                                "nextEffect": null,
+                                "payload": Object {
+                                  "element": <WrapperComponent
+                                    Component={[Function]}
+                                    context={null}
+                                    props={
+                                      Object {
+                                        "children": <AuthenticatedRoute
+                                          authenticated={true}
+                                          component={[Function]}
+                                          path="/dashboard"
+                                        />,
+                                      }
+                                    }
+                                    wrappingComponentProps={null}
+                                  />,
+                                },
+                                "tag": 0,
+                              },
+                              "lastCapturedEffect": null,
+                              "lastCapturedUpdate": null,
+                              "lastEffect": null,
+                              "lastUpdate": Object {
+                                "callback": null,
+                                "expirationTime": 1073741823,
+                                "next": null,
+                                "nextEffect": null,
+                                "payload": Object {
+                                  "element": <WrapperComponent
+                                    Component={[Function]}
+                                    context={null}
+                                    props={
+                                      Object {
+                                        "children": <AuthenticatedRoute
+                                          authenticated={true}
+                                          component={[Function]}
+                                          path="/dashboard"
+                                        />,
+                                      }
+                                    }
+                                    wrappingComponentProps={null}
+                                  />,
+                                },
+                                "tag": 0,
+                              },
+                            },
+                          },
+                          "child": [Circular],
+                          "childExpirationTime": 0,
+                          "contextDependencies": null,
+                          "effectTag": 32,
+                          "elementType": null,
+                          "expirationTime": 0,
+                          "firstEffect": [Circular],
+                          "index": 0,
+                          "key": null,
+                          "lastEffect": [Circular],
+                          "memoizedProps": null,
+                          "memoizedState": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={
+                                Object {
+                                  "children": <AuthenticatedRoute
+                                    authenticated={true}
+                                    component={[Function]}
+                                    path="/dashboard"
+                                  />,
+                                }
+                              }
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "mode": 0,
+                          "nextEffect": null,
+                          "pendingProps": null,
+                          "ref": null,
+                          "return": null,
+                          "selfBaseDuration": 0,
+                          "sibling": null,
+                          "stateNode": Object {
+                            "containerInfo": <div />,
+                            "context": Object {},
+                            "current": [Circular],
+                            "didError": false,
+                            "earliestPendingTime": 0,
+                            "earliestSuspendedTime": 0,
+                            "expirationTime": 0,
+                            "finishedWork": null,
+                            "firstBatch": null,
+                            "hydrate": false,
+                            "interactionThreadID": 15,
+                            "latestPendingTime": 0,
+                            "latestPingedTime": 0,
+                            "latestSuspendedTime": 0,
+                            "memoizedInteractions": Set {},
+                            "nextExpirationTimeToWorkOn": 0,
+                            "nextScheduledRoot": null,
+                            "pendingChildren": null,
+                            "pendingCommitExpirationTime": 0,
+                            "pendingContext": null,
+                            "pendingInteractionMap": Map {},
+                            "pingCache": null,
+                            "timeoutHandle": -1,
+                          },
+                          "tag": 3,
+                          "treeBaseDuration": 0,
+                          "type": null,
+                          "updateQueue": Object {
+                            "baseState": Object {
+                              "element": <WrapperComponent
+                                Component={[Function]}
+                                context={null}
+                                props={
+                                  Object {
+                                    "children": <AuthenticatedRoute
+                                      authenticated={true}
+                                      component={[Function]}
+                                      path="/dashboard"
+                                    />,
+                                  }
+                                }
+                                wrappingComponentProps={null}
+                              />,
+                            },
+                            "firstCapturedEffect": null,
+                            "firstCapturedUpdate": null,
+                            "firstEffect": null,
+                            "firstUpdate": null,
+                            "lastCapturedEffect": null,
+                            "lastCapturedUpdate": null,
+                            "lastEffect": null,
+                            "lastUpdate": null,
+                          },
+                        },
+                        "selfBaseDuration": 0,
+                        "sibling": null,
+                        "stateNode": WrapperComponent {
+                          "_reactInternalFiber": [Circular],
+                          "_reactInternalInstance": Object {},
+                          "context": Object {},
+                          "props": Object {
+                            "Component": [Function],
+                            "context": null,
+                            "props": Object {
+                              "children": <AuthenticatedRoute
+                                authenticated={true}
+                                component={[Function]}
+                                path="/dashboard"
+                              />,
+                            },
+                            "wrappingComponentProps": null,
+                          },
+                          "refs": Object {},
+                          "rootFinderInstance": null,
+                          "state": Object {
+                            "context": null,
+                            "mount": true,
+                            "props": Object {
+                              "children": <AuthenticatedRoute
+                                authenticated={true}
+                                component={[Function]}
+                                path="/dashboard"
+                              />,
+                            },
+                            "wrappingComponentProps": null,
+                          },
+                          "updater": Object {
+                            "enqueueForceUpdate": [Function],
+                            "enqueueReplaceState": [Function],
+                            "enqueueSetState": [Function],
+                            "isMounted": [Function],
+                          },
+                        },
+                        "tag": 1,
+                        "treeBaseDuration": 0,
+                        "type": [Function],
+                        "updateQueue": null,
+                      },
+                      "_debugSource": null,
+                      "actualDuration": 0,
+                      "actualStartTime": -1,
+                      "alternate": null,
+                      "child": [Circular],
+                      "childExpirationTime": 0,
+                      "contextDependencies": null,
+                      "effectTag": 1,
+                      "elementType": [Function],
+                      "expirationTime": 0,
+                      "firstEffect": null,
+                      "index": 0,
+                      "key": null,
+                      "lastEffect": null,
+                      "memoizedProps": Object {
+                        "children": <AuthenticatedRoute
+                          authenticated={true}
+                          component={[Function]}
+                          path="/dashboard"
+                        />,
+                      },
+                      "memoizedState": null,
+                      "mode": 0,
+                      "nextEffect": null,
+                      "pendingProps": Object {
+                        "children": <AuthenticatedRoute
+                          authenticated={true}
+                          component={[Function]}
+                          path="/dashboard"
+                        />,
+                      },
+                      "ref": null,
+                      "return": FiberNode {
+                        "_debugHookTypes": null,
+                        "_debugID": 62,
+                        "_debugIsCurrentlyTiming": false,
+                        "_debugOwner": null,
+                        "_debugSource": null,
+                        "actualDuration": 0,
+                        "actualStartTime": -1,
+                        "alternate": null,
+                        "child": [Circular],
+                        "childExpirationTime": 0,
+                        "contextDependencies": null,
+                        "effectTag": 1,
+                        "elementType": [Function],
+                        "expirationTime": 0,
+                        "firstEffect": null,
+                        "index": 0,
+                        "key": null,
+                        "lastEffect": null,
+                        "memoizedProps": Object {
+                          "Component": [Function],
+                          "context": null,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "memoizedState": Object {
+                          "context": null,
+                          "mount": true,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "mode": 0,
+                        "nextEffect": FiberNode {
+                          "_debugHookTypes": null,
+                          "_debugID": 60,
+                          "_debugIsCurrentlyTiming": false,
+                          "_debugOwner": null,
+                          "_debugSource": null,
+                          "actualDuration": 0,
+                          "actualStartTime": -1,
+                          "alternate": FiberNode {
+                            "_debugHookTypes": null,
+                            "_debugID": 60,
+                            "_debugIsCurrentlyTiming": false,
+                            "_debugOwner": null,
+                            "_debugSource": null,
+                            "actualDuration": 0,
+                            "actualStartTime": -1,
+                            "alternate": [Circular],
+                            "child": null,
+                            "childExpirationTime": 0,
+                            "contextDependencies": null,
+                            "effectTag": 0,
+                            "elementType": null,
+                            "expirationTime": 1073741823,
+                            "firstEffect": null,
+                            "index": 0,
+                            "key": null,
+                            "lastEffect": null,
+                            "memoizedProps": null,
+                            "memoizedState": null,
+                            "mode": 0,
+                            "nextEffect": null,
+                            "pendingProps": null,
+                            "ref": null,
+                            "return": null,
+                            "selfBaseDuration": 0,
+                            "sibling": null,
+                            "stateNode": Object {
+                              "containerInfo": <div />,
+                              "context": Object {},
+                              "current": [Circular],
+                              "didError": false,
+                              "earliestPendingTime": 0,
+                              "earliestSuspendedTime": 0,
+                              "expirationTime": 0,
+                              "finishedWork": null,
+                              "firstBatch": null,
+                              "hydrate": false,
+                              "interactionThreadID": 15,
+                              "latestPendingTime": 0,
+                              "latestPingedTime": 0,
+                              "latestSuspendedTime": 0,
+                              "memoizedInteractions": Set {},
+                              "nextExpirationTimeToWorkOn": 0,
+                              "nextScheduledRoot": null,
+                              "pendingChildren": null,
+                              "pendingCommitExpirationTime": 0,
+                              "pendingContext": null,
+                              "pendingInteractionMap": Map {},
+                              "pingCache": null,
+                              "timeoutHandle": -1,
+                            },
+                            "tag": 3,
+                            "treeBaseDuration": 0,
+                            "type": null,
+                            "updateQueue": Object {
+                              "baseState": null,
+                              "firstCapturedEffect": null,
+                              "firstCapturedUpdate": null,
+                              "firstEffect": null,
+                              "firstUpdate": Object {
+                                "callback": null,
+                                "expirationTime": 1073741823,
+                                "next": null,
+                                "nextEffect": null,
+                                "payload": Object {
+                                  "element": <WrapperComponent
+                                    Component={[Function]}
+                                    context={null}
+                                    props={
+                                      Object {
+                                        "children": <AuthenticatedRoute
+                                          authenticated={true}
+                                          component={[Function]}
+                                          path="/dashboard"
+                                        />,
+                                      }
+                                    }
+                                    wrappingComponentProps={null}
+                                  />,
+                                },
+                                "tag": 0,
+                              },
+                              "lastCapturedEffect": null,
+                              "lastCapturedUpdate": null,
+                              "lastEffect": null,
+                              "lastUpdate": Object {
+                                "callback": null,
+                                "expirationTime": 1073741823,
+                                "next": null,
+                                "nextEffect": null,
+                                "payload": Object {
+                                  "element": <WrapperComponent
+                                    Component={[Function]}
+                                    context={null}
+                                    props={
+                                      Object {
+                                        "children": <AuthenticatedRoute
+                                          authenticated={true}
+                                          component={[Function]}
+                                          path="/dashboard"
+                                        />,
+                                      }
+                                    }
+                                    wrappingComponentProps={null}
+                                  />,
+                                },
+                                "tag": 0,
+                              },
+                            },
+                          },
+                          "child": [Circular],
+                          "childExpirationTime": 0,
+                          "contextDependencies": null,
+                          "effectTag": 32,
+                          "elementType": null,
+                          "expirationTime": 0,
+                          "firstEffect": [Circular],
+                          "index": 0,
+                          "key": null,
+                          "lastEffect": [Circular],
+                          "memoizedProps": null,
+                          "memoizedState": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={
+                                Object {
+                                  "children": <AuthenticatedRoute
+                                    authenticated={true}
+                                    component={[Function]}
+                                    path="/dashboard"
+                                  />,
+                                }
+                              }
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "mode": 0,
+                          "nextEffect": null,
+                          "pendingProps": null,
+                          "ref": null,
+                          "return": null,
+                          "selfBaseDuration": 0,
+                          "sibling": null,
+                          "stateNode": Object {
+                            "containerInfo": <div />,
+                            "context": Object {},
+                            "current": [Circular],
+                            "didError": false,
+                            "earliestPendingTime": 0,
+                            "earliestSuspendedTime": 0,
+                            "expirationTime": 0,
+                            "finishedWork": null,
+                            "firstBatch": null,
+                            "hydrate": false,
+                            "interactionThreadID": 15,
+                            "latestPendingTime": 0,
+                            "latestPingedTime": 0,
+                            "latestSuspendedTime": 0,
+                            "memoizedInteractions": Set {},
+                            "nextExpirationTimeToWorkOn": 0,
+                            "nextScheduledRoot": null,
+                            "pendingChildren": null,
+                            "pendingCommitExpirationTime": 0,
+                            "pendingContext": null,
+                            "pendingInteractionMap": Map {},
+                            "pingCache": null,
+                            "timeoutHandle": -1,
+                          },
+                          "tag": 3,
+                          "treeBaseDuration": 0,
+                          "type": null,
+                          "updateQueue": Object {
+                            "baseState": Object {
+                              "element": <WrapperComponent
+                                Component={[Function]}
+                                context={null}
+                                props={
+                                  Object {
+                                    "children": <AuthenticatedRoute
+                                      authenticated={true}
+                                      component={[Function]}
+                                      path="/dashboard"
+                                    />,
+                                  }
+                                }
+                                wrappingComponentProps={null}
+                              />,
+                            },
+                            "firstCapturedEffect": null,
+                            "firstCapturedUpdate": null,
+                            "firstEffect": null,
+                            "firstUpdate": null,
+                            "lastCapturedEffect": null,
+                            "lastCapturedUpdate": null,
+                            "lastEffect": null,
+                            "lastUpdate": null,
+                          },
+                        },
+                        "pendingProps": Object {
+                          "Component": [Function],
+                          "context": null,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "ref": null,
+                        "return": FiberNode {
+                          "_debugHookTypes": null,
+                          "_debugID": 60,
+                          "_debugIsCurrentlyTiming": false,
+                          "_debugOwner": null,
+                          "_debugSource": null,
+                          "actualDuration": 0,
+                          "actualStartTime": -1,
+                          "alternate": FiberNode {
+                            "_debugHookTypes": null,
+                            "_debugID": 60,
+                            "_debugIsCurrentlyTiming": false,
+                            "_debugOwner": null,
+                            "_debugSource": null,
+                            "actualDuration": 0,
+                            "actualStartTime": -1,
+                            "alternate": [Circular],
+                            "child": null,
+                            "childExpirationTime": 0,
+                            "contextDependencies": null,
+                            "effectTag": 0,
+                            "elementType": null,
+                            "expirationTime": 1073741823,
+                            "firstEffect": null,
+                            "index": 0,
+                            "key": null,
+                            "lastEffect": null,
+                            "memoizedProps": null,
+                            "memoizedState": null,
+                            "mode": 0,
+                            "nextEffect": null,
+                            "pendingProps": null,
+                            "ref": null,
+                            "return": null,
+                            "selfBaseDuration": 0,
+                            "sibling": null,
+                            "stateNode": Object {
+                              "containerInfo": <div />,
+                              "context": Object {},
+                              "current": [Circular],
+                              "didError": false,
+                              "earliestPendingTime": 0,
+                              "earliestSuspendedTime": 0,
+                              "expirationTime": 0,
+                              "finishedWork": null,
+                              "firstBatch": null,
+                              "hydrate": false,
+                              "interactionThreadID": 15,
+                              "latestPendingTime": 0,
+                              "latestPingedTime": 0,
+                              "latestSuspendedTime": 0,
+                              "memoizedInteractions": Set {},
+                              "nextExpirationTimeToWorkOn": 0,
+                              "nextScheduledRoot": null,
+                              "pendingChildren": null,
+                              "pendingCommitExpirationTime": 0,
+                              "pendingContext": null,
+                              "pendingInteractionMap": Map {},
+                              "pingCache": null,
+                              "timeoutHandle": -1,
+                            },
+                            "tag": 3,
+                            "treeBaseDuration": 0,
+                            "type": null,
+                            "updateQueue": Object {
+                              "baseState": null,
+                              "firstCapturedEffect": null,
+                              "firstCapturedUpdate": null,
+                              "firstEffect": null,
+                              "firstUpdate": Object {
+                                "callback": null,
+                                "expirationTime": 1073741823,
+                                "next": null,
+                                "nextEffect": null,
+                                "payload": Object {
+                                  "element": <WrapperComponent
+                                    Component={[Function]}
+                                    context={null}
+                                    props={
+                                      Object {
+                                        "children": <AuthenticatedRoute
+                                          authenticated={true}
+                                          component={[Function]}
+                                          path="/dashboard"
+                                        />,
+                                      }
+                                    }
+                                    wrappingComponentProps={null}
+                                  />,
+                                },
+                                "tag": 0,
+                              },
+                              "lastCapturedEffect": null,
+                              "lastCapturedUpdate": null,
+                              "lastEffect": null,
+                              "lastUpdate": Object {
+                                "callback": null,
+                                "expirationTime": 1073741823,
+                                "next": null,
+                                "nextEffect": null,
+                                "payload": Object {
+                                  "element": <WrapperComponent
+                                    Component={[Function]}
+                                    context={null}
+                                    props={
+                                      Object {
+                                        "children": <AuthenticatedRoute
+                                          authenticated={true}
+                                          component={[Function]}
+                                          path="/dashboard"
+                                        />,
+                                      }
+                                    }
+                                    wrappingComponentProps={null}
+                                  />,
+                                },
+                                "tag": 0,
+                              },
+                            },
+                          },
+                          "child": [Circular],
+                          "childExpirationTime": 0,
+                          "contextDependencies": null,
+                          "effectTag": 32,
+                          "elementType": null,
+                          "expirationTime": 0,
+                          "firstEffect": [Circular],
+                          "index": 0,
+                          "key": null,
+                          "lastEffect": [Circular],
+                          "memoizedProps": null,
+                          "memoizedState": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={
+                                Object {
+                                  "children": <AuthenticatedRoute
+                                    authenticated={true}
+                                    component={[Function]}
+                                    path="/dashboard"
+                                  />,
+                                }
+                              }
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "mode": 0,
+                          "nextEffect": null,
+                          "pendingProps": null,
+                          "ref": null,
+                          "return": null,
+                          "selfBaseDuration": 0,
+                          "sibling": null,
+                          "stateNode": Object {
+                            "containerInfo": <div />,
+                            "context": Object {},
+                            "current": [Circular],
+                            "didError": false,
+                            "earliestPendingTime": 0,
+                            "earliestSuspendedTime": 0,
+                            "expirationTime": 0,
+                            "finishedWork": null,
+                            "firstBatch": null,
+                            "hydrate": false,
+                            "interactionThreadID": 15,
+                            "latestPendingTime": 0,
+                            "latestPingedTime": 0,
+                            "latestSuspendedTime": 0,
+                            "memoizedInteractions": Set {},
+                            "nextExpirationTimeToWorkOn": 0,
+                            "nextScheduledRoot": null,
+                            "pendingChildren": null,
+                            "pendingCommitExpirationTime": 0,
+                            "pendingContext": null,
+                            "pendingInteractionMap": Map {},
+                            "pingCache": null,
+                            "timeoutHandle": -1,
+                          },
+                          "tag": 3,
+                          "treeBaseDuration": 0,
+                          "type": null,
+                          "updateQueue": Object {
+                            "baseState": Object {
+                              "element": <WrapperComponent
+                                Component={[Function]}
+                                context={null}
+                                props={
+                                  Object {
+                                    "children": <AuthenticatedRoute
+                                      authenticated={true}
+                                      component={[Function]}
+                                      path="/dashboard"
+                                    />,
+                                  }
+                                }
+                                wrappingComponentProps={null}
+                              />,
+                            },
+                            "firstCapturedEffect": null,
+                            "firstCapturedUpdate": null,
+                            "firstEffect": null,
+                            "firstUpdate": null,
+                            "lastCapturedEffect": null,
+                            "lastCapturedUpdate": null,
+                            "lastEffect": null,
+                            "lastUpdate": null,
+                          },
+                        },
+                        "selfBaseDuration": 0,
+                        "sibling": null,
+                        "stateNode": WrapperComponent {
+                          "_reactInternalFiber": [Circular],
+                          "_reactInternalInstance": Object {},
+                          "context": Object {},
+                          "props": Object {
+                            "Component": [Function],
+                            "context": null,
+                            "props": Object {
+                              "children": <AuthenticatedRoute
+                                authenticated={true}
+                                component={[Function]}
+                                path="/dashboard"
+                              />,
+                            },
+                            "wrappingComponentProps": null,
+                          },
+                          "refs": Object {},
+                          "rootFinderInstance": null,
+                          "state": Object {
+                            "context": null,
+                            "mount": true,
+                            "props": Object {
+                              "children": <AuthenticatedRoute
+                                authenticated={true}
+                                component={[Function]}
+                                path="/dashboard"
+                              />,
+                            },
+                            "wrappingComponentProps": null,
+                          },
+                          "updater": Object {
+                            "enqueueForceUpdate": [Function],
+                            "enqueueReplaceState": [Function],
+                            "enqueueSetState": [Function],
+                            "isMounted": [Function],
+                          },
+                        },
+                        "tag": 1,
+                        "treeBaseDuration": 0,
+                        "type": [Function],
+                        "updateQueue": null,
+                      },
+                      "selfBaseDuration": 0,
+                      "sibling": null,
+                      "stateNode": BrowserRouter {
+                        "_reactInternalFiber": [Circular],
+                        "_reactInternalInstance": Object {},
+                        "context": Object {},
+                        "history": Object {
+                          "action": "POP",
+                          "block": [Function],
+                          "createHref": [Function],
+                          "go": [Function],
+                          "goBack": [Function],
+                          "goForward": [Function],
+                          "length": 1,
+                          "listen": [Function],
+                          "location": Object {
+                            "hash": "",
+                            "pathname": "/",
+                            "search": "",
+                            "state": undefined,
+                          },
+                          "push": [Function],
+                          "replace": [Function],
+                        },
+                        "props": Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        },
+                        "refs": Object {},
+                        "state": null,
+                        "updater": Object {
+                          "enqueueForceUpdate": [Function],
+                          "enqueueReplaceState": [Function],
+                          "enqueueSetState": [Function],
+                          "isMounted": [Function],
+                        },
+                      },
+                      "tag": 1,
+                      "treeBaseDuration": 0,
+                      "type": [Function],
+                      "updateQueue": null,
+                    },
+                    "_debugSource": null,
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": null,
+                    "child": [Circular],
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 1,
+                    "elementType": [Function],
+                    "expirationTime": 0,
+                    "firstEffect": null,
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": null,
+                    "memoizedProps": Object {
+                      "children": <AuthenticatedRoute
+                        authenticated={true}
+                        component={[Function]}
+                        path="/dashboard"
+                      />,
+                      "history": Object {
+                        "action": "POP",
+                        "block": [Function],
+                        "createHref": [Function],
+                        "go": [Function],
+                        "goBack": [Function],
+                        "goForward": [Function],
+                        "length": 1,
+                        "listen": [Function],
+                        "location": Object {
+                          "hash": "",
+                          "pathname": "/",
+                          "search": "",
+                          "state": undefined,
+                        },
+                        "push": [Function],
+                        "replace": [Function],
+                      },
+                    },
+                    "memoizedState": Object {
+                      "match": Object {
+                        "isExact": true,
+                        "params": Object {},
+                        "path": "/",
+                        "url": "/",
+                      },
+                    },
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": Object {
+                      "children": <AuthenticatedRoute
+                        authenticated={true}
+                        component={[Function]}
+                        path="/dashboard"
+                      />,
+                      "history": Object {
+                        "action": "POP",
+                        "block": [Function],
+                        "createHref": [Function],
+                        "go": [Function],
+                        "goBack": [Function],
+                        "goForward": [Function],
+                        "length": 1,
+                        "listen": [Function],
+                        "location": Object {
+                          "hash": "",
+                          "pathname": "/",
+                          "search": "",
+                          "state": undefined,
+                        },
+                        "push": [Function],
+                        "replace": [Function],
+                      },
+                    },
+                    "ref": null,
+                    "return": FiberNode {
+                      "_debugHookTypes": null,
+                      "_debugID": 63,
+                      "_debugIsCurrentlyTiming": false,
+                      "_debugOwner": FiberNode {
+                        "_debugHookTypes": null,
+                        "_debugID": 62,
+                        "_debugIsCurrentlyTiming": false,
+                        "_debugOwner": null,
+                        "_debugSource": null,
+                        "actualDuration": 0,
+                        "actualStartTime": -1,
+                        "alternate": null,
+                        "child": [Circular],
+                        "childExpirationTime": 0,
+                        "contextDependencies": null,
+                        "effectTag": 1,
+                        "elementType": [Function],
+                        "expirationTime": 0,
+                        "firstEffect": null,
+                        "index": 0,
+                        "key": null,
+                        "lastEffect": null,
+                        "memoizedProps": Object {
+                          "Component": [Function],
+                          "context": null,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "memoizedState": Object {
+                          "context": null,
+                          "mount": true,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "mode": 0,
+                        "nextEffect": FiberNode {
+                          "_debugHookTypes": null,
+                          "_debugID": 60,
+                          "_debugIsCurrentlyTiming": false,
+                          "_debugOwner": null,
+                          "_debugSource": null,
+                          "actualDuration": 0,
+                          "actualStartTime": -1,
+                          "alternate": FiberNode {
+                            "_debugHookTypes": null,
+                            "_debugID": 60,
+                            "_debugIsCurrentlyTiming": false,
+                            "_debugOwner": null,
+                            "_debugSource": null,
+                            "actualDuration": 0,
+                            "actualStartTime": -1,
+                            "alternate": [Circular],
+                            "child": null,
+                            "childExpirationTime": 0,
+                            "contextDependencies": null,
+                            "effectTag": 0,
+                            "elementType": null,
+                            "expirationTime": 1073741823,
+                            "firstEffect": null,
+                            "index": 0,
+                            "key": null,
+                            "lastEffect": null,
+                            "memoizedProps": null,
+                            "memoizedState": null,
+                            "mode": 0,
+                            "nextEffect": null,
+                            "pendingProps": null,
+                            "ref": null,
+                            "return": null,
+                            "selfBaseDuration": 0,
+                            "sibling": null,
+                            "stateNode": Object {
+                              "containerInfo": <div />,
+                              "context": Object {},
+                              "current": [Circular],
+                              "didError": false,
+                              "earliestPendingTime": 0,
+                              "earliestSuspendedTime": 0,
+                              "expirationTime": 0,
+                              "finishedWork": null,
+                              "firstBatch": null,
+                              "hydrate": false,
+                              "interactionThreadID": 15,
+                              "latestPendingTime": 0,
+                              "latestPingedTime": 0,
+                              "latestSuspendedTime": 0,
+                              "memoizedInteractions": Set {},
+                              "nextExpirationTimeToWorkOn": 0,
+                              "nextScheduledRoot": null,
+                              "pendingChildren": null,
+                              "pendingCommitExpirationTime": 0,
+                              "pendingContext": null,
+                              "pendingInteractionMap": Map {},
+                              "pingCache": null,
+                              "timeoutHandle": -1,
+                            },
+                            "tag": 3,
+                            "treeBaseDuration": 0,
+                            "type": null,
+                            "updateQueue": Object {
+                              "baseState": null,
+                              "firstCapturedEffect": null,
+                              "firstCapturedUpdate": null,
+                              "firstEffect": null,
+                              "firstUpdate": Object {
+                                "callback": null,
+                                "expirationTime": 1073741823,
+                                "next": null,
+                                "nextEffect": null,
+                                "payload": Object {
+                                  "element": <WrapperComponent
+                                    Component={[Function]}
+                                    context={null}
+                                    props={
+                                      Object {
+                                        "children": <AuthenticatedRoute
+                                          authenticated={true}
+                                          component={[Function]}
+                                          path="/dashboard"
+                                        />,
+                                      }
+                                    }
+                                    wrappingComponentProps={null}
+                                  />,
+                                },
+                                "tag": 0,
+                              },
+                              "lastCapturedEffect": null,
+                              "lastCapturedUpdate": null,
+                              "lastEffect": null,
+                              "lastUpdate": Object {
+                                "callback": null,
+                                "expirationTime": 1073741823,
+                                "next": null,
+                                "nextEffect": null,
+                                "payload": Object {
+                                  "element": <WrapperComponent
+                                    Component={[Function]}
+                                    context={null}
+                                    props={
+                                      Object {
+                                        "children": <AuthenticatedRoute
+                                          authenticated={true}
+                                          component={[Function]}
+                                          path="/dashboard"
+                                        />,
+                                      }
+                                    }
+                                    wrappingComponentProps={null}
+                                  />,
+                                },
+                                "tag": 0,
+                              },
+                            },
+                          },
+                          "child": [Circular],
+                          "childExpirationTime": 0,
+                          "contextDependencies": null,
+                          "effectTag": 32,
+                          "elementType": null,
+                          "expirationTime": 0,
+                          "firstEffect": [Circular],
+                          "index": 0,
+                          "key": null,
+                          "lastEffect": [Circular],
+                          "memoizedProps": null,
+                          "memoizedState": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={
+                                Object {
+                                  "children": <AuthenticatedRoute
+                                    authenticated={true}
+                                    component={[Function]}
+                                    path="/dashboard"
+                                  />,
+                                }
+                              }
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "mode": 0,
+                          "nextEffect": null,
+                          "pendingProps": null,
+                          "ref": null,
+                          "return": null,
+                          "selfBaseDuration": 0,
+                          "sibling": null,
+                          "stateNode": Object {
+                            "containerInfo": <div />,
+                            "context": Object {},
+                            "current": [Circular],
+                            "didError": false,
+                            "earliestPendingTime": 0,
+                            "earliestSuspendedTime": 0,
+                            "expirationTime": 0,
+                            "finishedWork": null,
+                            "firstBatch": null,
+                            "hydrate": false,
+                            "interactionThreadID": 15,
+                            "latestPendingTime": 0,
+                            "latestPingedTime": 0,
+                            "latestSuspendedTime": 0,
+                            "memoizedInteractions": Set {},
+                            "nextExpirationTimeToWorkOn": 0,
+                            "nextScheduledRoot": null,
+                            "pendingChildren": null,
+                            "pendingCommitExpirationTime": 0,
+                            "pendingContext": null,
+                            "pendingInteractionMap": Map {},
+                            "pingCache": null,
+                            "timeoutHandle": -1,
+                          },
+                          "tag": 3,
+                          "treeBaseDuration": 0,
+                          "type": null,
+                          "updateQueue": Object {
+                            "baseState": Object {
+                              "element": <WrapperComponent
+                                Component={[Function]}
+                                context={null}
+                                props={
+                                  Object {
+                                    "children": <AuthenticatedRoute
+                                      authenticated={true}
+                                      component={[Function]}
+                                      path="/dashboard"
+                                    />,
+                                  }
+                                }
+                                wrappingComponentProps={null}
+                              />,
+                            },
+                            "firstCapturedEffect": null,
+                            "firstCapturedUpdate": null,
+                            "firstEffect": null,
+                            "firstUpdate": null,
+                            "lastCapturedEffect": null,
+                            "lastCapturedUpdate": null,
+                            "lastEffect": null,
+                            "lastUpdate": null,
+                          },
+                        },
+                        "pendingProps": Object {
+                          "Component": [Function],
+                          "context": null,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "ref": null,
+                        "return": FiberNode {
+                          "_debugHookTypes": null,
+                          "_debugID": 60,
+                          "_debugIsCurrentlyTiming": false,
+                          "_debugOwner": null,
+                          "_debugSource": null,
+                          "actualDuration": 0,
+                          "actualStartTime": -1,
+                          "alternate": FiberNode {
+                            "_debugHookTypes": null,
+                            "_debugID": 60,
+                            "_debugIsCurrentlyTiming": false,
+                            "_debugOwner": null,
+                            "_debugSource": null,
+                            "actualDuration": 0,
+                            "actualStartTime": -1,
+                            "alternate": [Circular],
+                            "child": null,
+                            "childExpirationTime": 0,
+                            "contextDependencies": null,
+                            "effectTag": 0,
+                            "elementType": null,
+                            "expirationTime": 1073741823,
+                            "firstEffect": null,
+                            "index": 0,
+                            "key": null,
+                            "lastEffect": null,
+                            "memoizedProps": null,
+                            "memoizedState": null,
+                            "mode": 0,
+                            "nextEffect": null,
+                            "pendingProps": null,
+                            "ref": null,
+                            "return": null,
+                            "selfBaseDuration": 0,
+                            "sibling": null,
+                            "stateNode": Object {
+                              "containerInfo": <div />,
+                              "context": Object {},
+                              "current": [Circular],
+                              "didError": false,
+                              "earliestPendingTime": 0,
+                              "earliestSuspendedTime": 0,
+                              "expirationTime": 0,
+                              "finishedWork": null,
+                              "firstBatch": null,
+                              "hydrate": false,
+                              "interactionThreadID": 15,
+                              "latestPendingTime": 0,
+                              "latestPingedTime": 0,
+                              "latestSuspendedTime": 0,
+                              "memoizedInteractions": Set {},
+                              "nextExpirationTimeToWorkOn": 0,
+                              "nextScheduledRoot": null,
+                              "pendingChildren": null,
+                              "pendingCommitExpirationTime": 0,
+                              "pendingContext": null,
+                              "pendingInteractionMap": Map {},
+                              "pingCache": null,
+                              "timeoutHandle": -1,
+                            },
+                            "tag": 3,
+                            "treeBaseDuration": 0,
+                            "type": null,
+                            "updateQueue": Object {
+                              "baseState": null,
+                              "firstCapturedEffect": null,
+                              "firstCapturedUpdate": null,
+                              "firstEffect": null,
+                              "firstUpdate": Object {
+                                "callback": null,
+                                "expirationTime": 1073741823,
+                                "next": null,
+                                "nextEffect": null,
+                                "payload": Object {
+                                  "element": <WrapperComponent
+                                    Component={[Function]}
+                                    context={null}
+                                    props={
+                                      Object {
+                                        "children": <AuthenticatedRoute
+                                          authenticated={true}
+                                          component={[Function]}
+                                          path="/dashboard"
+                                        />,
+                                      }
+                                    }
+                                    wrappingComponentProps={null}
+                                  />,
+                                },
+                                "tag": 0,
+                              },
+                              "lastCapturedEffect": null,
+                              "lastCapturedUpdate": null,
+                              "lastEffect": null,
+                              "lastUpdate": Object {
+                                "callback": null,
+                                "expirationTime": 1073741823,
+                                "next": null,
+                                "nextEffect": null,
+                                "payload": Object {
+                                  "element": <WrapperComponent
+                                    Component={[Function]}
+                                    context={null}
+                                    props={
+                                      Object {
+                                        "children": <AuthenticatedRoute
+                                          authenticated={true}
+                                          component={[Function]}
+                                          path="/dashboard"
+                                        />,
+                                      }
+                                    }
+                                    wrappingComponentProps={null}
+                                  />,
+                                },
+                                "tag": 0,
+                              },
+                            },
+                          },
+                          "child": [Circular],
+                          "childExpirationTime": 0,
+                          "contextDependencies": null,
+                          "effectTag": 32,
+                          "elementType": null,
+                          "expirationTime": 0,
+                          "firstEffect": [Circular],
+                          "index": 0,
+                          "key": null,
+                          "lastEffect": [Circular],
+                          "memoizedProps": null,
+                          "memoizedState": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={
+                                Object {
+                                  "children": <AuthenticatedRoute
+                                    authenticated={true}
+                                    component={[Function]}
+                                    path="/dashboard"
+                                  />,
+                                }
+                              }
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "mode": 0,
+                          "nextEffect": null,
+                          "pendingProps": null,
+                          "ref": null,
+                          "return": null,
+                          "selfBaseDuration": 0,
+                          "sibling": null,
+                          "stateNode": Object {
+                            "containerInfo": <div />,
+                            "context": Object {},
+                            "current": [Circular],
+                            "didError": false,
+                            "earliestPendingTime": 0,
+                            "earliestSuspendedTime": 0,
+                            "expirationTime": 0,
+                            "finishedWork": null,
+                            "firstBatch": null,
+                            "hydrate": false,
+                            "interactionThreadID": 15,
+                            "latestPendingTime": 0,
+                            "latestPingedTime": 0,
+                            "latestSuspendedTime": 0,
+                            "memoizedInteractions": Set {},
+                            "nextExpirationTimeToWorkOn": 0,
+                            "nextScheduledRoot": null,
+                            "pendingChildren": null,
+                            "pendingCommitExpirationTime": 0,
+                            "pendingContext": null,
+                            "pendingInteractionMap": Map {},
+                            "pingCache": null,
+                            "timeoutHandle": -1,
+                          },
+                          "tag": 3,
+                          "treeBaseDuration": 0,
+                          "type": null,
+                          "updateQueue": Object {
+                            "baseState": Object {
+                              "element": <WrapperComponent
+                                Component={[Function]}
+                                context={null}
+                                props={
+                                  Object {
+                                    "children": <AuthenticatedRoute
+                                      authenticated={true}
+                                      component={[Function]}
+                                      path="/dashboard"
+                                    />,
+                                  }
+                                }
+                                wrappingComponentProps={null}
+                              />,
+                            },
+                            "firstCapturedEffect": null,
+                            "firstCapturedUpdate": null,
+                            "firstEffect": null,
+                            "firstUpdate": null,
+                            "lastCapturedEffect": null,
+                            "lastCapturedUpdate": null,
+                            "lastEffect": null,
+                            "lastUpdate": null,
+                          },
+                        },
+                        "selfBaseDuration": 0,
+                        "sibling": null,
+                        "stateNode": WrapperComponent {
+                          "_reactInternalFiber": [Circular],
+                          "_reactInternalInstance": Object {},
+                          "context": Object {},
+                          "props": Object {
+                            "Component": [Function],
+                            "context": null,
+                            "props": Object {
+                              "children": <AuthenticatedRoute
+                                authenticated={true}
+                                component={[Function]}
+                                path="/dashboard"
+                              />,
+                            },
+                            "wrappingComponentProps": null,
+                          },
+                          "refs": Object {},
+                          "rootFinderInstance": null,
+                          "state": Object {
+                            "context": null,
+                            "mount": true,
+                            "props": Object {
+                              "children": <AuthenticatedRoute
+                                authenticated={true}
+                                component={[Function]}
+                                path="/dashboard"
+                              />,
+                            },
+                            "wrappingComponentProps": null,
+                          },
+                          "updater": Object {
+                            "enqueueForceUpdate": [Function],
+                            "enqueueReplaceState": [Function],
+                            "enqueueSetState": [Function],
+                            "isMounted": [Function],
+                          },
+                        },
+                        "tag": 1,
+                        "treeBaseDuration": 0,
+                        "type": [Function],
+                        "updateQueue": null,
+                      },
+                      "_debugSource": null,
+                      "actualDuration": 0,
+                      "actualStartTime": -1,
+                      "alternate": null,
+                      "child": [Circular],
+                      "childExpirationTime": 0,
+                      "contextDependencies": null,
+                      "effectTag": 1,
+                      "elementType": [Function],
+                      "expirationTime": 0,
+                      "firstEffect": null,
+                      "index": 0,
+                      "key": null,
+                      "lastEffect": null,
+                      "memoizedProps": Object {
+                        "children": <AuthenticatedRoute
+                          authenticated={true}
+                          component={[Function]}
+                          path="/dashboard"
+                        />,
+                      },
+                      "memoizedState": null,
+                      "mode": 0,
+                      "nextEffect": null,
+                      "pendingProps": Object {
+                        "children": <AuthenticatedRoute
+                          authenticated={true}
+                          component={[Function]}
+                          path="/dashboard"
+                        />,
+                      },
+                      "ref": null,
+                      "return": FiberNode {
+                        "_debugHookTypes": null,
+                        "_debugID": 62,
+                        "_debugIsCurrentlyTiming": false,
+                        "_debugOwner": null,
+                        "_debugSource": null,
+                        "actualDuration": 0,
+                        "actualStartTime": -1,
+                        "alternate": null,
+                        "child": [Circular],
+                        "childExpirationTime": 0,
+                        "contextDependencies": null,
+                        "effectTag": 1,
+                        "elementType": [Function],
+                        "expirationTime": 0,
+                        "firstEffect": null,
+                        "index": 0,
+                        "key": null,
+                        "lastEffect": null,
+                        "memoizedProps": Object {
+                          "Component": [Function],
+                          "context": null,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "memoizedState": Object {
+                          "context": null,
+                          "mount": true,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "mode": 0,
+                        "nextEffect": FiberNode {
+                          "_debugHookTypes": null,
+                          "_debugID": 60,
+                          "_debugIsCurrentlyTiming": false,
+                          "_debugOwner": null,
+                          "_debugSource": null,
+                          "actualDuration": 0,
+                          "actualStartTime": -1,
+                          "alternate": FiberNode {
+                            "_debugHookTypes": null,
+                            "_debugID": 60,
+                            "_debugIsCurrentlyTiming": false,
+                            "_debugOwner": null,
+                            "_debugSource": null,
+                            "actualDuration": 0,
+                            "actualStartTime": -1,
+                            "alternate": [Circular],
+                            "child": null,
+                            "childExpirationTime": 0,
+                            "contextDependencies": null,
+                            "effectTag": 0,
+                            "elementType": null,
+                            "expirationTime": 1073741823,
+                            "firstEffect": null,
+                            "index": 0,
+                            "key": null,
+                            "lastEffect": null,
+                            "memoizedProps": null,
+                            "memoizedState": null,
+                            "mode": 0,
+                            "nextEffect": null,
+                            "pendingProps": null,
+                            "ref": null,
+                            "return": null,
+                            "selfBaseDuration": 0,
+                            "sibling": null,
+                            "stateNode": Object {
+                              "containerInfo": <div />,
+                              "context": Object {},
+                              "current": [Circular],
+                              "didError": false,
+                              "earliestPendingTime": 0,
+                              "earliestSuspendedTime": 0,
+                              "expirationTime": 0,
+                              "finishedWork": null,
+                              "firstBatch": null,
+                              "hydrate": false,
+                              "interactionThreadID": 15,
+                              "latestPendingTime": 0,
+                              "latestPingedTime": 0,
+                              "latestSuspendedTime": 0,
+                              "memoizedInteractions": Set {},
+                              "nextExpirationTimeToWorkOn": 0,
+                              "nextScheduledRoot": null,
+                              "pendingChildren": null,
+                              "pendingCommitExpirationTime": 0,
+                              "pendingContext": null,
+                              "pendingInteractionMap": Map {},
+                              "pingCache": null,
+                              "timeoutHandle": -1,
+                            },
+                            "tag": 3,
+                            "treeBaseDuration": 0,
+                            "type": null,
+                            "updateQueue": Object {
+                              "baseState": null,
+                              "firstCapturedEffect": null,
+                              "firstCapturedUpdate": null,
+                              "firstEffect": null,
+                              "firstUpdate": Object {
+                                "callback": null,
+                                "expirationTime": 1073741823,
+                                "next": null,
+                                "nextEffect": null,
+                                "payload": Object {
+                                  "element": <WrapperComponent
+                                    Component={[Function]}
+                                    context={null}
+                                    props={
+                                      Object {
+                                        "children": <AuthenticatedRoute
+                                          authenticated={true}
+                                          component={[Function]}
+                                          path="/dashboard"
+                                        />,
+                                      }
+                                    }
+                                    wrappingComponentProps={null}
+                                  />,
+                                },
+                                "tag": 0,
+                              },
+                              "lastCapturedEffect": null,
+                              "lastCapturedUpdate": null,
+                              "lastEffect": null,
+                              "lastUpdate": Object {
+                                "callback": null,
+                                "expirationTime": 1073741823,
+                                "next": null,
+                                "nextEffect": null,
+                                "payload": Object {
+                                  "element": <WrapperComponent
+                                    Component={[Function]}
+                                    context={null}
+                                    props={
+                                      Object {
+                                        "children": <AuthenticatedRoute
+                                          authenticated={true}
+                                          component={[Function]}
+                                          path="/dashboard"
+                                        />,
+                                      }
+                                    }
+                                    wrappingComponentProps={null}
+                                  />,
+                                },
+                                "tag": 0,
+                              },
+                            },
+                          },
+                          "child": [Circular],
+                          "childExpirationTime": 0,
+                          "contextDependencies": null,
+                          "effectTag": 32,
+                          "elementType": null,
+                          "expirationTime": 0,
+                          "firstEffect": [Circular],
+                          "index": 0,
+                          "key": null,
+                          "lastEffect": [Circular],
+                          "memoizedProps": null,
+                          "memoizedState": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={
+                                Object {
+                                  "children": <AuthenticatedRoute
+                                    authenticated={true}
+                                    component={[Function]}
+                                    path="/dashboard"
+                                  />,
+                                }
+                              }
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "mode": 0,
+                          "nextEffect": null,
+                          "pendingProps": null,
+                          "ref": null,
+                          "return": null,
+                          "selfBaseDuration": 0,
+                          "sibling": null,
+                          "stateNode": Object {
+                            "containerInfo": <div />,
+                            "context": Object {},
+                            "current": [Circular],
+                            "didError": false,
+                            "earliestPendingTime": 0,
+                            "earliestSuspendedTime": 0,
+                            "expirationTime": 0,
+                            "finishedWork": null,
+                            "firstBatch": null,
+                            "hydrate": false,
+                            "interactionThreadID": 15,
+                            "latestPendingTime": 0,
+                            "latestPingedTime": 0,
+                            "latestSuspendedTime": 0,
+                            "memoizedInteractions": Set {},
+                            "nextExpirationTimeToWorkOn": 0,
+                            "nextScheduledRoot": null,
+                            "pendingChildren": null,
+                            "pendingCommitExpirationTime": 0,
+                            "pendingContext": null,
+                            "pendingInteractionMap": Map {},
+                            "pingCache": null,
+                            "timeoutHandle": -1,
+                          },
+                          "tag": 3,
+                          "treeBaseDuration": 0,
+                          "type": null,
+                          "updateQueue": Object {
+                            "baseState": Object {
+                              "element": <WrapperComponent
+                                Component={[Function]}
+                                context={null}
+                                props={
+                                  Object {
+                                    "children": <AuthenticatedRoute
+                                      authenticated={true}
+                                      component={[Function]}
+                                      path="/dashboard"
+                                    />,
+                                  }
+                                }
+                                wrappingComponentProps={null}
+                              />,
+                            },
+                            "firstCapturedEffect": null,
+                            "firstCapturedUpdate": null,
+                            "firstEffect": null,
+                            "firstUpdate": null,
+                            "lastCapturedEffect": null,
+                            "lastCapturedUpdate": null,
+                            "lastEffect": null,
+                            "lastUpdate": null,
+                          },
+                        },
+                        "pendingProps": Object {
+                          "Component": [Function],
+                          "context": null,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "ref": null,
+                        "return": FiberNode {
+                          "_debugHookTypes": null,
+                          "_debugID": 60,
+                          "_debugIsCurrentlyTiming": false,
+                          "_debugOwner": null,
+                          "_debugSource": null,
+                          "actualDuration": 0,
+                          "actualStartTime": -1,
+                          "alternate": FiberNode {
+                            "_debugHookTypes": null,
+                            "_debugID": 60,
+                            "_debugIsCurrentlyTiming": false,
+                            "_debugOwner": null,
+                            "_debugSource": null,
+                            "actualDuration": 0,
+                            "actualStartTime": -1,
+                            "alternate": [Circular],
+                            "child": null,
+                            "childExpirationTime": 0,
+                            "contextDependencies": null,
+                            "effectTag": 0,
+                            "elementType": null,
+                            "expirationTime": 1073741823,
+                            "firstEffect": null,
+                            "index": 0,
+                            "key": null,
+                            "lastEffect": null,
+                            "memoizedProps": null,
+                            "memoizedState": null,
+                            "mode": 0,
+                            "nextEffect": null,
+                            "pendingProps": null,
+                            "ref": null,
+                            "return": null,
+                            "selfBaseDuration": 0,
+                            "sibling": null,
+                            "stateNode": Object {
+                              "containerInfo": <div />,
+                              "context": Object {},
+                              "current": [Circular],
+                              "didError": false,
+                              "earliestPendingTime": 0,
+                              "earliestSuspendedTime": 0,
+                              "expirationTime": 0,
+                              "finishedWork": null,
+                              "firstBatch": null,
+                              "hydrate": false,
+                              "interactionThreadID": 15,
+                              "latestPendingTime": 0,
+                              "latestPingedTime": 0,
+                              "latestSuspendedTime": 0,
+                              "memoizedInteractions": Set {},
+                              "nextExpirationTimeToWorkOn": 0,
+                              "nextScheduledRoot": null,
+                              "pendingChildren": null,
+                              "pendingCommitExpirationTime": 0,
+                              "pendingContext": null,
+                              "pendingInteractionMap": Map {},
+                              "pingCache": null,
+                              "timeoutHandle": -1,
+                            },
+                            "tag": 3,
+                            "treeBaseDuration": 0,
+                            "type": null,
+                            "updateQueue": Object {
+                              "baseState": null,
+                              "firstCapturedEffect": null,
+                              "firstCapturedUpdate": null,
+                              "firstEffect": null,
+                              "firstUpdate": Object {
+                                "callback": null,
+                                "expirationTime": 1073741823,
+                                "next": null,
+                                "nextEffect": null,
+                                "payload": Object {
+                                  "element": <WrapperComponent
+                                    Component={[Function]}
+                                    context={null}
+                                    props={
+                                      Object {
+                                        "children": <AuthenticatedRoute
+                                          authenticated={true}
+                                          component={[Function]}
+                                          path="/dashboard"
+                                        />,
+                                      }
+                                    }
+                                    wrappingComponentProps={null}
+                                  />,
+                                },
+                                "tag": 0,
+                              },
+                              "lastCapturedEffect": null,
+                              "lastCapturedUpdate": null,
+                              "lastEffect": null,
+                              "lastUpdate": Object {
+                                "callback": null,
+                                "expirationTime": 1073741823,
+                                "next": null,
+                                "nextEffect": null,
+                                "payload": Object {
+                                  "element": <WrapperComponent
+                                    Component={[Function]}
+                                    context={null}
+                                    props={
+                                      Object {
+                                        "children": <AuthenticatedRoute
+                                          authenticated={true}
+                                          component={[Function]}
+                                          path="/dashboard"
+                                        />,
+                                      }
+                                    }
+                                    wrappingComponentProps={null}
+                                  />,
+                                },
+                                "tag": 0,
+                              },
+                            },
+                          },
+                          "child": [Circular],
+                          "childExpirationTime": 0,
+                          "contextDependencies": null,
+                          "effectTag": 32,
+                          "elementType": null,
+                          "expirationTime": 0,
+                          "firstEffect": [Circular],
+                          "index": 0,
+                          "key": null,
+                          "lastEffect": [Circular],
+                          "memoizedProps": null,
+                          "memoizedState": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={
+                                Object {
+                                  "children": <AuthenticatedRoute
+                                    authenticated={true}
+                                    component={[Function]}
+                                    path="/dashboard"
+                                  />,
+                                }
+                              }
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "mode": 0,
+                          "nextEffect": null,
+                          "pendingProps": null,
+                          "ref": null,
+                          "return": null,
+                          "selfBaseDuration": 0,
+                          "sibling": null,
+                          "stateNode": Object {
+                            "containerInfo": <div />,
+                            "context": Object {},
+                            "current": [Circular],
+                            "didError": false,
+                            "earliestPendingTime": 0,
+                            "earliestSuspendedTime": 0,
+                            "expirationTime": 0,
+                            "finishedWork": null,
+                            "firstBatch": null,
+                            "hydrate": false,
+                            "interactionThreadID": 15,
+                            "latestPendingTime": 0,
+                            "latestPingedTime": 0,
+                            "latestSuspendedTime": 0,
+                            "memoizedInteractions": Set {},
+                            "nextExpirationTimeToWorkOn": 0,
+                            "nextScheduledRoot": null,
+                            "pendingChildren": null,
+                            "pendingCommitExpirationTime": 0,
+                            "pendingContext": null,
+                            "pendingInteractionMap": Map {},
+                            "pingCache": null,
+                            "timeoutHandle": -1,
+                          },
+                          "tag": 3,
+                          "treeBaseDuration": 0,
+                          "type": null,
+                          "updateQueue": Object {
+                            "baseState": Object {
+                              "element": <WrapperComponent
+                                Component={[Function]}
+                                context={null}
+                                props={
+                                  Object {
+                                    "children": <AuthenticatedRoute
+                                      authenticated={true}
+                                      component={[Function]}
+                                      path="/dashboard"
+                                    />,
+                                  }
+                                }
+                                wrappingComponentProps={null}
+                              />,
+                            },
+                            "firstCapturedEffect": null,
+                            "firstCapturedUpdate": null,
+                            "firstEffect": null,
+                            "firstUpdate": null,
+                            "lastCapturedEffect": null,
+                            "lastCapturedUpdate": null,
+                            "lastEffect": null,
+                            "lastUpdate": null,
+                          },
+                        },
+                        "selfBaseDuration": 0,
+                        "sibling": null,
+                        "stateNode": WrapperComponent {
+                          "_reactInternalFiber": [Circular],
+                          "_reactInternalInstance": Object {},
+                          "context": Object {},
+                          "props": Object {
+                            "Component": [Function],
+                            "context": null,
+                            "props": Object {
+                              "children": <AuthenticatedRoute
+                                authenticated={true}
+                                component={[Function]}
+                                path="/dashboard"
+                              />,
+                            },
+                            "wrappingComponentProps": null,
+                          },
+                          "refs": Object {},
+                          "rootFinderInstance": null,
+                          "state": Object {
+                            "context": null,
+                            "mount": true,
+                            "props": Object {
+                              "children": <AuthenticatedRoute
+                                authenticated={true}
+                                component={[Function]}
+                                path="/dashboard"
+                              />,
+                            },
+                            "wrappingComponentProps": null,
+                          },
+                          "updater": Object {
+                            "enqueueForceUpdate": [Function],
+                            "enqueueReplaceState": [Function],
+                            "enqueueSetState": [Function],
+                            "isMounted": [Function],
+                          },
+                        },
+                        "tag": 1,
+                        "treeBaseDuration": 0,
+                        "type": [Function],
+                        "updateQueue": null,
+                      },
+                      "selfBaseDuration": 0,
+                      "sibling": null,
+                      "stateNode": BrowserRouter {
+                        "_reactInternalFiber": [Circular],
+                        "_reactInternalInstance": Object {},
+                        "context": Object {},
+                        "history": Object {
+                          "action": "POP",
+                          "block": [Function],
+                          "createHref": [Function],
+                          "go": [Function],
+                          "goBack": [Function],
+                          "goForward": [Function],
+                          "length": 1,
+                          "listen": [Function],
+                          "location": Object {
+                            "hash": "",
+                            "pathname": "/",
+                            "search": "",
+                            "state": undefined,
+                          },
+                          "push": [Function],
+                          "replace": [Function],
+                        },
+                        "props": Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        },
+                        "refs": Object {},
+                        "state": null,
+                        "updater": Object {
+                          "enqueueForceUpdate": [Function],
+                          "enqueueReplaceState": [Function],
+                          "enqueueSetState": [Function],
+                          "isMounted": [Function],
+                        },
+                      },
+                      "tag": 1,
+                      "treeBaseDuration": 0,
+                      "type": [Function],
+                      "updateQueue": null,
+                    },
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": Router {
+                      "__reactInternalMemoizedMaskedChildContext": Object {
+                        "router": undefined,
+                      },
+                      "__reactInternalMemoizedMergedChildContext": Object {
+                        "router": Object {
+                          "history": Object {
+                            "action": "POP",
+                            "block": [Function],
+                            "createHref": [Function],
+                            "go": [Function],
+                            "goBack": [Function],
+                            "goForward": [Function],
+                            "length": 1,
+                            "listen": [Function],
+                            "location": Object {
+                              "hash": "",
+                              "pathname": "/",
+                              "search": "",
+                              "state": undefined,
+                            },
+                            "push": [Function],
+                            "replace": [Function],
+                          },
+                          "route": Object {
+                            "location": Object {
+                              "hash": "",
+                              "pathname": "/",
+                              "search": "",
+                              "state": undefined,
+                            },
+                            "match": Object {
+                              "isExact": true,
+                              "params": Object {},
+                              "path": "/",
+                              "url": "/",
+                            },
+                          },
+                        },
+                      },
+                      "__reactInternalMemoizedUnmaskedChildContext": Object {},
+                      "_reactInternalFiber": [Circular],
+                      "_reactInternalInstance": Object {},
+                      "context": Object {
+                        "router": undefined,
+                      },
+                      "props": Object {
+                        "children": <AuthenticatedRoute
+                          authenticated={true}
+                          component={[Function]}
+                          path="/dashboard"
+                        />,
+                        "history": Object {
+                          "action": "POP",
+                          "block": [Function],
+                          "createHref": [Function],
+                          "go": [Function],
+                          "goBack": [Function],
+                          "goForward": [Function],
+                          "length": 1,
+                          "listen": [Function],
+                          "location": Object {
+                            "hash": "",
+                            "pathname": "/",
+                            "search": "",
+                            "state": undefined,
+                          },
+                          "push": [Function],
+                          "replace": [Function],
+                        },
+                      },
+                      "refs": Object {},
+                      "state": Object {
+                        "match": Object {
+                          "isExact": true,
+                          "params": Object {},
+                          "path": "/",
+                          "url": "/",
+                        },
+                      },
+                      "unlisten": [Function],
+                      "updater": Object {
+                        "enqueueForceUpdate": [Function],
+                        "enqueueReplaceState": [Function],
+                        "enqueueSetState": [Function],
+                        "isMounted": [Function],
+                      },
+                    },
+                    "tag": 1,
+                    "treeBaseDuration": 0,
+                    "type": [Function],
+                    "updateQueue": null,
+                  },
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": null,
+                  "tag": 0,
+                  "treeBaseDuration": 0,
+                  "type": [Function],
+                  "updateQueue": null,
+                },
+                "_debugSource": Object {
+                  "fileName": "/Users/home/Documents/Projects/javascript/Andela/bp-esa/bp-esa-frontend/src/App.jsx",
+                  "lineNumber": 15,
+                },
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": null,
+                "child": null,
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 1,
+                "elementType": [Function],
+                "expirationTime": 0,
+                "firstEffect": null,
+                "index": 0,
+                "key": null,
+                "lastEffect": null,
+                "memoizedProps": Object {
+                  "path": "/dashboard",
+                  "render": [Function],
+                },
+                "memoizedState": Object {
+                  "match": null,
+                },
+                "mode": 0,
+                "nextEffect": null,
+                "pendingProps": Object {
+                  "path": "/dashboard",
+                  "render": [Function],
+                },
+                "ref": null,
+                "return": FiberNode {
+                  "_debugHookTypes": null,
+                  "_debugID": 65,
+                  "_debugIsCurrentlyTiming": false,
+                  "_debugOwner": null,
+                  "_debugSource": Object {
+                    "fileName": "/Users/home/Documents/Projects/javascript/Andela/bp-esa/bp-esa-frontend/src/App.test.jsx",
+                    "lineNumber": 123,
+                  },
+                  "actualDuration": 0,
+                  "actualStartTime": -1,
+                  "alternate": null,
+                  "child": [Circular],
+                  "childExpirationTime": 0,
+                  "contextDependencies": null,
+                  "effectTag": 1,
+                  "elementType": [Function],
+                  "expirationTime": 0,
+                  "firstEffect": null,
+                  "index": 0,
+                  "key": null,
+                  "lastEffect": null,
+                  "memoizedProps": Object {
+                    "authenticated": true,
+                    "component": [Function],
+                    "path": "/dashboard",
+                  },
+                  "memoizedState": null,
+                  "mode": 0,
+                  "nextEffect": null,
+                  "pendingProps": Object {
+                    "authenticated": true,
+                    "component": [Function],
+                    "path": "/dashboard",
+                  },
+                  "ref": null,
+                  "return": FiberNode {
+                    "_debugHookTypes": null,
+                    "_debugID": 64,
+                    "_debugIsCurrentlyTiming": false,
+                    "_debugOwner": FiberNode {
+                      "_debugHookTypes": null,
+                      "_debugID": 63,
+                      "_debugIsCurrentlyTiming": false,
+                      "_debugOwner": FiberNode {
+                        "_debugHookTypes": null,
+                        "_debugID": 62,
+                        "_debugIsCurrentlyTiming": false,
+                        "_debugOwner": null,
+                        "_debugSource": null,
+                        "actualDuration": 0,
+                        "actualStartTime": -1,
+                        "alternate": null,
+                        "child": [Circular],
+                        "childExpirationTime": 0,
+                        "contextDependencies": null,
+                        "effectTag": 1,
+                        "elementType": [Function],
+                        "expirationTime": 0,
+                        "firstEffect": null,
+                        "index": 0,
+                        "key": null,
+                        "lastEffect": null,
+                        "memoizedProps": Object {
+                          "Component": [Function],
+                          "context": null,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "memoizedState": Object {
+                          "context": null,
+                          "mount": true,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "mode": 0,
+                        "nextEffect": FiberNode {
+                          "_debugHookTypes": null,
+                          "_debugID": 60,
+                          "_debugIsCurrentlyTiming": false,
+                          "_debugOwner": null,
+                          "_debugSource": null,
+                          "actualDuration": 0,
+                          "actualStartTime": -1,
+                          "alternate": FiberNode {
+                            "_debugHookTypes": null,
+                            "_debugID": 60,
+                            "_debugIsCurrentlyTiming": false,
+                            "_debugOwner": null,
+                            "_debugSource": null,
+                            "actualDuration": 0,
+                            "actualStartTime": -1,
+                            "alternate": [Circular],
+                            "child": null,
+                            "childExpirationTime": 0,
+                            "contextDependencies": null,
+                            "effectTag": 0,
+                            "elementType": null,
+                            "expirationTime": 1073741823,
+                            "firstEffect": null,
+                            "index": 0,
+                            "key": null,
+                            "lastEffect": null,
+                            "memoizedProps": null,
+                            "memoizedState": null,
+                            "mode": 0,
+                            "nextEffect": null,
+                            "pendingProps": null,
+                            "ref": null,
+                            "return": null,
+                            "selfBaseDuration": 0,
+                            "sibling": null,
+                            "stateNode": Object {
+                              "containerInfo": <div />,
+                              "context": Object {},
+                              "current": [Circular],
+                              "didError": false,
+                              "earliestPendingTime": 0,
+                              "earliestSuspendedTime": 0,
+                              "expirationTime": 0,
+                              "finishedWork": null,
+                              "firstBatch": null,
+                              "hydrate": false,
+                              "interactionThreadID": 15,
+                              "latestPendingTime": 0,
+                              "latestPingedTime": 0,
+                              "latestSuspendedTime": 0,
+                              "memoizedInteractions": Set {},
+                              "nextExpirationTimeToWorkOn": 0,
+                              "nextScheduledRoot": null,
+                              "pendingChildren": null,
+                              "pendingCommitExpirationTime": 0,
+                              "pendingContext": null,
+                              "pendingInteractionMap": Map {},
+                              "pingCache": null,
+                              "timeoutHandle": -1,
+                            },
+                            "tag": 3,
+                            "treeBaseDuration": 0,
+                            "type": null,
+                            "updateQueue": Object {
+                              "baseState": null,
+                              "firstCapturedEffect": null,
+                              "firstCapturedUpdate": null,
+                              "firstEffect": null,
+                              "firstUpdate": Object {
+                                "callback": null,
+                                "expirationTime": 1073741823,
+                                "next": null,
+                                "nextEffect": null,
+                                "payload": Object {
+                                  "element": <WrapperComponent
+                                    Component={[Function]}
+                                    context={null}
+                                    props={
+                                      Object {
+                                        "children": <AuthenticatedRoute
+                                          authenticated={true}
+                                          component={[Function]}
+                                          path="/dashboard"
+                                        />,
+                                      }
+                                    }
+                                    wrappingComponentProps={null}
+                                  />,
+                                },
+                                "tag": 0,
+                              },
+                              "lastCapturedEffect": null,
+                              "lastCapturedUpdate": null,
+                              "lastEffect": null,
+                              "lastUpdate": Object {
+                                "callback": null,
+                                "expirationTime": 1073741823,
+                                "next": null,
+                                "nextEffect": null,
+                                "payload": Object {
+                                  "element": <WrapperComponent
+                                    Component={[Function]}
+                                    context={null}
+                                    props={
+                                      Object {
+                                        "children": <AuthenticatedRoute
+                                          authenticated={true}
+                                          component={[Function]}
+                                          path="/dashboard"
+                                        />,
+                                      }
+                                    }
+                                    wrappingComponentProps={null}
+                                  />,
+                                },
+                                "tag": 0,
+                              },
+                            },
+                          },
+                          "child": [Circular],
+                          "childExpirationTime": 0,
+                          "contextDependencies": null,
+                          "effectTag": 32,
+                          "elementType": null,
+                          "expirationTime": 0,
+                          "firstEffect": [Circular],
+                          "index": 0,
+                          "key": null,
+                          "lastEffect": [Circular],
+                          "memoizedProps": null,
+                          "memoizedState": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={
+                                Object {
+                                  "children": <AuthenticatedRoute
+                                    authenticated={true}
+                                    component={[Function]}
+                                    path="/dashboard"
+                                  />,
+                                }
+                              }
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "mode": 0,
+                          "nextEffect": null,
+                          "pendingProps": null,
+                          "ref": null,
+                          "return": null,
+                          "selfBaseDuration": 0,
+                          "sibling": null,
+                          "stateNode": Object {
+                            "containerInfo": <div />,
+                            "context": Object {},
+                            "current": [Circular],
+                            "didError": false,
+                            "earliestPendingTime": 0,
+                            "earliestSuspendedTime": 0,
+                            "expirationTime": 0,
+                            "finishedWork": null,
+                            "firstBatch": null,
+                            "hydrate": false,
+                            "interactionThreadID": 15,
+                            "latestPendingTime": 0,
+                            "latestPingedTime": 0,
+                            "latestSuspendedTime": 0,
+                            "memoizedInteractions": Set {},
+                            "nextExpirationTimeToWorkOn": 0,
+                            "nextScheduledRoot": null,
+                            "pendingChildren": null,
+                            "pendingCommitExpirationTime": 0,
+                            "pendingContext": null,
+                            "pendingInteractionMap": Map {},
+                            "pingCache": null,
+                            "timeoutHandle": -1,
+                          },
+                          "tag": 3,
+                          "treeBaseDuration": 0,
+                          "type": null,
+                          "updateQueue": Object {
+                            "baseState": Object {
+                              "element": <WrapperComponent
+                                Component={[Function]}
+                                context={null}
+                                props={
+                                  Object {
+                                    "children": <AuthenticatedRoute
+                                      authenticated={true}
+                                      component={[Function]}
+                                      path="/dashboard"
+                                    />,
+                                  }
+                                }
+                                wrappingComponentProps={null}
+                              />,
+                            },
+                            "firstCapturedEffect": null,
+                            "firstCapturedUpdate": null,
+                            "firstEffect": null,
+                            "firstUpdate": null,
+                            "lastCapturedEffect": null,
+                            "lastCapturedUpdate": null,
+                            "lastEffect": null,
+                            "lastUpdate": null,
+                          },
+                        },
+                        "pendingProps": Object {
+                          "Component": [Function],
+                          "context": null,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "ref": null,
+                        "return": FiberNode {
+                          "_debugHookTypes": null,
+                          "_debugID": 60,
+                          "_debugIsCurrentlyTiming": false,
+                          "_debugOwner": null,
+                          "_debugSource": null,
+                          "actualDuration": 0,
+                          "actualStartTime": -1,
+                          "alternate": FiberNode {
+                            "_debugHookTypes": null,
+                            "_debugID": 60,
+                            "_debugIsCurrentlyTiming": false,
+                            "_debugOwner": null,
+                            "_debugSource": null,
+                            "actualDuration": 0,
+                            "actualStartTime": -1,
+                            "alternate": [Circular],
+                            "child": null,
+                            "childExpirationTime": 0,
+                            "contextDependencies": null,
+                            "effectTag": 0,
+                            "elementType": null,
+                            "expirationTime": 1073741823,
+                            "firstEffect": null,
+                            "index": 0,
+                            "key": null,
+                            "lastEffect": null,
+                            "memoizedProps": null,
+                            "memoizedState": null,
+                            "mode": 0,
+                            "nextEffect": null,
+                            "pendingProps": null,
+                            "ref": null,
+                            "return": null,
+                            "selfBaseDuration": 0,
+                            "sibling": null,
+                            "stateNode": Object {
+                              "containerInfo": <div />,
+                              "context": Object {},
+                              "current": [Circular],
+                              "didError": false,
+                              "earliestPendingTime": 0,
+                              "earliestSuspendedTime": 0,
+                              "expirationTime": 0,
+                              "finishedWork": null,
+                              "firstBatch": null,
+                              "hydrate": false,
+                              "interactionThreadID": 15,
+                              "latestPendingTime": 0,
+                              "latestPingedTime": 0,
+                              "latestSuspendedTime": 0,
+                              "memoizedInteractions": Set {},
+                              "nextExpirationTimeToWorkOn": 0,
+                              "nextScheduledRoot": null,
+                              "pendingChildren": null,
+                              "pendingCommitExpirationTime": 0,
+                              "pendingContext": null,
+                              "pendingInteractionMap": Map {},
+                              "pingCache": null,
+                              "timeoutHandle": -1,
+                            },
+                            "tag": 3,
+                            "treeBaseDuration": 0,
+                            "type": null,
+                            "updateQueue": Object {
+                              "baseState": null,
+                              "firstCapturedEffect": null,
+                              "firstCapturedUpdate": null,
+                              "firstEffect": null,
+                              "firstUpdate": Object {
+                                "callback": null,
+                                "expirationTime": 1073741823,
+                                "next": null,
+                                "nextEffect": null,
+                                "payload": Object {
+                                  "element": <WrapperComponent
+                                    Component={[Function]}
+                                    context={null}
+                                    props={
+                                      Object {
+                                        "children": <AuthenticatedRoute
+                                          authenticated={true}
+                                          component={[Function]}
+                                          path="/dashboard"
+                                        />,
+                                      }
+                                    }
+                                    wrappingComponentProps={null}
+                                  />,
+                                },
+                                "tag": 0,
+                              },
+                              "lastCapturedEffect": null,
+                              "lastCapturedUpdate": null,
+                              "lastEffect": null,
+                              "lastUpdate": Object {
+                                "callback": null,
+                                "expirationTime": 1073741823,
+                                "next": null,
+                                "nextEffect": null,
+                                "payload": Object {
+                                  "element": <WrapperComponent
+                                    Component={[Function]}
+                                    context={null}
+                                    props={
+                                      Object {
+                                        "children": <AuthenticatedRoute
+                                          authenticated={true}
+                                          component={[Function]}
+                                          path="/dashboard"
+                                        />,
+                                      }
+                                    }
+                                    wrappingComponentProps={null}
+                                  />,
+                                },
+                                "tag": 0,
+                              },
+                            },
+                          },
+                          "child": [Circular],
+                          "childExpirationTime": 0,
+                          "contextDependencies": null,
+                          "effectTag": 32,
+                          "elementType": null,
+                          "expirationTime": 0,
+                          "firstEffect": [Circular],
+                          "index": 0,
+                          "key": null,
+                          "lastEffect": [Circular],
+                          "memoizedProps": null,
+                          "memoizedState": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={
+                                Object {
+                                  "children": <AuthenticatedRoute
+                                    authenticated={true}
+                                    component={[Function]}
+                                    path="/dashboard"
+                                  />,
+                                }
+                              }
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "mode": 0,
+                          "nextEffect": null,
+                          "pendingProps": null,
+                          "ref": null,
+                          "return": null,
+                          "selfBaseDuration": 0,
+                          "sibling": null,
+                          "stateNode": Object {
+                            "containerInfo": <div />,
+                            "context": Object {},
+                            "current": [Circular],
+                            "didError": false,
+                            "earliestPendingTime": 0,
+                            "earliestSuspendedTime": 0,
+                            "expirationTime": 0,
+                            "finishedWork": null,
+                            "firstBatch": null,
+                            "hydrate": false,
+                            "interactionThreadID": 15,
+                            "latestPendingTime": 0,
+                            "latestPingedTime": 0,
+                            "latestSuspendedTime": 0,
+                            "memoizedInteractions": Set {},
+                            "nextExpirationTimeToWorkOn": 0,
+                            "nextScheduledRoot": null,
+                            "pendingChildren": null,
+                            "pendingCommitExpirationTime": 0,
+                            "pendingContext": null,
+                            "pendingInteractionMap": Map {},
+                            "pingCache": null,
+                            "timeoutHandle": -1,
+                          },
+                          "tag": 3,
+                          "treeBaseDuration": 0,
+                          "type": null,
+                          "updateQueue": Object {
+                            "baseState": Object {
+                              "element": <WrapperComponent
+                                Component={[Function]}
+                                context={null}
+                                props={
+                                  Object {
+                                    "children": <AuthenticatedRoute
+                                      authenticated={true}
+                                      component={[Function]}
+                                      path="/dashboard"
+                                    />,
+                                  }
+                                }
+                                wrappingComponentProps={null}
+                              />,
+                            },
+                            "firstCapturedEffect": null,
+                            "firstCapturedUpdate": null,
+                            "firstEffect": null,
+                            "firstUpdate": null,
+                            "lastCapturedEffect": null,
+                            "lastCapturedUpdate": null,
+                            "lastEffect": null,
+                            "lastUpdate": null,
+                          },
+                        },
+                        "selfBaseDuration": 0,
+                        "sibling": null,
+                        "stateNode": WrapperComponent {
+                          "_reactInternalFiber": [Circular],
+                          "_reactInternalInstance": Object {},
+                          "context": Object {},
+                          "props": Object {
+                            "Component": [Function],
+                            "context": null,
+                            "props": Object {
+                              "children": <AuthenticatedRoute
+                                authenticated={true}
+                                component={[Function]}
+                                path="/dashboard"
+                              />,
+                            },
+                            "wrappingComponentProps": null,
+                          },
+                          "refs": Object {},
+                          "rootFinderInstance": null,
+                          "state": Object {
+                            "context": null,
+                            "mount": true,
+                            "props": Object {
+                              "children": <AuthenticatedRoute
+                                authenticated={true}
+                                component={[Function]}
+                                path="/dashboard"
+                              />,
+                            },
+                            "wrappingComponentProps": null,
+                          },
+                          "updater": Object {
+                            "enqueueForceUpdate": [Function],
+                            "enqueueReplaceState": [Function],
+                            "enqueueSetState": [Function],
+                            "isMounted": [Function],
+                          },
+                        },
+                        "tag": 1,
+                        "treeBaseDuration": 0,
+                        "type": [Function],
+                        "updateQueue": null,
+                      },
+                      "_debugSource": null,
+                      "actualDuration": 0,
+                      "actualStartTime": -1,
+                      "alternate": null,
+                      "child": [Circular],
+                      "childExpirationTime": 0,
+                      "contextDependencies": null,
+                      "effectTag": 1,
+                      "elementType": [Function],
+                      "expirationTime": 0,
+                      "firstEffect": null,
+                      "index": 0,
+                      "key": null,
+                      "lastEffect": null,
+                      "memoizedProps": Object {
+                        "children": <AuthenticatedRoute
+                          authenticated={true}
+                          component={[Function]}
+                          path="/dashboard"
+                        />,
+                      },
+                      "memoizedState": null,
+                      "mode": 0,
+                      "nextEffect": null,
+                      "pendingProps": Object {
+                        "children": <AuthenticatedRoute
+                          authenticated={true}
+                          component={[Function]}
+                          path="/dashboard"
+                        />,
+                      },
+                      "ref": null,
+                      "return": FiberNode {
+                        "_debugHookTypes": null,
+                        "_debugID": 62,
+                        "_debugIsCurrentlyTiming": false,
+                        "_debugOwner": null,
+                        "_debugSource": null,
+                        "actualDuration": 0,
+                        "actualStartTime": -1,
+                        "alternate": null,
+                        "child": [Circular],
+                        "childExpirationTime": 0,
+                        "contextDependencies": null,
+                        "effectTag": 1,
+                        "elementType": [Function],
+                        "expirationTime": 0,
+                        "firstEffect": null,
+                        "index": 0,
+                        "key": null,
+                        "lastEffect": null,
+                        "memoizedProps": Object {
+                          "Component": [Function],
+                          "context": null,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "memoizedState": Object {
+                          "context": null,
+                          "mount": true,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "mode": 0,
+                        "nextEffect": FiberNode {
+                          "_debugHookTypes": null,
+                          "_debugID": 60,
+                          "_debugIsCurrentlyTiming": false,
+                          "_debugOwner": null,
+                          "_debugSource": null,
+                          "actualDuration": 0,
+                          "actualStartTime": -1,
+                          "alternate": FiberNode {
+                            "_debugHookTypes": null,
+                            "_debugID": 60,
+                            "_debugIsCurrentlyTiming": false,
+                            "_debugOwner": null,
+                            "_debugSource": null,
+                            "actualDuration": 0,
+                            "actualStartTime": -1,
+                            "alternate": [Circular],
+                            "child": null,
+                            "childExpirationTime": 0,
+                            "contextDependencies": null,
+                            "effectTag": 0,
+                            "elementType": null,
+                            "expirationTime": 1073741823,
+                            "firstEffect": null,
+                            "index": 0,
+                            "key": null,
+                            "lastEffect": null,
+                            "memoizedProps": null,
+                            "memoizedState": null,
+                            "mode": 0,
+                            "nextEffect": null,
+                            "pendingProps": null,
+                            "ref": null,
+                            "return": null,
+                            "selfBaseDuration": 0,
+                            "sibling": null,
+                            "stateNode": Object {
+                              "containerInfo": <div />,
+                              "context": Object {},
+                              "current": [Circular],
+                              "didError": false,
+                              "earliestPendingTime": 0,
+                              "earliestSuspendedTime": 0,
+                              "expirationTime": 0,
+                              "finishedWork": null,
+                              "firstBatch": null,
+                              "hydrate": false,
+                              "interactionThreadID": 15,
+                              "latestPendingTime": 0,
+                              "latestPingedTime": 0,
+                              "latestSuspendedTime": 0,
+                              "memoizedInteractions": Set {},
+                              "nextExpirationTimeToWorkOn": 0,
+                              "nextScheduledRoot": null,
+                              "pendingChildren": null,
+                              "pendingCommitExpirationTime": 0,
+                              "pendingContext": null,
+                              "pendingInteractionMap": Map {},
+                              "pingCache": null,
+                              "timeoutHandle": -1,
+                            },
+                            "tag": 3,
+                            "treeBaseDuration": 0,
+                            "type": null,
+                            "updateQueue": Object {
+                              "baseState": null,
+                              "firstCapturedEffect": null,
+                              "firstCapturedUpdate": null,
+                              "firstEffect": null,
+                              "firstUpdate": Object {
+                                "callback": null,
+                                "expirationTime": 1073741823,
+                                "next": null,
+                                "nextEffect": null,
+                                "payload": Object {
+                                  "element": <WrapperComponent
+                                    Component={[Function]}
+                                    context={null}
+                                    props={
+                                      Object {
+                                        "children": <AuthenticatedRoute
+                                          authenticated={true}
+                                          component={[Function]}
+                                          path="/dashboard"
+                                        />,
+                                      }
+                                    }
+                                    wrappingComponentProps={null}
+                                  />,
+                                },
+                                "tag": 0,
+                              },
+                              "lastCapturedEffect": null,
+                              "lastCapturedUpdate": null,
+                              "lastEffect": null,
+                              "lastUpdate": Object {
+                                "callback": null,
+                                "expirationTime": 1073741823,
+                                "next": null,
+                                "nextEffect": null,
+                                "payload": Object {
+                                  "element": <WrapperComponent
+                                    Component={[Function]}
+                                    context={null}
+                                    props={
+                                      Object {
+                                        "children": <AuthenticatedRoute
+                                          authenticated={true}
+                                          component={[Function]}
+                                          path="/dashboard"
+                                        />,
+                                      }
+                                    }
+                                    wrappingComponentProps={null}
+                                  />,
+                                },
+                                "tag": 0,
+                              },
+                            },
+                          },
+                          "child": [Circular],
+                          "childExpirationTime": 0,
+                          "contextDependencies": null,
+                          "effectTag": 32,
+                          "elementType": null,
+                          "expirationTime": 0,
+                          "firstEffect": [Circular],
+                          "index": 0,
+                          "key": null,
+                          "lastEffect": [Circular],
+                          "memoizedProps": null,
+                          "memoizedState": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={
+                                Object {
+                                  "children": <AuthenticatedRoute
+                                    authenticated={true}
+                                    component={[Function]}
+                                    path="/dashboard"
+                                  />,
+                                }
+                              }
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "mode": 0,
+                          "nextEffect": null,
+                          "pendingProps": null,
+                          "ref": null,
+                          "return": null,
+                          "selfBaseDuration": 0,
+                          "sibling": null,
+                          "stateNode": Object {
+                            "containerInfo": <div />,
+                            "context": Object {},
+                            "current": [Circular],
+                            "didError": false,
+                            "earliestPendingTime": 0,
+                            "earliestSuspendedTime": 0,
+                            "expirationTime": 0,
+                            "finishedWork": null,
+                            "firstBatch": null,
+                            "hydrate": false,
+                            "interactionThreadID": 15,
+                            "latestPendingTime": 0,
+                            "latestPingedTime": 0,
+                            "latestSuspendedTime": 0,
+                            "memoizedInteractions": Set {},
+                            "nextExpirationTimeToWorkOn": 0,
+                            "nextScheduledRoot": null,
+                            "pendingChildren": null,
+                            "pendingCommitExpirationTime": 0,
+                            "pendingContext": null,
+                            "pendingInteractionMap": Map {},
+                            "pingCache": null,
+                            "timeoutHandle": -1,
+                          },
+                          "tag": 3,
+                          "treeBaseDuration": 0,
+                          "type": null,
+                          "updateQueue": Object {
+                            "baseState": Object {
+                              "element": <WrapperComponent
+                                Component={[Function]}
+                                context={null}
+                                props={
+                                  Object {
+                                    "children": <AuthenticatedRoute
+                                      authenticated={true}
+                                      component={[Function]}
+                                      path="/dashboard"
+                                    />,
+                                  }
+                                }
+                                wrappingComponentProps={null}
+                              />,
+                            },
+                            "firstCapturedEffect": null,
+                            "firstCapturedUpdate": null,
+                            "firstEffect": null,
+                            "firstUpdate": null,
+                            "lastCapturedEffect": null,
+                            "lastCapturedUpdate": null,
+                            "lastEffect": null,
+                            "lastUpdate": null,
+                          },
+                        },
+                        "pendingProps": Object {
+                          "Component": [Function],
+                          "context": null,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "ref": null,
+                        "return": FiberNode {
+                          "_debugHookTypes": null,
+                          "_debugID": 60,
+                          "_debugIsCurrentlyTiming": false,
+                          "_debugOwner": null,
+                          "_debugSource": null,
+                          "actualDuration": 0,
+                          "actualStartTime": -1,
+                          "alternate": FiberNode {
+                            "_debugHookTypes": null,
+                            "_debugID": 60,
+                            "_debugIsCurrentlyTiming": false,
+                            "_debugOwner": null,
+                            "_debugSource": null,
+                            "actualDuration": 0,
+                            "actualStartTime": -1,
+                            "alternate": [Circular],
+                            "child": null,
+                            "childExpirationTime": 0,
+                            "contextDependencies": null,
+                            "effectTag": 0,
+                            "elementType": null,
+                            "expirationTime": 1073741823,
+                            "firstEffect": null,
+                            "index": 0,
+                            "key": null,
+                            "lastEffect": null,
+                            "memoizedProps": null,
+                            "memoizedState": null,
+                            "mode": 0,
+                            "nextEffect": null,
+                            "pendingProps": null,
+                            "ref": null,
+                            "return": null,
+                            "selfBaseDuration": 0,
+                            "sibling": null,
+                            "stateNode": Object {
+                              "containerInfo": <div />,
+                              "context": Object {},
+                              "current": [Circular],
+                              "didError": false,
+                              "earliestPendingTime": 0,
+                              "earliestSuspendedTime": 0,
+                              "expirationTime": 0,
+                              "finishedWork": null,
+                              "firstBatch": null,
+                              "hydrate": false,
+                              "interactionThreadID": 15,
+                              "latestPendingTime": 0,
+                              "latestPingedTime": 0,
+                              "latestSuspendedTime": 0,
+                              "memoizedInteractions": Set {},
+                              "nextExpirationTimeToWorkOn": 0,
+                              "nextScheduledRoot": null,
+                              "pendingChildren": null,
+                              "pendingCommitExpirationTime": 0,
+                              "pendingContext": null,
+                              "pendingInteractionMap": Map {},
+                              "pingCache": null,
+                              "timeoutHandle": -1,
+                            },
+                            "tag": 3,
+                            "treeBaseDuration": 0,
+                            "type": null,
+                            "updateQueue": Object {
+                              "baseState": null,
+                              "firstCapturedEffect": null,
+                              "firstCapturedUpdate": null,
+                              "firstEffect": null,
+                              "firstUpdate": Object {
+                                "callback": null,
+                                "expirationTime": 1073741823,
+                                "next": null,
+                                "nextEffect": null,
+                                "payload": Object {
+                                  "element": <WrapperComponent
+                                    Component={[Function]}
+                                    context={null}
+                                    props={
+                                      Object {
+                                        "children": <AuthenticatedRoute
+                                          authenticated={true}
+                                          component={[Function]}
+                                          path="/dashboard"
+                                        />,
+                                      }
+                                    }
+                                    wrappingComponentProps={null}
+                                  />,
+                                },
+                                "tag": 0,
+                              },
+                              "lastCapturedEffect": null,
+                              "lastCapturedUpdate": null,
+                              "lastEffect": null,
+                              "lastUpdate": Object {
+                                "callback": null,
+                                "expirationTime": 1073741823,
+                                "next": null,
+                                "nextEffect": null,
+                                "payload": Object {
+                                  "element": <WrapperComponent
+                                    Component={[Function]}
+                                    context={null}
+                                    props={
+                                      Object {
+                                        "children": <AuthenticatedRoute
+                                          authenticated={true}
+                                          component={[Function]}
+                                          path="/dashboard"
+                                        />,
+                                      }
+                                    }
+                                    wrappingComponentProps={null}
+                                  />,
+                                },
+                                "tag": 0,
+                              },
+                            },
+                          },
+                          "child": [Circular],
+                          "childExpirationTime": 0,
+                          "contextDependencies": null,
+                          "effectTag": 32,
+                          "elementType": null,
+                          "expirationTime": 0,
+                          "firstEffect": [Circular],
+                          "index": 0,
+                          "key": null,
+                          "lastEffect": [Circular],
+                          "memoizedProps": null,
+                          "memoizedState": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={
+                                Object {
+                                  "children": <AuthenticatedRoute
+                                    authenticated={true}
+                                    component={[Function]}
+                                    path="/dashboard"
+                                  />,
+                                }
+                              }
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "mode": 0,
+                          "nextEffect": null,
+                          "pendingProps": null,
+                          "ref": null,
+                          "return": null,
+                          "selfBaseDuration": 0,
+                          "sibling": null,
+                          "stateNode": Object {
+                            "containerInfo": <div />,
+                            "context": Object {},
+                            "current": [Circular],
+                            "didError": false,
+                            "earliestPendingTime": 0,
+                            "earliestSuspendedTime": 0,
+                            "expirationTime": 0,
+                            "finishedWork": null,
+                            "firstBatch": null,
+                            "hydrate": false,
+                            "interactionThreadID": 15,
+                            "latestPendingTime": 0,
+                            "latestPingedTime": 0,
+                            "latestSuspendedTime": 0,
+                            "memoizedInteractions": Set {},
+                            "nextExpirationTimeToWorkOn": 0,
+                            "nextScheduledRoot": null,
+                            "pendingChildren": null,
+                            "pendingCommitExpirationTime": 0,
+                            "pendingContext": null,
+                            "pendingInteractionMap": Map {},
+                            "pingCache": null,
+                            "timeoutHandle": -1,
+                          },
+                          "tag": 3,
+                          "treeBaseDuration": 0,
+                          "type": null,
+                          "updateQueue": Object {
+                            "baseState": Object {
+                              "element": <WrapperComponent
+                                Component={[Function]}
+                                context={null}
+                                props={
+                                  Object {
+                                    "children": <AuthenticatedRoute
+                                      authenticated={true}
+                                      component={[Function]}
+                                      path="/dashboard"
+                                    />,
+                                  }
+                                }
+                                wrappingComponentProps={null}
+                              />,
+                            },
+                            "firstCapturedEffect": null,
+                            "firstCapturedUpdate": null,
+                            "firstEffect": null,
+                            "firstUpdate": null,
+                            "lastCapturedEffect": null,
+                            "lastCapturedUpdate": null,
+                            "lastEffect": null,
+                            "lastUpdate": null,
+                          },
+                        },
+                        "selfBaseDuration": 0,
+                        "sibling": null,
+                        "stateNode": WrapperComponent {
+                          "_reactInternalFiber": [Circular],
+                          "_reactInternalInstance": Object {},
+                          "context": Object {},
+                          "props": Object {
+                            "Component": [Function],
+                            "context": null,
+                            "props": Object {
+                              "children": <AuthenticatedRoute
+                                authenticated={true}
+                                component={[Function]}
+                                path="/dashboard"
+                              />,
+                            },
+                            "wrappingComponentProps": null,
+                          },
+                          "refs": Object {},
+                          "rootFinderInstance": null,
+                          "state": Object {
+                            "context": null,
+                            "mount": true,
+                            "props": Object {
+                              "children": <AuthenticatedRoute
+                                authenticated={true}
+                                component={[Function]}
+                                path="/dashboard"
+                              />,
+                            },
+                            "wrappingComponentProps": null,
+                          },
+                          "updater": Object {
+                            "enqueueForceUpdate": [Function],
+                            "enqueueReplaceState": [Function],
+                            "enqueueSetState": [Function],
+                            "isMounted": [Function],
+                          },
+                        },
+                        "tag": 1,
+                        "treeBaseDuration": 0,
+                        "type": [Function],
+                        "updateQueue": null,
+                      },
+                      "selfBaseDuration": 0,
+                      "sibling": null,
+                      "stateNode": BrowserRouter {
+                        "_reactInternalFiber": [Circular],
+                        "_reactInternalInstance": Object {},
+                        "context": Object {},
+                        "history": Object {
+                          "action": "POP",
+                          "block": [Function],
+                          "createHref": [Function],
+                          "go": [Function],
+                          "goBack": [Function],
+                          "goForward": [Function],
+                          "length": 1,
+                          "listen": [Function],
+                          "location": Object {
+                            "hash": "",
+                            "pathname": "/",
+                            "search": "",
+                            "state": undefined,
+                          },
+                          "push": [Function],
+                          "replace": [Function],
+                        },
+                        "props": Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        },
+                        "refs": Object {},
+                        "state": null,
+                        "updater": Object {
+                          "enqueueForceUpdate": [Function],
+                          "enqueueReplaceState": [Function],
+                          "enqueueSetState": [Function],
+                          "isMounted": [Function],
+                        },
+                      },
+                      "tag": 1,
+                      "treeBaseDuration": 0,
+                      "type": [Function],
+                      "updateQueue": null,
+                    },
+                    "_debugSource": null,
+                    "actualDuration": 0,
+                    "actualStartTime": -1,
+                    "alternate": null,
+                    "child": [Circular],
+                    "childExpirationTime": 0,
+                    "contextDependencies": null,
+                    "effectTag": 1,
+                    "elementType": [Function],
+                    "expirationTime": 0,
+                    "firstEffect": null,
+                    "index": 0,
+                    "key": null,
+                    "lastEffect": null,
+                    "memoizedProps": Object {
+                      "children": <AuthenticatedRoute
+                        authenticated={true}
+                        component={[Function]}
+                        path="/dashboard"
+                      />,
+                      "history": Object {
+                        "action": "POP",
+                        "block": [Function],
+                        "createHref": [Function],
+                        "go": [Function],
+                        "goBack": [Function],
+                        "goForward": [Function],
+                        "length": 1,
+                        "listen": [Function],
+                        "location": Object {
+                          "hash": "",
+                          "pathname": "/",
+                          "search": "",
+                          "state": undefined,
+                        },
+                        "push": [Function],
+                        "replace": [Function],
+                      },
+                    },
+                    "memoizedState": Object {
+                      "match": Object {
+                        "isExact": true,
+                        "params": Object {},
+                        "path": "/",
+                        "url": "/",
+                      },
+                    },
+                    "mode": 0,
+                    "nextEffect": null,
+                    "pendingProps": Object {
+                      "children": <AuthenticatedRoute
+                        authenticated={true}
+                        component={[Function]}
+                        path="/dashboard"
+                      />,
+                      "history": Object {
+                        "action": "POP",
+                        "block": [Function],
+                        "createHref": [Function],
+                        "go": [Function],
+                        "goBack": [Function],
+                        "goForward": [Function],
+                        "length": 1,
+                        "listen": [Function],
+                        "location": Object {
+                          "hash": "",
+                          "pathname": "/",
+                          "search": "",
+                          "state": undefined,
+                        },
+                        "push": [Function],
+                        "replace": [Function],
+                      },
+                    },
+                    "ref": null,
+                    "return": FiberNode {
+                      "_debugHookTypes": null,
+                      "_debugID": 63,
+                      "_debugIsCurrentlyTiming": false,
+                      "_debugOwner": FiberNode {
+                        "_debugHookTypes": null,
+                        "_debugID": 62,
+                        "_debugIsCurrentlyTiming": false,
+                        "_debugOwner": null,
+                        "_debugSource": null,
+                        "actualDuration": 0,
+                        "actualStartTime": -1,
+                        "alternate": null,
+                        "child": [Circular],
+                        "childExpirationTime": 0,
+                        "contextDependencies": null,
+                        "effectTag": 1,
+                        "elementType": [Function],
+                        "expirationTime": 0,
+                        "firstEffect": null,
+                        "index": 0,
+                        "key": null,
+                        "lastEffect": null,
+                        "memoizedProps": Object {
+                          "Component": [Function],
+                          "context": null,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "memoizedState": Object {
+                          "context": null,
+                          "mount": true,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "mode": 0,
+                        "nextEffect": FiberNode {
+                          "_debugHookTypes": null,
+                          "_debugID": 60,
+                          "_debugIsCurrentlyTiming": false,
+                          "_debugOwner": null,
+                          "_debugSource": null,
+                          "actualDuration": 0,
+                          "actualStartTime": -1,
+                          "alternate": FiberNode {
+                            "_debugHookTypes": null,
+                            "_debugID": 60,
+                            "_debugIsCurrentlyTiming": false,
+                            "_debugOwner": null,
+                            "_debugSource": null,
+                            "actualDuration": 0,
+                            "actualStartTime": -1,
+                            "alternate": [Circular],
+                            "child": null,
+                            "childExpirationTime": 0,
+                            "contextDependencies": null,
+                            "effectTag": 0,
+                            "elementType": null,
+                            "expirationTime": 1073741823,
+                            "firstEffect": null,
+                            "index": 0,
+                            "key": null,
+                            "lastEffect": null,
+                            "memoizedProps": null,
+                            "memoizedState": null,
+                            "mode": 0,
+                            "nextEffect": null,
+                            "pendingProps": null,
+                            "ref": null,
+                            "return": null,
+                            "selfBaseDuration": 0,
+                            "sibling": null,
+                            "stateNode": Object {
+                              "containerInfo": <div />,
+                              "context": Object {},
+                              "current": [Circular],
+                              "didError": false,
+                              "earliestPendingTime": 0,
+                              "earliestSuspendedTime": 0,
+                              "expirationTime": 0,
+                              "finishedWork": null,
+                              "firstBatch": null,
+                              "hydrate": false,
+                              "interactionThreadID": 15,
+                              "latestPendingTime": 0,
+                              "latestPingedTime": 0,
+                              "latestSuspendedTime": 0,
+                              "memoizedInteractions": Set {},
+                              "nextExpirationTimeToWorkOn": 0,
+                              "nextScheduledRoot": null,
+                              "pendingChildren": null,
+                              "pendingCommitExpirationTime": 0,
+                              "pendingContext": null,
+                              "pendingInteractionMap": Map {},
+                              "pingCache": null,
+                              "timeoutHandle": -1,
+                            },
+                            "tag": 3,
+                            "treeBaseDuration": 0,
+                            "type": null,
+                            "updateQueue": Object {
+                              "baseState": null,
+                              "firstCapturedEffect": null,
+                              "firstCapturedUpdate": null,
+                              "firstEffect": null,
+                              "firstUpdate": Object {
+                                "callback": null,
+                                "expirationTime": 1073741823,
+                                "next": null,
+                                "nextEffect": null,
+                                "payload": Object {
+                                  "element": <WrapperComponent
+                                    Component={[Function]}
+                                    context={null}
+                                    props={
+                                      Object {
+                                        "children": <AuthenticatedRoute
+                                          authenticated={true}
+                                          component={[Function]}
+                                          path="/dashboard"
+                                        />,
+                                      }
+                                    }
+                                    wrappingComponentProps={null}
+                                  />,
+                                },
+                                "tag": 0,
+                              },
+                              "lastCapturedEffect": null,
+                              "lastCapturedUpdate": null,
+                              "lastEffect": null,
+                              "lastUpdate": Object {
+                                "callback": null,
+                                "expirationTime": 1073741823,
+                                "next": null,
+                                "nextEffect": null,
+                                "payload": Object {
+                                  "element": <WrapperComponent
+                                    Component={[Function]}
+                                    context={null}
+                                    props={
+                                      Object {
+                                        "children": <AuthenticatedRoute
+                                          authenticated={true}
+                                          component={[Function]}
+                                          path="/dashboard"
+                                        />,
+                                      }
+                                    }
+                                    wrappingComponentProps={null}
+                                  />,
+                                },
+                                "tag": 0,
+                              },
+                            },
+                          },
+                          "child": [Circular],
+                          "childExpirationTime": 0,
+                          "contextDependencies": null,
+                          "effectTag": 32,
+                          "elementType": null,
+                          "expirationTime": 0,
+                          "firstEffect": [Circular],
+                          "index": 0,
+                          "key": null,
+                          "lastEffect": [Circular],
+                          "memoizedProps": null,
+                          "memoizedState": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={
+                                Object {
+                                  "children": <AuthenticatedRoute
+                                    authenticated={true}
+                                    component={[Function]}
+                                    path="/dashboard"
+                                  />,
+                                }
+                              }
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "mode": 0,
+                          "nextEffect": null,
+                          "pendingProps": null,
+                          "ref": null,
+                          "return": null,
+                          "selfBaseDuration": 0,
+                          "sibling": null,
+                          "stateNode": Object {
+                            "containerInfo": <div />,
+                            "context": Object {},
+                            "current": [Circular],
+                            "didError": false,
+                            "earliestPendingTime": 0,
+                            "earliestSuspendedTime": 0,
+                            "expirationTime": 0,
+                            "finishedWork": null,
+                            "firstBatch": null,
+                            "hydrate": false,
+                            "interactionThreadID": 15,
+                            "latestPendingTime": 0,
+                            "latestPingedTime": 0,
+                            "latestSuspendedTime": 0,
+                            "memoizedInteractions": Set {},
+                            "nextExpirationTimeToWorkOn": 0,
+                            "nextScheduledRoot": null,
+                            "pendingChildren": null,
+                            "pendingCommitExpirationTime": 0,
+                            "pendingContext": null,
+                            "pendingInteractionMap": Map {},
+                            "pingCache": null,
+                            "timeoutHandle": -1,
+                          },
+                          "tag": 3,
+                          "treeBaseDuration": 0,
+                          "type": null,
+                          "updateQueue": Object {
+                            "baseState": Object {
+                              "element": <WrapperComponent
+                                Component={[Function]}
+                                context={null}
+                                props={
+                                  Object {
+                                    "children": <AuthenticatedRoute
+                                      authenticated={true}
+                                      component={[Function]}
+                                      path="/dashboard"
+                                    />,
+                                  }
+                                }
+                                wrappingComponentProps={null}
+                              />,
+                            },
+                            "firstCapturedEffect": null,
+                            "firstCapturedUpdate": null,
+                            "firstEffect": null,
+                            "firstUpdate": null,
+                            "lastCapturedEffect": null,
+                            "lastCapturedUpdate": null,
+                            "lastEffect": null,
+                            "lastUpdate": null,
+                          },
+                        },
+                        "pendingProps": Object {
+                          "Component": [Function],
+                          "context": null,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "ref": null,
+                        "return": FiberNode {
+                          "_debugHookTypes": null,
+                          "_debugID": 60,
+                          "_debugIsCurrentlyTiming": false,
+                          "_debugOwner": null,
+                          "_debugSource": null,
+                          "actualDuration": 0,
+                          "actualStartTime": -1,
+                          "alternate": FiberNode {
+                            "_debugHookTypes": null,
+                            "_debugID": 60,
+                            "_debugIsCurrentlyTiming": false,
+                            "_debugOwner": null,
+                            "_debugSource": null,
+                            "actualDuration": 0,
+                            "actualStartTime": -1,
+                            "alternate": [Circular],
+                            "child": null,
+                            "childExpirationTime": 0,
+                            "contextDependencies": null,
+                            "effectTag": 0,
+                            "elementType": null,
+                            "expirationTime": 1073741823,
+                            "firstEffect": null,
+                            "index": 0,
+                            "key": null,
+                            "lastEffect": null,
+                            "memoizedProps": null,
+                            "memoizedState": null,
+                            "mode": 0,
+                            "nextEffect": null,
+                            "pendingProps": null,
+                            "ref": null,
+                            "return": null,
+                            "selfBaseDuration": 0,
+                            "sibling": null,
+                            "stateNode": Object {
+                              "containerInfo": <div />,
+                              "context": Object {},
+                              "current": [Circular],
+                              "didError": false,
+                              "earliestPendingTime": 0,
+                              "earliestSuspendedTime": 0,
+                              "expirationTime": 0,
+                              "finishedWork": null,
+                              "firstBatch": null,
+                              "hydrate": false,
+                              "interactionThreadID": 15,
+                              "latestPendingTime": 0,
+                              "latestPingedTime": 0,
+                              "latestSuspendedTime": 0,
+                              "memoizedInteractions": Set {},
+                              "nextExpirationTimeToWorkOn": 0,
+                              "nextScheduledRoot": null,
+                              "pendingChildren": null,
+                              "pendingCommitExpirationTime": 0,
+                              "pendingContext": null,
+                              "pendingInteractionMap": Map {},
+                              "pingCache": null,
+                              "timeoutHandle": -1,
+                            },
+                            "tag": 3,
+                            "treeBaseDuration": 0,
+                            "type": null,
+                            "updateQueue": Object {
+                              "baseState": null,
+                              "firstCapturedEffect": null,
+                              "firstCapturedUpdate": null,
+                              "firstEffect": null,
+                              "firstUpdate": Object {
+                                "callback": null,
+                                "expirationTime": 1073741823,
+                                "next": null,
+                                "nextEffect": null,
+                                "payload": Object {
+                                  "element": <WrapperComponent
+                                    Component={[Function]}
+                                    context={null}
+                                    props={
+                                      Object {
+                                        "children": <AuthenticatedRoute
+                                          authenticated={true}
+                                          component={[Function]}
+                                          path="/dashboard"
+                                        />,
+                                      }
+                                    }
+                                    wrappingComponentProps={null}
+                                  />,
+                                },
+                                "tag": 0,
+                              },
+                              "lastCapturedEffect": null,
+                              "lastCapturedUpdate": null,
+                              "lastEffect": null,
+                              "lastUpdate": Object {
+                                "callback": null,
+                                "expirationTime": 1073741823,
+                                "next": null,
+                                "nextEffect": null,
+                                "payload": Object {
+                                  "element": <WrapperComponent
+                                    Component={[Function]}
+                                    context={null}
+                                    props={
+                                      Object {
+                                        "children": <AuthenticatedRoute
+                                          authenticated={true}
+                                          component={[Function]}
+                                          path="/dashboard"
+                                        />,
+                                      }
+                                    }
+                                    wrappingComponentProps={null}
+                                  />,
+                                },
+                                "tag": 0,
+                              },
+                            },
+                          },
+                          "child": [Circular],
+                          "childExpirationTime": 0,
+                          "contextDependencies": null,
+                          "effectTag": 32,
+                          "elementType": null,
+                          "expirationTime": 0,
+                          "firstEffect": [Circular],
+                          "index": 0,
+                          "key": null,
+                          "lastEffect": [Circular],
+                          "memoizedProps": null,
+                          "memoizedState": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={
+                                Object {
+                                  "children": <AuthenticatedRoute
+                                    authenticated={true}
+                                    component={[Function]}
+                                    path="/dashboard"
+                                  />,
+                                }
+                              }
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "mode": 0,
+                          "nextEffect": null,
+                          "pendingProps": null,
+                          "ref": null,
+                          "return": null,
+                          "selfBaseDuration": 0,
+                          "sibling": null,
+                          "stateNode": Object {
+                            "containerInfo": <div />,
+                            "context": Object {},
+                            "current": [Circular],
+                            "didError": false,
+                            "earliestPendingTime": 0,
+                            "earliestSuspendedTime": 0,
+                            "expirationTime": 0,
+                            "finishedWork": null,
+                            "firstBatch": null,
+                            "hydrate": false,
+                            "interactionThreadID": 15,
+                            "latestPendingTime": 0,
+                            "latestPingedTime": 0,
+                            "latestSuspendedTime": 0,
+                            "memoizedInteractions": Set {},
+                            "nextExpirationTimeToWorkOn": 0,
+                            "nextScheduledRoot": null,
+                            "pendingChildren": null,
+                            "pendingCommitExpirationTime": 0,
+                            "pendingContext": null,
+                            "pendingInteractionMap": Map {},
+                            "pingCache": null,
+                            "timeoutHandle": -1,
+                          },
+                          "tag": 3,
+                          "treeBaseDuration": 0,
+                          "type": null,
+                          "updateQueue": Object {
+                            "baseState": Object {
+                              "element": <WrapperComponent
+                                Component={[Function]}
+                                context={null}
+                                props={
+                                  Object {
+                                    "children": <AuthenticatedRoute
+                                      authenticated={true}
+                                      component={[Function]}
+                                      path="/dashboard"
+                                    />,
+                                  }
+                                }
+                                wrappingComponentProps={null}
+                              />,
+                            },
+                            "firstCapturedEffect": null,
+                            "firstCapturedUpdate": null,
+                            "firstEffect": null,
+                            "firstUpdate": null,
+                            "lastCapturedEffect": null,
+                            "lastCapturedUpdate": null,
+                            "lastEffect": null,
+                            "lastUpdate": null,
+                          },
+                        },
+                        "selfBaseDuration": 0,
+                        "sibling": null,
+                        "stateNode": WrapperComponent {
+                          "_reactInternalFiber": [Circular],
+                          "_reactInternalInstance": Object {},
+                          "context": Object {},
+                          "props": Object {
+                            "Component": [Function],
+                            "context": null,
+                            "props": Object {
+                              "children": <AuthenticatedRoute
+                                authenticated={true}
+                                component={[Function]}
+                                path="/dashboard"
+                              />,
+                            },
+                            "wrappingComponentProps": null,
+                          },
+                          "refs": Object {},
+                          "rootFinderInstance": null,
+                          "state": Object {
+                            "context": null,
+                            "mount": true,
+                            "props": Object {
+                              "children": <AuthenticatedRoute
+                                authenticated={true}
+                                component={[Function]}
+                                path="/dashboard"
+                              />,
+                            },
+                            "wrappingComponentProps": null,
+                          },
+                          "updater": Object {
+                            "enqueueForceUpdate": [Function],
+                            "enqueueReplaceState": [Function],
+                            "enqueueSetState": [Function],
+                            "isMounted": [Function],
+                          },
+                        },
+                        "tag": 1,
+                        "treeBaseDuration": 0,
+                        "type": [Function],
+                        "updateQueue": null,
+                      },
+                      "_debugSource": null,
+                      "actualDuration": 0,
+                      "actualStartTime": -1,
+                      "alternate": null,
+                      "child": [Circular],
+                      "childExpirationTime": 0,
+                      "contextDependencies": null,
+                      "effectTag": 1,
+                      "elementType": [Function],
+                      "expirationTime": 0,
+                      "firstEffect": null,
+                      "index": 0,
+                      "key": null,
+                      "lastEffect": null,
+                      "memoizedProps": Object {
+                        "children": <AuthenticatedRoute
+                          authenticated={true}
+                          component={[Function]}
+                          path="/dashboard"
+                        />,
+                      },
+                      "memoizedState": null,
+                      "mode": 0,
+                      "nextEffect": null,
+                      "pendingProps": Object {
+                        "children": <AuthenticatedRoute
+                          authenticated={true}
+                          component={[Function]}
+                          path="/dashboard"
+                        />,
+                      },
+                      "ref": null,
+                      "return": FiberNode {
+                        "_debugHookTypes": null,
+                        "_debugID": 62,
+                        "_debugIsCurrentlyTiming": false,
+                        "_debugOwner": null,
+                        "_debugSource": null,
+                        "actualDuration": 0,
+                        "actualStartTime": -1,
+                        "alternate": null,
+                        "child": [Circular],
+                        "childExpirationTime": 0,
+                        "contextDependencies": null,
+                        "effectTag": 1,
+                        "elementType": [Function],
+                        "expirationTime": 0,
+                        "firstEffect": null,
+                        "index": 0,
+                        "key": null,
+                        "lastEffect": null,
+                        "memoizedProps": Object {
+                          "Component": [Function],
+                          "context": null,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "memoizedState": Object {
+                          "context": null,
+                          "mount": true,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "mode": 0,
+                        "nextEffect": FiberNode {
+                          "_debugHookTypes": null,
+                          "_debugID": 60,
+                          "_debugIsCurrentlyTiming": false,
+                          "_debugOwner": null,
+                          "_debugSource": null,
+                          "actualDuration": 0,
+                          "actualStartTime": -1,
+                          "alternate": FiberNode {
+                            "_debugHookTypes": null,
+                            "_debugID": 60,
+                            "_debugIsCurrentlyTiming": false,
+                            "_debugOwner": null,
+                            "_debugSource": null,
+                            "actualDuration": 0,
+                            "actualStartTime": -1,
+                            "alternate": [Circular],
+                            "child": null,
+                            "childExpirationTime": 0,
+                            "contextDependencies": null,
+                            "effectTag": 0,
+                            "elementType": null,
+                            "expirationTime": 1073741823,
+                            "firstEffect": null,
+                            "index": 0,
+                            "key": null,
+                            "lastEffect": null,
+                            "memoizedProps": null,
+                            "memoizedState": null,
+                            "mode": 0,
+                            "nextEffect": null,
+                            "pendingProps": null,
+                            "ref": null,
+                            "return": null,
+                            "selfBaseDuration": 0,
+                            "sibling": null,
+                            "stateNode": Object {
+                              "containerInfo": <div />,
+                              "context": Object {},
+                              "current": [Circular],
+                              "didError": false,
+                              "earliestPendingTime": 0,
+                              "earliestSuspendedTime": 0,
+                              "expirationTime": 0,
+                              "finishedWork": null,
+                              "firstBatch": null,
+                              "hydrate": false,
+                              "interactionThreadID": 15,
+                              "latestPendingTime": 0,
+                              "latestPingedTime": 0,
+                              "latestSuspendedTime": 0,
+                              "memoizedInteractions": Set {},
+                              "nextExpirationTimeToWorkOn": 0,
+                              "nextScheduledRoot": null,
+                              "pendingChildren": null,
+                              "pendingCommitExpirationTime": 0,
+                              "pendingContext": null,
+                              "pendingInteractionMap": Map {},
+                              "pingCache": null,
+                              "timeoutHandle": -1,
+                            },
+                            "tag": 3,
+                            "treeBaseDuration": 0,
+                            "type": null,
+                            "updateQueue": Object {
+                              "baseState": null,
+                              "firstCapturedEffect": null,
+                              "firstCapturedUpdate": null,
+                              "firstEffect": null,
+                              "firstUpdate": Object {
+                                "callback": null,
+                                "expirationTime": 1073741823,
+                                "next": null,
+                                "nextEffect": null,
+                                "payload": Object {
+                                  "element": <WrapperComponent
+                                    Component={[Function]}
+                                    context={null}
+                                    props={
+                                      Object {
+                                        "children": <AuthenticatedRoute
+                                          authenticated={true}
+                                          component={[Function]}
+                                          path="/dashboard"
+                                        />,
+                                      }
+                                    }
+                                    wrappingComponentProps={null}
+                                  />,
+                                },
+                                "tag": 0,
+                              },
+                              "lastCapturedEffect": null,
+                              "lastCapturedUpdate": null,
+                              "lastEffect": null,
+                              "lastUpdate": Object {
+                                "callback": null,
+                                "expirationTime": 1073741823,
+                                "next": null,
+                                "nextEffect": null,
+                                "payload": Object {
+                                  "element": <WrapperComponent
+                                    Component={[Function]}
+                                    context={null}
+                                    props={
+                                      Object {
+                                        "children": <AuthenticatedRoute
+                                          authenticated={true}
+                                          component={[Function]}
+                                          path="/dashboard"
+                                        />,
+                                      }
+                                    }
+                                    wrappingComponentProps={null}
+                                  />,
+                                },
+                                "tag": 0,
+                              },
+                            },
+                          },
+                          "child": [Circular],
+                          "childExpirationTime": 0,
+                          "contextDependencies": null,
+                          "effectTag": 32,
+                          "elementType": null,
+                          "expirationTime": 0,
+                          "firstEffect": [Circular],
+                          "index": 0,
+                          "key": null,
+                          "lastEffect": [Circular],
+                          "memoizedProps": null,
+                          "memoizedState": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={
+                                Object {
+                                  "children": <AuthenticatedRoute
+                                    authenticated={true}
+                                    component={[Function]}
+                                    path="/dashboard"
+                                  />,
+                                }
+                              }
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "mode": 0,
+                          "nextEffect": null,
+                          "pendingProps": null,
+                          "ref": null,
+                          "return": null,
+                          "selfBaseDuration": 0,
+                          "sibling": null,
+                          "stateNode": Object {
+                            "containerInfo": <div />,
+                            "context": Object {},
+                            "current": [Circular],
+                            "didError": false,
+                            "earliestPendingTime": 0,
+                            "earliestSuspendedTime": 0,
+                            "expirationTime": 0,
+                            "finishedWork": null,
+                            "firstBatch": null,
+                            "hydrate": false,
+                            "interactionThreadID": 15,
+                            "latestPendingTime": 0,
+                            "latestPingedTime": 0,
+                            "latestSuspendedTime": 0,
+                            "memoizedInteractions": Set {},
+                            "nextExpirationTimeToWorkOn": 0,
+                            "nextScheduledRoot": null,
+                            "pendingChildren": null,
+                            "pendingCommitExpirationTime": 0,
+                            "pendingContext": null,
+                            "pendingInteractionMap": Map {},
+                            "pingCache": null,
+                            "timeoutHandle": -1,
+                          },
+                          "tag": 3,
+                          "treeBaseDuration": 0,
+                          "type": null,
+                          "updateQueue": Object {
+                            "baseState": Object {
+                              "element": <WrapperComponent
+                                Component={[Function]}
+                                context={null}
+                                props={
+                                  Object {
+                                    "children": <AuthenticatedRoute
+                                      authenticated={true}
+                                      component={[Function]}
+                                      path="/dashboard"
+                                    />,
+                                  }
+                                }
+                                wrappingComponentProps={null}
+                              />,
+                            },
+                            "firstCapturedEffect": null,
+                            "firstCapturedUpdate": null,
+                            "firstEffect": null,
+                            "firstUpdate": null,
+                            "lastCapturedEffect": null,
+                            "lastCapturedUpdate": null,
+                            "lastEffect": null,
+                            "lastUpdate": null,
+                          },
+                        },
+                        "pendingProps": Object {
+                          "Component": [Function],
+                          "context": null,
+                          "props": Object {
+                            "children": <AuthenticatedRoute
+                              authenticated={true}
+                              component={[Function]}
+                              path="/dashboard"
+                            />,
+                          },
+                          "wrappingComponentProps": null,
+                        },
+                        "ref": null,
+                        "return": FiberNode {
+                          "_debugHookTypes": null,
+                          "_debugID": 60,
+                          "_debugIsCurrentlyTiming": false,
+                          "_debugOwner": null,
+                          "_debugSource": null,
+                          "actualDuration": 0,
+                          "actualStartTime": -1,
+                          "alternate": FiberNode {
+                            "_debugHookTypes": null,
+                            "_debugID": 60,
+                            "_debugIsCurrentlyTiming": false,
+                            "_debugOwner": null,
+                            "_debugSource": null,
+                            "actualDuration": 0,
+                            "actualStartTime": -1,
+                            "alternate": [Circular],
+                            "child": null,
+                            "childExpirationTime": 0,
+                            "contextDependencies": null,
+                            "effectTag": 0,
+                            "elementType": null,
+                            "expirationTime": 1073741823,
+                            "firstEffect": null,
+                            "index": 0,
+                            "key": null,
+                            "lastEffect": null,
+                            "memoizedProps": null,
+                            "memoizedState": null,
+                            "mode": 0,
+                            "nextEffect": null,
+                            "pendingProps": null,
+                            "ref": null,
+                            "return": null,
+                            "selfBaseDuration": 0,
+                            "sibling": null,
+                            "stateNode": Object {
+                              "containerInfo": <div />,
+                              "context": Object {},
+                              "current": [Circular],
+                              "didError": false,
+                              "earliestPendingTime": 0,
+                              "earliestSuspendedTime": 0,
+                              "expirationTime": 0,
+                              "finishedWork": null,
+                              "firstBatch": null,
+                              "hydrate": false,
+                              "interactionThreadID": 15,
+                              "latestPendingTime": 0,
+                              "latestPingedTime": 0,
+                              "latestSuspendedTime": 0,
+                              "memoizedInteractions": Set {},
+                              "nextExpirationTimeToWorkOn": 0,
+                              "nextScheduledRoot": null,
+                              "pendingChildren": null,
+                              "pendingCommitExpirationTime": 0,
+                              "pendingContext": null,
+                              "pendingInteractionMap": Map {},
+                              "pingCache": null,
+                              "timeoutHandle": -1,
+                            },
+                            "tag": 3,
+                            "treeBaseDuration": 0,
+                            "type": null,
+                            "updateQueue": Object {
+                              "baseState": null,
+                              "firstCapturedEffect": null,
+                              "firstCapturedUpdate": null,
+                              "firstEffect": null,
+                              "firstUpdate": Object {
+                                "callback": null,
+                                "expirationTime": 1073741823,
+                                "next": null,
+                                "nextEffect": null,
+                                "payload": Object {
+                                  "element": <WrapperComponent
+                                    Component={[Function]}
+                                    context={null}
+                                    props={
+                                      Object {
+                                        "children": <AuthenticatedRoute
+                                          authenticated={true}
+                                          component={[Function]}
+                                          path="/dashboard"
+                                        />,
+                                      }
+                                    }
+                                    wrappingComponentProps={null}
+                                  />,
+                                },
+                                "tag": 0,
+                              },
+                              "lastCapturedEffect": null,
+                              "lastCapturedUpdate": null,
+                              "lastEffect": null,
+                              "lastUpdate": Object {
+                                "callback": null,
+                                "expirationTime": 1073741823,
+                                "next": null,
+                                "nextEffect": null,
+                                "payload": Object {
+                                  "element": <WrapperComponent
+                                    Component={[Function]}
+                                    context={null}
+                                    props={
+                                      Object {
+                                        "children": <AuthenticatedRoute
+                                          authenticated={true}
+                                          component={[Function]}
+                                          path="/dashboard"
+                                        />,
+                                      }
+                                    }
+                                    wrappingComponentProps={null}
+                                  />,
+                                },
+                                "tag": 0,
+                              },
+                            },
+                          },
+                          "child": [Circular],
+                          "childExpirationTime": 0,
+                          "contextDependencies": null,
+                          "effectTag": 32,
+                          "elementType": null,
+                          "expirationTime": 0,
+                          "firstEffect": [Circular],
+                          "index": 0,
+                          "key": null,
+                          "lastEffect": [Circular],
+                          "memoizedProps": null,
+                          "memoizedState": Object {
+                            "element": <WrapperComponent
+                              Component={[Function]}
+                              context={null}
+                              props={
+                                Object {
+                                  "children": <AuthenticatedRoute
+                                    authenticated={true}
+                                    component={[Function]}
+                                    path="/dashboard"
+                                  />,
+                                }
+                              }
+                              wrappingComponentProps={null}
+                            />,
+                          },
+                          "mode": 0,
+                          "nextEffect": null,
+                          "pendingProps": null,
+                          "ref": null,
+                          "return": null,
+                          "selfBaseDuration": 0,
+                          "sibling": null,
+                          "stateNode": Object {
+                            "containerInfo": <div />,
+                            "context": Object {},
+                            "current": [Circular],
+                            "didError": false,
+                            "earliestPendingTime": 0,
+                            "earliestSuspendedTime": 0,
+                            "expirationTime": 0,
+                            "finishedWork": null,
+                            "firstBatch": null,
+                            "hydrate": false,
+                            "interactionThreadID": 15,
+                            "latestPendingTime": 0,
+                            "latestPingedTime": 0,
+                            "latestSuspendedTime": 0,
+                            "memoizedInteractions": Set {},
+                            "nextExpirationTimeToWorkOn": 0,
+                            "nextScheduledRoot": null,
+                            "pendingChildren": null,
+                            "pendingCommitExpirationTime": 0,
+                            "pendingContext": null,
+                            "pendingInteractionMap": Map {},
+                            "pingCache": null,
+                            "timeoutHandle": -1,
+                          },
+                          "tag": 3,
+                          "treeBaseDuration": 0,
+                          "type": null,
+                          "updateQueue": Object {
+                            "baseState": Object {
+                              "element": <WrapperComponent
+                                Component={[Function]}
+                                context={null}
+                                props={
+                                  Object {
+                                    "children": <AuthenticatedRoute
+                                      authenticated={true}
+                                      component={[Function]}
+                                      path="/dashboard"
+                                    />,
+                                  }
+                                }
+                                wrappingComponentProps={null}
+                              />,
+                            },
+                            "firstCapturedEffect": null,
+                            "firstCapturedUpdate": null,
+                            "firstEffect": null,
+                            "firstUpdate": null,
+                            "lastCapturedEffect": null,
+                            "lastCapturedUpdate": null,
+                            "lastEffect": null,
+                            "lastUpdate": null,
+                          },
+                        },
+                        "selfBaseDuration": 0,
+                        "sibling": null,
+                        "stateNode": WrapperComponent {
+                          "_reactInternalFiber": [Circular],
+                          "_reactInternalInstance": Object {},
+                          "context": Object {},
+                          "props": Object {
+                            "Component": [Function],
+                            "context": null,
+                            "props": Object {
+                              "children": <AuthenticatedRoute
+                                authenticated={true}
+                                component={[Function]}
+                                path="/dashboard"
+                              />,
+                            },
+                            "wrappingComponentProps": null,
+                          },
+                          "refs": Object {},
+                          "rootFinderInstance": null,
+                          "state": Object {
+                            "context": null,
+                            "mount": true,
+                            "props": Object {
+                              "children": <AuthenticatedRoute
+                                authenticated={true}
+                                component={[Function]}
+                                path="/dashboard"
+                              />,
+                            },
+                            "wrappingComponentProps": null,
+                          },
+                          "updater": Object {
+                            "enqueueForceUpdate": [Function],
+                            "enqueueReplaceState": [Function],
+                            "enqueueSetState": [Function],
+                            "isMounted": [Function],
+                          },
+                        },
+                        "tag": 1,
+                        "treeBaseDuration": 0,
+                        "type": [Function],
+                        "updateQueue": null,
+                      },
+                      "selfBaseDuration": 0,
+                      "sibling": null,
+                      "stateNode": BrowserRouter {
+                        "_reactInternalFiber": [Circular],
+                        "_reactInternalInstance": Object {},
+                        "context": Object {},
+                        "history": Object {
+                          "action": "POP",
+                          "block": [Function],
+                          "createHref": [Function],
+                          "go": [Function],
+                          "goBack": [Function],
+                          "goForward": [Function],
+                          "length": 1,
+                          "listen": [Function],
+                          "location": Object {
+                            "hash": "",
+                            "pathname": "/",
+                            "search": "",
+                            "state": undefined,
+                          },
+                          "push": [Function],
+                          "replace": [Function],
+                        },
+                        "props": Object {
+                          "children": <AuthenticatedRoute
+                            authenticated={true}
+                            component={[Function]}
+                            path="/dashboard"
+                          />,
+                        },
+                        "refs": Object {},
+                        "state": null,
+                        "updater": Object {
+                          "enqueueForceUpdate": [Function],
+                          "enqueueReplaceState": [Function],
+                          "enqueueSetState": [Function],
+                          "isMounted": [Function],
+                        },
+                      },
+                      "tag": 1,
+                      "treeBaseDuration": 0,
+                      "type": [Function],
+                      "updateQueue": null,
+                    },
+                    "selfBaseDuration": 0,
+                    "sibling": null,
+                    "stateNode": Router {
+                      "__reactInternalMemoizedMaskedChildContext": Object {
+                        "router": undefined,
+                      },
+                      "__reactInternalMemoizedMergedChildContext": Object {
+                        "router": Object {
+                          "history": Object {
+                            "action": "POP",
+                            "block": [Function],
+                            "createHref": [Function],
+                            "go": [Function],
+                            "goBack": [Function],
+                            "goForward": [Function],
+                            "length": 1,
+                            "listen": [Function],
+                            "location": Object {
+                              "hash": "",
+                              "pathname": "/",
+                              "search": "",
+                              "state": undefined,
+                            },
+                            "push": [Function],
+                            "replace": [Function],
+                          },
+                          "route": Object {
+                            "location": Object {
+                              "hash": "",
+                              "pathname": "/",
+                              "search": "",
+                              "state": undefined,
+                            },
+                            "match": Object {
+                              "isExact": true,
+                              "params": Object {},
+                              "path": "/",
+                              "url": "/",
+                            },
+                          },
+                        },
+                      },
+                      "__reactInternalMemoizedUnmaskedChildContext": Object {},
+                      "_reactInternalFiber": [Circular],
+                      "_reactInternalInstance": Object {},
+                      "context": Object {
+                        "router": undefined,
+                      },
+                      "props": Object {
+                        "children": <AuthenticatedRoute
+                          authenticated={true}
+                          component={[Function]}
+                          path="/dashboard"
+                        />,
+                        "history": Object {
+                          "action": "POP",
+                          "block": [Function],
+                          "createHref": [Function],
+                          "go": [Function],
+                          "goBack": [Function],
+                          "goForward": [Function],
+                          "length": 1,
+                          "listen": [Function],
+                          "location": Object {
+                            "hash": "",
+                            "pathname": "/",
+                            "search": "",
+                            "state": undefined,
+                          },
+                          "push": [Function],
+                          "replace": [Function],
+                        },
+                      },
+                      "refs": Object {},
+                      "state": Object {
+                        "match": Object {
+                          "isExact": true,
+                          "params": Object {},
+                          "path": "/",
+                          "url": "/",
+                        },
+                      },
+                      "unlisten": [Function],
+                      "updater": Object {
+                        "enqueueForceUpdate": [Function],
+                        "enqueueReplaceState": [Function],
+                        "enqueueSetState": [Function],
+                        "isMounted": [Function],
+                      },
+                    },
+                    "tag": 1,
+                    "treeBaseDuration": 0,
+                    "type": [Function],
+                    "updateQueue": null,
+                  },
+                  "selfBaseDuration": 0,
+                  "sibling": null,
+                  "stateNode": null,
+                  "tag": 0,
+                  "treeBaseDuration": 0,
+                  "type": [Function],
+                  "updateQueue": null,
+                },
+                "selfBaseDuration": 0,
+                "sibling": null,
+                "stateNode": [Circular],
+                "tag": 1,
+                "treeBaseDuration": 0,
+                "type": [Function],
+                "updateQueue": null,
+              },
+              "_reactInternalInstance": Object {},
+              "context": Object {
+                "router": Object {
+                  "history": Object {
+                    "action": "POP",
+                    "block": [Function],
+                    "createHref": [Function],
+                    "go": [Function],
+                    "goBack": [Function],
+                    "goForward": [Function],
+                    "length": 1,
+                    "listen": [Function],
+                    "location": Object {
+                      "hash": "",
+                      "pathname": "/",
+                      "search": "",
+                      "state": undefined,
+                    },
+                    "push": [Function],
+                    "replace": [Function],
+                  },
+                  "route": Object {
+                    "location": Object {
+                      "hash": "",
+                      "pathname": "/",
+                      "search": "",
+                      "state": undefined,
+                    },
+                    "match": Object {
+                      "isExact": true,
+                      "params": Object {},
+                      "path": "/",
+                      "url": "/",
+                    },
+                  },
+                },
+              },
+              "props": Object {
+                "path": "/dashboard",
+                "render": [Function],
+              },
+              "refs": Object {},
+              "state": Object {
+                "match": null,
+              },
+              "updater": Object {
+                "enqueueForceUpdate": [Function],
+                "enqueueReplaceState": [Function],
+                "enqueueSetState": [Function],
+                "isMounted": [Function],
+              },
+            },
+            "key": undefined,
+            "nodeType": "class",
+            "props": Object {
+              "path": "/dashboard",
+              "render": [Function],
+            },
+            "ref": null,
+            "rendered": null,
+            "type": [Function],
+          },
+          "type": [Function],
+        },
+        "type": [Function],
+      },
+      "type": [Function],
+    },
+  ],
+  Symbol(enzyme.__options__): Object {
+    "adapter": ReactSixteenAdapter {
+      "options": Object {
+        "enableComponentDidUpdateOnSetState": true,
+        "legacyContextMode": "parent",
+        "lifecycles": Object {
+          "componentDidUpdate": Object {
+            "onSetState": true,
+          },
+          "getChildContext": Object {
+            "calledByRenderer": false,
+          },
+          "getDerivedStateFromError": true,
+          "getDerivedStateFromProps": Object {
+            "hasShouldComponentUpdateBug": false,
+          },
+          "getSnapshotBeforeUpdate": true,
+          "setState": Object {
+            "skipsComponentDidUpdateOnNullish": true,
+          },
+        },
+      },
+    },
+  },
+}
+`;

--- a/src/__tests__/components/Dashboard/__snapshots__/Card.test.jsx.snap
+++ b/src/__tests__/components/Dashboard/__snapshots__/Card.test.jsx.snap
@@ -2,6 +2,23 @@
 
 exports[`Dashboard card renders appropriately 1`] = `
 ReactWrapper {
+  Symbol(enzyme.__unrendered__): <Card
+    classes="class"
+    component={
+      [MockFunction] {
+        "calls": Array [
+          Array [],
+        ],
+        "results": Array [
+          Object {
+            "isThrow": false,
+            "value": undefined,
+          },
+        ],
+      }
+    }
+    title="Title Card"
+  />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
     "getNode": [Function],
@@ -16,14 +33,12 @@ ReactWrapper {
     "instance": Card {
       "_reactInternalFiber": FiberNode {
         "_debugHookTypes": null,
-        "_debugID": 123,
+        "_debugID": 63,
         "_debugIsCurrentlyTiming": false,
-        "_debugNeedsRemount": false,
         "_debugOwner": FiberNode {
           "_debugHookTypes": null,
-          "_debugID": 121,
+          "_debugID": 62,
           "_debugIsCurrentlyTiming": false,
-          "_debugNeedsRemount": false,
           "_debugOwner": null,
           "_debugSource": null,
           "actualDuration": 0,
@@ -31,7 +46,7 @@ ReactWrapper {
           "alternate": null,
           "child": [Circular],
           "childExpirationTime": 0,
-          "dependencies": null,
+          "contextDependencies": null,
           "effectTag": 1,
           "elementType": [Function],
           "expirationTime": 0,
@@ -80,42 +95,18 @@ ReactWrapper {
             "wrappingComponentProps": null,
           },
           "mode": 0,
-          "nextEffect": null,
-          "pendingProps": Object {
-            "Component": [Function],
-            "context": null,
-            "props": Object {
-              "classes": "class",
-              "component": [MockFunction] {
-                "calls": Array [
-                  Array [],
-                ],
-                "results": Array [
-                  Object {
-                    "isThrow": false,
-                    "value": undefined,
-                  },
-                ],
-              },
-              "title": "Title Card",
-            },
-            "wrappingComponentProps": null,
-          },
-          "ref": null,
-          "return": FiberNode {
+          "nextEffect": FiberNode {
             "_debugHookTypes": null,
-            "_debugID": 118,
+            "_debugID": 60,
             "_debugIsCurrentlyTiming": false,
-            "_debugNeedsRemount": false,
             "_debugOwner": null,
             "_debugSource": null,
             "actualDuration": 0,
             "actualStartTime": -1,
             "alternate": FiberNode {
               "_debugHookTypes": null,
-              "_debugID": 118,
+              "_debugID": 60,
               "_debugIsCurrentlyTiming": false,
-              "_debugNeedsRemount": false,
               "_debugOwner": null,
               "_debugSource": null,
               "actualDuration": 0,
@@ -123,7 +114,7 @@ ReactWrapper {
               "alternate": [Circular],
               "child": null,
               "childExpirationTime": 0,
-              "dependencies": null,
+              "contextDependencies": null,
               "effectTag": 0,
               "elementType": null,
               "expirationTime": 1073741823,
@@ -140,9 +131,7 @@ ReactWrapper {
               "return": null,
               "selfBaseDuration": 0,
               "sibling": null,
-              "stateNode": FiberRootNode {
-                "callbackExpirationTime": 0,
-                "callbackNode": null,
+              "stateNode": Object {
                 "containerInfo": <div>
                   <div
                     class="dashboard-card class"
@@ -156,20 +145,25 @@ ReactWrapper {
                 </div>,
                 "context": Object {},
                 "current": [Circular],
-                "finishedExpirationTime": 0,
+                "didError": false,
+                "earliestPendingTime": 0,
+                "earliestSuspendedTime": 0,
+                "expirationTime": 0,
                 "finishedWork": null,
                 "firstBatch": null,
-                "firstPendingTime": 0,
                 "hydrate": false,
-                "interactionThreadID": 16,
-                "lastPendingTime": 0,
+                "interactionThreadID": 15,
+                "latestPendingTime": 0,
+                "latestPingedTime": 0,
+                "latestSuspendedTime": 0,
                 "memoizedInteractions": Set {},
+                "nextExpirationTimeToWorkOn": 0,
+                "nextScheduledRoot": null,
                 "pendingChildren": null,
+                "pendingCommitExpirationTime": 0,
                 "pendingContext": null,
                 "pendingInteractionMap": Map {},
                 "pingCache": null,
-                "pingTime": 0,
-                "tag": 0,
                 "timeoutHandle": -1,
               },
               "tag": 3,
@@ -209,8 +203,6 @@ ReactWrapper {
                       wrappingComponentProps={null}
                     />,
                   },
-                  "priority": 97,
-                  "suspenseConfig": null,
                   "tag": 0,
                 },
                 "lastCapturedEffect": null,
@@ -245,16 +237,14 @@ ReactWrapper {
                       wrappingComponentProps={null}
                     />,
                   },
-                  "priority": 97,
-                  "suspenseConfig": null,
                   "tag": 0,
                 },
               },
             },
             "child": [Circular],
             "childExpirationTime": 0,
-            "dependencies": null,
-            "effectTag": 0,
+            "contextDependencies": null,
+            "effectTag": 32,
             "elementType": null,
             "expirationTime": 0,
             "firstEffect": [Circular],
@@ -293,9 +283,7 @@ ReactWrapper {
             "return": null,
             "selfBaseDuration": 0,
             "sibling": null,
-            "stateNode": FiberRootNode {
-              "callbackExpirationTime": 0,
-              "callbackNode": null,
+            "stateNode": Object {
               "containerInfo": <div>
                 <div
                   class="dashboard-card class"
@@ -309,20 +297,307 @@ ReactWrapper {
               </div>,
               "context": Object {},
               "current": [Circular],
-              "finishedExpirationTime": 0,
+              "didError": false,
+              "earliestPendingTime": 0,
+              "earliestSuspendedTime": 0,
+              "expirationTime": 0,
               "finishedWork": null,
               "firstBatch": null,
-              "firstPendingTime": 0,
               "hydrate": false,
-              "interactionThreadID": 16,
-              "lastPendingTime": 0,
+              "interactionThreadID": 15,
+              "latestPendingTime": 0,
+              "latestPingedTime": 0,
+              "latestSuspendedTime": 0,
               "memoizedInteractions": Set {},
+              "nextExpirationTimeToWorkOn": 0,
+              "nextScheduledRoot": null,
               "pendingChildren": null,
+              "pendingCommitExpirationTime": 0,
               "pendingContext": null,
               "pendingInteractionMap": Map {},
               "pingCache": null,
-              "pingTime": 0,
-              "tag": 0,
+              "timeoutHandle": -1,
+            },
+            "tag": 3,
+            "treeBaseDuration": 0,
+            "type": null,
+            "updateQueue": Object {
+              "baseState": Object {
+                "element": <WrapperComponent
+                  Component={[Function]}
+                  context={null}
+                  props={
+                    Object {
+                      "classes": "class",
+                      "component": [MockFunction] {
+                        "calls": Array [
+                          Array [],
+                        ],
+                        "results": Array [
+                          Object {
+                            "isThrow": false,
+                            "value": undefined,
+                          },
+                        ],
+                      },
+                      "title": "Title Card",
+                    }
+                  }
+                  wrappingComponentProps={null}
+                />,
+              },
+              "firstCapturedEffect": null,
+              "firstCapturedUpdate": null,
+              "firstEffect": null,
+              "firstUpdate": null,
+              "lastCapturedEffect": null,
+              "lastCapturedUpdate": null,
+              "lastEffect": null,
+              "lastUpdate": null,
+            },
+          },
+          "pendingProps": Object {
+            "Component": [Function],
+            "context": null,
+            "props": Object {
+              "classes": "class",
+              "component": [MockFunction] {
+                "calls": Array [
+                  Array [],
+                ],
+                "results": Array [
+                  Object {
+                    "isThrow": false,
+                    "value": undefined,
+                  },
+                ],
+              },
+              "title": "Title Card",
+            },
+            "wrappingComponentProps": null,
+          },
+          "ref": null,
+          "return": FiberNode {
+            "_debugHookTypes": null,
+            "_debugID": 60,
+            "_debugIsCurrentlyTiming": false,
+            "_debugOwner": null,
+            "_debugSource": null,
+            "actualDuration": 0,
+            "actualStartTime": -1,
+            "alternate": FiberNode {
+              "_debugHookTypes": null,
+              "_debugID": 60,
+              "_debugIsCurrentlyTiming": false,
+              "_debugOwner": null,
+              "_debugSource": null,
+              "actualDuration": 0,
+              "actualStartTime": -1,
+              "alternate": [Circular],
+              "child": null,
+              "childExpirationTime": 0,
+              "contextDependencies": null,
+              "effectTag": 0,
+              "elementType": null,
+              "expirationTime": 1073741823,
+              "firstEffect": null,
+              "index": 0,
+              "key": null,
+              "lastEffect": null,
+              "memoizedProps": null,
+              "memoizedState": null,
+              "mode": 0,
+              "nextEffect": null,
+              "pendingProps": null,
+              "ref": null,
+              "return": null,
+              "selfBaseDuration": 0,
+              "sibling": null,
+              "stateNode": Object {
+                "containerInfo": <div>
+                  <div
+                    class="dashboard-card class"
+                  >
+                    <div
+                      class="title"
+                    >
+                      Title Card
+                    </div>
+                  </div>
+                </div>,
+                "context": Object {},
+                "current": [Circular],
+                "didError": false,
+                "earliestPendingTime": 0,
+                "earliestSuspendedTime": 0,
+                "expirationTime": 0,
+                "finishedWork": null,
+                "firstBatch": null,
+                "hydrate": false,
+                "interactionThreadID": 15,
+                "latestPendingTime": 0,
+                "latestPingedTime": 0,
+                "latestSuspendedTime": 0,
+                "memoizedInteractions": Set {},
+                "nextExpirationTimeToWorkOn": 0,
+                "nextScheduledRoot": null,
+                "pendingChildren": null,
+                "pendingCommitExpirationTime": 0,
+                "pendingContext": null,
+                "pendingInteractionMap": Map {},
+                "pingCache": null,
+                "timeoutHandle": -1,
+              },
+              "tag": 3,
+              "treeBaseDuration": 0,
+              "type": null,
+              "updateQueue": Object {
+                "baseState": null,
+                "firstCapturedEffect": null,
+                "firstCapturedUpdate": null,
+                "firstEffect": null,
+                "firstUpdate": Object {
+                  "callback": null,
+                  "expirationTime": 1073741823,
+                  "next": null,
+                  "nextEffect": null,
+                  "payload": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={
+                        Object {
+                          "classes": "class",
+                          "component": [MockFunction] {
+                            "calls": Array [
+                              Array [],
+                            ],
+                            "results": Array [
+                              Object {
+                                "isThrow": false,
+                                "value": undefined,
+                              },
+                            ],
+                          },
+                          "title": "Title Card",
+                        }
+                      }
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "tag": 0,
+                },
+                "lastCapturedEffect": null,
+                "lastCapturedUpdate": null,
+                "lastEffect": null,
+                "lastUpdate": Object {
+                  "callback": null,
+                  "expirationTime": 1073741823,
+                  "next": null,
+                  "nextEffect": null,
+                  "payload": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={
+                        Object {
+                          "classes": "class",
+                          "component": [MockFunction] {
+                            "calls": Array [
+                              Array [],
+                            ],
+                            "results": Array [
+                              Object {
+                                "isThrow": false,
+                                "value": undefined,
+                              },
+                            ],
+                          },
+                          "title": "Title Card",
+                        }
+                      }
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "tag": 0,
+                },
+              },
+            },
+            "child": [Circular],
+            "childExpirationTime": 0,
+            "contextDependencies": null,
+            "effectTag": 32,
+            "elementType": null,
+            "expirationTime": 0,
+            "firstEffect": [Circular],
+            "index": 0,
+            "key": null,
+            "lastEffect": [Circular],
+            "memoizedProps": null,
+            "memoizedState": Object {
+              "element": <WrapperComponent
+                Component={[Function]}
+                context={null}
+                props={
+                  Object {
+                    "classes": "class",
+                    "component": [MockFunction] {
+                      "calls": Array [
+                        Array [],
+                      ],
+                      "results": Array [
+                        Object {
+                          "isThrow": false,
+                          "value": undefined,
+                        },
+                      ],
+                    },
+                    "title": "Title Card",
+                  }
+                }
+                wrappingComponentProps={null}
+              />,
+            },
+            "mode": 0,
+            "nextEffect": null,
+            "pendingProps": null,
+            "ref": null,
+            "return": null,
+            "selfBaseDuration": 0,
+            "sibling": null,
+            "stateNode": Object {
+              "containerInfo": <div>
+                <div
+                  class="dashboard-card class"
+                >
+                  <div
+                    class="title"
+                  >
+                    Title Card
+                  </div>
+                </div>
+              </div>,
+              "context": Object {},
+              "current": [Circular],
+              "didError": false,
+              "earliestPendingTime": 0,
+              "earliestSuspendedTime": 0,
+              "expirationTime": 0,
+              "finishedWork": null,
+              "firstBatch": null,
+              "hydrate": false,
+              "interactionThreadID": 15,
+              "latestPendingTime": 0,
+              "latestPingedTime": 0,
+              "latestSuspendedTime": 0,
+              "memoizedInteractions": Set {},
+              "nextExpirationTimeToWorkOn": 0,
+              "nextScheduledRoot": null,
+              "pendingChildren": null,
+              "pendingCommitExpirationTime": 0,
+              "pendingContext": null,
+              "pendingInteractionMap": Map {},
+              "pingCache": null,
               "timeoutHandle": -1,
             },
             "tag": 3,
@@ -429,12 +704,11 @@ ReactWrapper {
         "alternate": null,
         "child": FiberNode {
           "_debugHookTypes": null,
-          "_debugID": 125,
+          "_debugID": 64,
           "_debugIsCurrentlyTiming": false,
-          "_debugNeedsRemount": false,
           "_debugOwner": [Circular],
           "_debugSource": Object {
-            "fileName": "/Users/arnold/Andela-Project/bp-esa-frontend/src/components/Dashboard/Card.jsx",
+            "fileName": "/Users/home/Documents/Projects/javascript/Andela/bp-esa/bp-esa-frontend/src/components/Dashboard/Card.jsx",
             "lineNumber": 20,
           },
           "actualDuration": 0,
@@ -442,12 +716,11 @@ ReactWrapper {
           "alternate": null,
           "child": FiberNode {
             "_debugHookTypes": null,
-            "_debugID": 127,
+            "_debugID": 65,
             "_debugIsCurrentlyTiming": false,
-            "_debugNeedsRemount": false,
             "_debugOwner": [Circular],
             "_debugSource": Object {
-              "fileName": "/Users/arnold/Andela-Project/bp-esa-frontend/src/components/Dashboard/Card.jsx",
+              "fileName": "/Users/home/Documents/Projects/javascript/Andela/bp-esa/bp-esa-frontend/src/components/Dashboard/Card.jsx",
               "lineNumber": 21,
             },
             "actualDuration": 0,
@@ -455,7 +728,7 @@ ReactWrapper {
             "alternate": null,
             "child": null,
             "childExpirationTime": 0,
-            "dependencies": null,
+            "contextDependencies": null,
             "effectTag": 0,
             "elementType": "div",
             "expirationTime": 0,
@@ -489,7 +762,7 @@ ReactWrapper {
             "updateQueue": null,
           },
           "childExpirationTime": 0,
-          "dependencies": null,
+          "contextDependencies": null,
           "effectTag": 0,
           "elementType": "div",
           "expirationTime": 0,
@@ -541,7 +814,7 @@ ReactWrapper {
           "updateQueue": null,
         },
         "childExpirationTime": 0,
-        "dependencies": null,
+        "contextDependencies": null,
         "effectTag": 1,
         "elementType": [Function],
         "expirationTime": 0,
@@ -585,9 +858,8 @@ ReactWrapper {
         "ref": null,
         "return": FiberNode {
           "_debugHookTypes": null,
-          "_debugID": 121,
+          "_debugID": 62,
           "_debugIsCurrentlyTiming": false,
-          "_debugNeedsRemount": false,
           "_debugOwner": null,
           "_debugSource": null,
           "actualDuration": 0,
@@ -595,7 +867,7 @@ ReactWrapper {
           "alternate": null,
           "child": [Circular],
           "childExpirationTime": 0,
-          "dependencies": null,
+          "contextDependencies": null,
           "effectTag": 1,
           "elementType": [Function],
           "expirationTime": 0,
@@ -644,42 +916,18 @@ ReactWrapper {
             "wrappingComponentProps": null,
           },
           "mode": 0,
-          "nextEffect": null,
-          "pendingProps": Object {
-            "Component": [Function],
-            "context": null,
-            "props": Object {
-              "classes": "class",
-              "component": [MockFunction] {
-                "calls": Array [
-                  Array [],
-                ],
-                "results": Array [
-                  Object {
-                    "isThrow": false,
-                    "value": undefined,
-                  },
-                ],
-              },
-              "title": "Title Card",
-            },
-            "wrappingComponentProps": null,
-          },
-          "ref": null,
-          "return": FiberNode {
+          "nextEffect": FiberNode {
             "_debugHookTypes": null,
-            "_debugID": 118,
+            "_debugID": 60,
             "_debugIsCurrentlyTiming": false,
-            "_debugNeedsRemount": false,
             "_debugOwner": null,
             "_debugSource": null,
             "actualDuration": 0,
             "actualStartTime": -1,
             "alternate": FiberNode {
               "_debugHookTypes": null,
-              "_debugID": 118,
+              "_debugID": 60,
               "_debugIsCurrentlyTiming": false,
-              "_debugNeedsRemount": false,
               "_debugOwner": null,
               "_debugSource": null,
               "actualDuration": 0,
@@ -687,7 +935,7 @@ ReactWrapper {
               "alternate": [Circular],
               "child": null,
               "childExpirationTime": 0,
-              "dependencies": null,
+              "contextDependencies": null,
               "effectTag": 0,
               "elementType": null,
               "expirationTime": 1073741823,
@@ -704,9 +952,7 @@ ReactWrapper {
               "return": null,
               "selfBaseDuration": 0,
               "sibling": null,
-              "stateNode": FiberRootNode {
-                "callbackExpirationTime": 0,
-                "callbackNode": null,
+              "stateNode": Object {
                 "containerInfo": <div>
                   <div
                     class="dashboard-card class"
@@ -720,20 +966,25 @@ ReactWrapper {
                 </div>,
                 "context": Object {},
                 "current": [Circular],
-                "finishedExpirationTime": 0,
+                "didError": false,
+                "earliestPendingTime": 0,
+                "earliestSuspendedTime": 0,
+                "expirationTime": 0,
                 "finishedWork": null,
                 "firstBatch": null,
-                "firstPendingTime": 0,
                 "hydrate": false,
-                "interactionThreadID": 16,
-                "lastPendingTime": 0,
+                "interactionThreadID": 15,
+                "latestPendingTime": 0,
+                "latestPingedTime": 0,
+                "latestSuspendedTime": 0,
                 "memoizedInteractions": Set {},
+                "nextExpirationTimeToWorkOn": 0,
+                "nextScheduledRoot": null,
                 "pendingChildren": null,
+                "pendingCommitExpirationTime": 0,
                 "pendingContext": null,
                 "pendingInteractionMap": Map {},
                 "pingCache": null,
-                "pingTime": 0,
-                "tag": 0,
                 "timeoutHandle": -1,
               },
               "tag": 3,
@@ -773,8 +1024,6 @@ ReactWrapper {
                       wrappingComponentProps={null}
                     />,
                   },
-                  "priority": 97,
-                  "suspenseConfig": null,
                   "tag": 0,
                 },
                 "lastCapturedEffect": null,
@@ -809,16 +1058,14 @@ ReactWrapper {
                       wrappingComponentProps={null}
                     />,
                   },
-                  "priority": 97,
-                  "suspenseConfig": null,
                   "tag": 0,
                 },
               },
             },
             "child": [Circular],
             "childExpirationTime": 0,
-            "dependencies": null,
-            "effectTag": 0,
+            "contextDependencies": null,
+            "effectTag": 32,
             "elementType": null,
             "expirationTime": 0,
             "firstEffect": [Circular],
@@ -857,9 +1104,7 @@ ReactWrapper {
             "return": null,
             "selfBaseDuration": 0,
             "sibling": null,
-            "stateNode": FiberRootNode {
-              "callbackExpirationTime": 0,
-              "callbackNode": null,
+            "stateNode": Object {
               "containerInfo": <div>
                 <div
                   class="dashboard-card class"
@@ -873,20 +1118,307 @@ ReactWrapper {
               </div>,
               "context": Object {},
               "current": [Circular],
-              "finishedExpirationTime": 0,
+              "didError": false,
+              "earliestPendingTime": 0,
+              "earliestSuspendedTime": 0,
+              "expirationTime": 0,
               "finishedWork": null,
               "firstBatch": null,
-              "firstPendingTime": 0,
               "hydrate": false,
-              "interactionThreadID": 16,
-              "lastPendingTime": 0,
+              "interactionThreadID": 15,
+              "latestPendingTime": 0,
+              "latestPingedTime": 0,
+              "latestSuspendedTime": 0,
               "memoizedInteractions": Set {},
+              "nextExpirationTimeToWorkOn": 0,
+              "nextScheduledRoot": null,
               "pendingChildren": null,
+              "pendingCommitExpirationTime": 0,
               "pendingContext": null,
               "pendingInteractionMap": Map {},
               "pingCache": null,
-              "pingTime": 0,
-              "tag": 0,
+              "timeoutHandle": -1,
+            },
+            "tag": 3,
+            "treeBaseDuration": 0,
+            "type": null,
+            "updateQueue": Object {
+              "baseState": Object {
+                "element": <WrapperComponent
+                  Component={[Function]}
+                  context={null}
+                  props={
+                    Object {
+                      "classes": "class",
+                      "component": [MockFunction] {
+                        "calls": Array [
+                          Array [],
+                        ],
+                        "results": Array [
+                          Object {
+                            "isThrow": false,
+                            "value": undefined,
+                          },
+                        ],
+                      },
+                      "title": "Title Card",
+                    }
+                  }
+                  wrappingComponentProps={null}
+                />,
+              },
+              "firstCapturedEffect": null,
+              "firstCapturedUpdate": null,
+              "firstEffect": null,
+              "firstUpdate": null,
+              "lastCapturedEffect": null,
+              "lastCapturedUpdate": null,
+              "lastEffect": null,
+              "lastUpdate": null,
+            },
+          },
+          "pendingProps": Object {
+            "Component": [Function],
+            "context": null,
+            "props": Object {
+              "classes": "class",
+              "component": [MockFunction] {
+                "calls": Array [
+                  Array [],
+                ],
+                "results": Array [
+                  Object {
+                    "isThrow": false,
+                    "value": undefined,
+                  },
+                ],
+              },
+              "title": "Title Card",
+            },
+            "wrappingComponentProps": null,
+          },
+          "ref": null,
+          "return": FiberNode {
+            "_debugHookTypes": null,
+            "_debugID": 60,
+            "_debugIsCurrentlyTiming": false,
+            "_debugOwner": null,
+            "_debugSource": null,
+            "actualDuration": 0,
+            "actualStartTime": -1,
+            "alternate": FiberNode {
+              "_debugHookTypes": null,
+              "_debugID": 60,
+              "_debugIsCurrentlyTiming": false,
+              "_debugOwner": null,
+              "_debugSource": null,
+              "actualDuration": 0,
+              "actualStartTime": -1,
+              "alternate": [Circular],
+              "child": null,
+              "childExpirationTime": 0,
+              "contextDependencies": null,
+              "effectTag": 0,
+              "elementType": null,
+              "expirationTime": 1073741823,
+              "firstEffect": null,
+              "index": 0,
+              "key": null,
+              "lastEffect": null,
+              "memoizedProps": null,
+              "memoizedState": null,
+              "mode": 0,
+              "nextEffect": null,
+              "pendingProps": null,
+              "ref": null,
+              "return": null,
+              "selfBaseDuration": 0,
+              "sibling": null,
+              "stateNode": Object {
+                "containerInfo": <div>
+                  <div
+                    class="dashboard-card class"
+                  >
+                    <div
+                      class="title"
+                    >
+                      Title Card
+                    </div>
+                  </div>
+                </div>,
+                "context": Object {},
+                "current": [Circular],
+                "didError": false,
+                "earliestPendingTime": 0,
+                "earliestSuspendedTime": 0,
+                "expirationTime": 0,
+                "finishedWork": null,
+                "firstBatch": null,
+                "hydrate": false,
+                "interactionThreadID": 15,
+                "latestPendingTime": 0,
+                "latestPingedTime": 0,
+                "latestSuspendedTime": 0,
+                "memoizedInteractions": Set {},
+                "nextExpirationTimeToWorkOn": 0,
+                "nextScheduledRoot": null,
+                "pendingChildren": null,
+                "pendingCommitExpirationTime": 0,
+                "pendingContext": null,
+                "pendingInteractionMap": Map {},
+                "pingCache": null,
+                "timeoutHandle": -1,
+              },
+              "tag": 3,
+              "treeBaseDuration": 0,
+              "type": null,
+              "updateQueue": Object {
+                "baseState": null,
+                "firstCapturedEffect": null,
+                "firstCapturedUpdate": null,
+                "firstEffect": null,
+                "firstUpdate": Object {
+                  "callback": null,
+                  "expirationTime": 1073741823,
+                  "next": null,
+                  "nextEffect": null,
+                  "payload": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={
+                        Object {
+                          "classes": "class",
+                          "component": [MockFunction] {
+                            "calls": Array [
+                              Array [],
+                            ],
+                            "results": Array [
+                              Object {
+                                "isThrow": false,
+                                "value": undefined,
+                              },
+                            ],
+                          },
+                          "title": "Title Card",
+                        }
+                      }
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "tag": 0,
+                },
+                "lastCapturedEffect": null,
+                "lastCapturedUpdate": null,
+                "lastEffect": null,
+                "lastUpdate": Object {
+                  "callback": null,
+                  "expirationTime": 1073741823,
+                  "next": null,
+                  "nextEffect": null,
+                  "payload": Object {
+                    "element": <WrapperComponent
+                      Component={[Function]}
+                      context={null}
+                      props={
+                        Object {
+                          "classes": "class",
+                          "component": [MockFunction] {
+                            "calls": Array [
+                              Array [],
+                            ],
+                            "results": Array [
+                              Object {
+                                "isThrow": false,
+                                "value": undefined,
+                              },
+                            ],
+                          },
+                          "title": "Title Card",
+                        }
+                      }
+                      wrappingComponentProps={null}
+                    />,
+                  },
+                  "tag": 0,
+                },
+              },
+            },
+            "child": [Circular],
+            "childExpirationTime": 0,
+            "contextDependencies": null,
+            "effectTag": 32,
+            "elementType": null,
+            "expirationTime": 0,
+            "firstEffect": [Circular],
+            "index": 0,
+            "key": null,
+            "lastEffect": [Circular],
+            "memoizedProps": null,
+            "memoizedState": Object {
+              "element": <WrapperComponent
+                Component={[Function]}
+                context={null}
+                props={
+                  Object {
+                    "classes": "class",
+                    "component": [MockFunction] {
+                      "calls": Array [
+                        Array [],
+                      ],
+                      "results": Array [
+                        Object {
+                          "isThrow": false,
+                          "value": undefined,
+                        },
+                      ],
+                    },
+                    "title": "Title Card",
+                  }
+                }
+                wrappingComponentProps={null}
+              />,
+            },
+            "mode": 0,
+            "nextEffect": null,
+            "pendingProps": null,
+            "ref": null,
+            "return": null,
+            "selfBaseDuration": 0,
+            "sibling": null,
+            "stateNode": Object {
+              "containerInfo": <div>
+                <div
+                  class="dashboard-card class"
+                >
+                  <div
+                    class="title"
+                  >
+                    Title Card
+                  </div>
+                </div>
+              </div>,
+              "context": Object {},
+              "current": [Circular],
+              "didError": false,
+              "earliestPendingTime": 0,
+              "earliestSuspendedTime": 0,
+              "expirationTime": 0,
+              "finishedWork": null,
+              "firstBatch": null,
+              "hydrate": false,
+              "interactionThreadID": 15,
+              "latestPendingTime": 0,
+              "latestPingedTime": 0,
+              "latestSuspendedTime": 0,
+              "memoizedInteractions": Set {},
+              "nextExpirationTimeToWorkOn": 0,
+              "nextScheduledRoot": null,
+              "pendingChildren": null,
+              "pendingCommitExpirationTime": 0,
+              "pendingContext": null,
+              "pendingInteractionMap": Map {},
+              "pingCache": null,
               "timeoutHandle": -1,
             },
             "tag": 3,
@@ -1092,14 +1624,12 @@ ReactWrapper {
       "instance": Card {
         "_reactInternalFiber": FiberNode {
           "_debugHookTypes": null,
-          "_debugID": 123,
+          "_debugID": 63,
           "_debugIsCurrentlyTiming": false,
-          "_debugNeedsRemount": false,
           "_debugOwner": FiberNode {
             "_debugHookTypes": null,
-            "_debugID": 121,
+            "_debugID": 62,
             "_debugIsCurrentlyTiming": false,
-            "_debugNeedsRemount": false,
             "_debugOwner": null,
             "_debugSource": null,
             "actualDuration": 0,
@@ -1107,7 +1637,7 @@ ReactWrapper {
             "alternate": null,
             "child": [Circular],
             "childExpirationTime": 0,
-            "dependencies": null,
+            "contextDependencies": null,
             "effectTag": 1,
             "elementType": [Function],
             "expirationTime": 0,
@@ -1156,42 +1686,18 @@ ReactWrapper {
               "wrappingComponentProps": null,
             },
             "mode": 0,
-            "nextEffect": null,
-            "pendingProps": Object {
-              "Component": [Function],
-              "context": null,
-              "props": Object {
-                "classes": "class",
-                "component": [MockFunction] {
-                  "calls": Array [
-                    Array [],
-                  ],
-                  "results": Array [
-                    Object {
-                      "isThrow": false,
-                      "value": undefined,
-                    },
-                  ],
-                },
-                "title": "Title Card",
-              },
-              "wrappingComponentProps": null,
-            },
-            "ref": null,
-            "return": FiberNode {
+            "nextEffect": FiberNode {
               "_debugHookTypes": null,
-              "_debugID": 118,
+              "_debugID": 60,
               "_debugIsCurrentlyTiming": false,
-              "_debugNeedsRemount": false,
               "_debugOwner": null,
               "_debugSource": null,
               "actualDuration": 0,
               "actualStartTime": -1,
               "alternate": FiberNode {
                 "_debugHookTypes": null,
-                "_debugID": 118,
+                "_debugID": 60,
                 "_debugIsCurrentlyTiming": false,
-                "_debugNeedsRemount": false,
                 "_debugOwner": null,
                 "_debugSource": null,
                 "actualDuration": 0,
@@ -1199,7 +1705,7 @@ ReactWrapper {
                 "alternate": [Circular],
                 "child": null,
                 "childExpirationTime": 0,
-                "dependencies": null,
+                "contextDependencies": null,
                 "effectTag": 0,
                 "elementType": null,
                 "expirationTime": 1073741823,
@@ -1216,9 +1722,7 @@ ReactWrapper {
                 "return": null,
                 "selfBaseDuration": 0,
                 "sibling": null,
-                "stateNode": FiberRootNode {
-                  "callbackExpirationTime": 0,
-                  "callbackNode": null,
+                "stateNode": Object {
                   "containerInfo": <div>
                     <div
                       class="dashboard-card class"
@@ -1232,20 +1736,25 @@ ReactWrapper {
                   </div>,
                   "context": Object {},
                   "current": [Circular],
-                  "finishedExpirationTime": 0,
+                  "didError": false,
+                  "earliestPendingTime": 0,
+                  "earliestSuspendedTime": 0,
+                  "expirationTime": 0,
                   "finishedWork": null,
                   "firstBatch": null,
-                  "firstPendingTime": 0,
                   "hydrate": false,
-                  "interactionThreadID": 16,
-                  "lastPendingTime": 0,
+                  "interactionThreadID": 15,
+                  "latestPendingTime": 0,
+                  "latestPingedTime": 0,
+                  "latestSuspendedTime": 0,
                   "memoizedInteractions": Set {},
+                  "nextExpirationTimeToWorkOn": 0,
+                  "nextScheduledRoot": null,
                   "pendingChildren": null,
+                  "pendingCommitExpirationTime": 0,
                   "pendingContext": null,
                   "pendingInteractionMap": Map {},
                   "pingCache": null,
-                  "pingTime": 0,
-                  "tag": 0,
                   "timeoutHandle": -1,
                 },
                 "tag": 3,
@@ -1285,8 +1794,6 @@ ReactWrapper {
                         wrappingComponentProps={null}
                       />,
                     },
-                    "priority": 97,
-                    "suspenseConfig": null,
                     "tag": 0,
                   },
                   "lastCapturedEffect": null,
@@ -1321,16 +1828,14 @@ ReactWrapper {
                         wrappingComponentProps={null}
                       />,
                     },
-                    "priority": 97,
-                    "suspenseConfig": null,
                     "tag": 0,
                   },
                 },
               },
               "child": [Circular],
               "childExpirationTime": 0,
-              "dependencies": null,
-              "effectTag": 0,
+              "contextDependencies": null,
+              "effectTag": 32,
               "elementType": null,
               "expirationTime": 0,
               "firstEffect": [Circular],
@@ -1369,9 +1874,7 @@ ReactWrapper {
               "return": null,
               "selfBaseDuration": 0,
               "sibling": null,
-              "stateNode": FiberRootNode {
-                "callbackExpirationTime": 0,
-                "callbackNode": null,
+              "stateNode": Object {
                 "containerInfo": <div>
                   <div
                     class="dashboard-card class"
@@ -1385,20 +1888,307 @@ ReactWrapper {
                 </div>,
                 "context": Object {},
                 "current": [Circular],
-                "finishedExpirationTime": 0,
+                "didError": false,
+                "earliestPendingTime": 0,
+                "earliestSuspendedTime": 0,
+                "expirationTime": 0,
                 "finishedWork": null,
                 "firstBatch": null,
-                "firstPendingTime": 0,
                 "hydrate": false,
-                "interactionThreadID": 16,
-                "lastPendingTime": 0,
+                "interactionThreadID": 15,
+                "latestPendingTime": 0,
+                "latestPingedTime": 0,
+                "latestSuspendedTime": 0,
                 "memoizedInteractions": Set {},
+                "nextExpirationTimeToWorkOn": 0,
+                "nextScheduledRoot": null,
                 "pendingChildren": null,
+                "pendingCommitExpirationTime": 0,
                 "pendingContext": null,
                 "pendingInteractionMap": Map {},
                 "pingCache": null,
-                "pingTime": 0,
-                "tag": 0,
+                "timeoutHandle": -1,
+              },
+              "tag": 3,
+              "treeBaseDuration": 0,
+              "type": null,
+              "updateQueue": Object {
+                "baseState": Object {
+                  "element": <WrapperComponent
+                    Component={[Function]}
+                    context={null}
+                    props={
+                      Object {
+                        "classes": "class",
+                        "component": [MockFunction] {
+                          "calls": Array [
+                            Array [],
+                          ],
+                          "results": Array [
+                            Object {
+                              "isThrow": false,
+                              "value": undefined,
+                            },
+                          ],
+                        },
+                        "title": "Title Card",
+                      }
+                    }
+                    wrappingComponentProps={null}
+                  />,
+                },
+                "firstCapturedEffect": null,
+                "firstCapturedUpdate": null,
+                "firstEffect": null,
+                "firstUpdate": null,
+                "lastCapturedEffect": null,
+                "lastCapturedUpdate": null,
+                "lastEffect": null,
+                "lastUpdate": null,
+              },
+            },
+            "pendingProps": Object {
+              "Component": [Function],
+              "context": null,
+              "props": Object {
+                "classes": "class",
+                "component": [MockFunction] {
+                  "calls": Array [
+                    Array [],
+                  ],
+                  "results": Array [
+                    Object {
+                      "isThrow": false,
+                      "value": undefined,
+                    },
+                  ],
+                },
+                "title": "Title Card",
+              },
+              "wrappingComponentProps": null,
+            },
+            "ref": null,
+            "return": FiberNode {
+              "_debugHookTypes": null,
+              "_debugID": 60,
+              "_debugIsCurrentlyTiming": false,
+              "_debugOwner": null,
+              "_debugSource": null,
+              "actualDuration": 0,
+              "actualStartTime": -1,
+              "alternate": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 60,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": null,
+                "_debugSource": null,
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": [Circular],
+                "child": null,
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 0,
+                "elementType": null,
+                "expirationTime": 1073741823,
+                "firstEffect": null,
+                "index": 0,
+                "key": null,
+                "lastEffect": null,
+                "memoizedProps": null,
+                "memoizedState": null,
+                "mode": 0,
+                "nextEffect": null,
+                "pendingProps": null,
+                "ref": null,
+                "return": null,
+                "selfBaseDuration": 0,
+                "sibling": null,
+                "stateNode": Object {
+                  "containerInfo": <div>
+                    <div
+                      class="dashboard-card class"
+                    >
+                      <div
+                        class="title"
+                      >
+                        Title Card
+                      </div>
+                    </div>
+                  </div>,
+                  "context": Object {},
+                  "current": [Circular],
+                  "didError": false,
+                  "earliestPendingTime": 0,
+                  "earliestSuspendedTime": 0,
+                  "expirationTime": 0,
+                  "finishedWork": null,
+                  "firstBatch": null,
+                  "hydrate": false,
+                  "interactionThreadID": 15,
+                  "latestPendingTime": 0,
+                  "latestPingedTime": 0,
+                  "latestSuspendedTime": 0,
+                  "memoizedInteractions": Set {},
+                  "nextExpirationTimeToWorkOn": 0,
+                  "nextScheduledRoot": null,
+                  "pendingChildren": null,
+                  "pendingCommitExpirationTime": 0,
+                  "pendingContext": null,
+                  "pendingInteractionMap": Map {},
+                  "pingCache": null,
+                  "timeoutHandle": -1,
+                },
+                "tag": 3,
+                "treeBaseDuration": 0,
+                "type": null,
+                "updateQueue": Object {
+                  "baseState": null,
+                  "firstCapturedEffect": null,
+                  "firstCapturedUpdate": null,
+                  "firstEffect": null,
+                  "firstUpdate": Object {
+                    "callback": null,
+                    "expirationTime": 1073741823,
+                    "next": null,
+                    "nextEffect": null,
+                    "payload": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={
+                          Object {
+                            "classes": "class",
+                            "component": [MockFunction] {
+                              "calls": Array [
+                                Array [],
+                              ],
+                              "results": Array [
+                                Object {
+                                  "isThrow": false,
+                                  "value": undefined,
+                                },
+                              ],
+                            },
+                            "title": "Title Card",
+                          }
+                        }
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "tag": 0,
+                  },
+                  "lastCapturedEffect": null,
+                  "lastCapturedUpdate": null,
+                  "lastEffect": null,
+                  "lastUpdate": Object {
+                    "callback": null,
+                    "expirationTime": 1073741823,
+                    "next": null,
+                    "nextEffect": null,
+                    "payload": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={
+                          Object {
+                            "classes": "class",
+                            "component": [MockFunction] {
+                              "calls": Array [
+                                Array [],
+                              ],
+                              "results": Array [
+                                Object {
+                                  "isThrow": false,
+                                  "value": undefined,
+                                },
+                              ],
+                            },
+                            "title": "Title Card",
+                          }
+                        }
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "tag": 0,
+                  },
+                },
+              },
+              "child": [Circular],
+              "childExpirationTime": 0,
+              "contextDependencies": null,
+              "effectTag": 32,
+              "elementType": null,
+              "expirationTime": 0,
+              "firstEffect": [Circular],
+              "index": 0,
+              "key": null,
+              "lastEffect": [Circular],
+              "memoizedProps": null,
+              "memoizedState": Object {
+                "element": <WrapperComponent
+                  Component={[Function]}
+                  context={null}
+                  props={
+                    Object {
+                      "classes": "class",
+                      "component": [MockFunction] {
+                        "calls": Array [
+                          Array [],
+                        ],
+                        "results": Array [
+                          Object {
+                            "isThrow": false,
+                            "value": undefined,
+                          },
+                        ],
+                      },
+                      "title": "Title Card",
+                    }
+                  }
+                  wrappingComponentProps={null}
+                />,
+              },
+              "mode": 0,
+              "nextEffect": null,
+              "pendingProps": null,
+              "ref": null,
+              "return": null,
+              "selfBaseDuration": 0,
+              "sibling": null,
+              "stateNode": Object {
+                "containerInfo": <div>
+                  <div
+                    class="dashboard-card class"
+                  >
+                    <div
+                      class="title"
+                    >
+                      Title Card
+                    </div>
+                  </div>
+                </div>,
+                "context": Object {},
+                "current": [Circular],
+                "didError": false,
+                "earliestPendingTime": 0,
+                "earliestSuspendedTime": 0,
+                "expirationTime": 0,
+                "finishedWork": null,
+                "firstBatch": null,
+                "hydrate": false,
+                "interactionThreadID": 15,
+                "latestPendingTime": 0,
+                "latestPingedTime": 0,
+                "latestSuspendedTime": 0,
+                "memoizedInteractions": Set {},
+                "nextExpirationTimeToWorkOn": 0,
+                "nextScheduledRoot": null,
+                "pendingChildren": null,
+                "pendingCommitExpirationTime": 0,
+                "pendingContext": null,
+                "pendingInteractionMap": Map {},
+                "pingCache": null,
                 "timeoutHandle": -1,
               },
               "tag": 3,
@@ -1505,12 +2295,11 @@ ReactWrapper {
           "alternate": null,
           "child": FiberNode {
             "_debugHookTypes": null,
-            "_debugID": 125,
+            "_debugID": 64,
             "_debugIsCurrentlyTiming": false,
-            "_debugNeedsRemount": false,
             "_debugOwner": [Circular],
             "_debugSource": Object {
-              "fileName": "/Users/arnold/Andela-Project/bp-esa-frontend/src/components/Dashboard/Card.jsx",
+              "fileName": "/Users/home/Documents/Projects/javascript/Andela/bp-esa/bp-esa-frontend/src/components/Dashboard/Card.jsx",
               "lineNumber": 20,
             },
             "actualDuration": 0,
@@ -1518,12 +2307,11 @@ ReactWrapper {
             "alternate": null,
             "child": FiberNode {
               "_debugHookTypes": null,
-              "_debugID": 127,
+              "_debugID": 65,
               "_debugIsCurrentlyTiming": false,
-              "_debugNeedsRemount": false,
               "_debugOwner": [Circular],
               "_debugSource": Object {
-                "fileName": "/Users/arnold/Andela-Project/bp-esa-frontend/src/components/Dashboard/Card.jsx",
+                "fileName": "/Users/home/Documents/Projects/javascript/Andela/bp-esa/bp-esa-frontend/src/components/Dashboard/Card.jsx",
                 "lineNumber": 21,
               },
               "actualDuration": 0,
@@ -1531,7 +2319,7 @@ ReactWrapper {
               "alternate": null,
               "child": null,
               "childExpirationTime": 0,
-              "dependencies": null,
+              "contextDependencies": null,
               "effectTag": 0,
               "elementType": "div",
               "expirationTime": 0,
@@ -1565,7 +2353,7 @@ ReactWrapper {
               "updateQueue": null,
             },
             "childExpirationTime": 0,
-            "dependencies": null,
+            "contextDependencies": null,
             "effectTag": 0,
             "elementType": "div",
             "expirationTime": 0,
@@ -1617,7 +2405,7 @@ ReactWrapper {
             "updateQueue": null,
           },
           "childExpirationTime": 0,
-          "dependencies": null,
+          "contextDependencies": null,
           "effectTag": 1,
           "elementType": [Function],
           "expirationTime": 0,
@@ -1661,9 +2449,8 @@ ReactWrapper {
           "ref": null,
           "return": FiberNode {
             "_debugHookTypes": null,
-            "_debugID": 121,
+            "_debugID": 62,
             "_debugIsCurrentlyTiming": false,
-            "_debugNeedsRemount": false,
             "_debugOwner": null,
             "_debugSource": null,
             "actualDuration": 0,
@@ -1671,7 +2458,7 @@ ReactWrapper {
             "alternate": null,
             "child": [Circular],
             "childExpirationTime": 0,
-            "dependencies": null,
+            "contextDependencies": null,
             "effectTag": 1,
             "elementType": [Function],
             "expirationTime": 0,
@@ -1720,42 +2507,18 @@ ReactWrapper {
               "wrappingComponentProps": null,
             },
             "mode": 0,
-            "nextEffect": null,
-            "pendingProps": Object {
-              "Component": [Function],
-              "context": null,
-              "props": Object {
-                "classes": "class",
-                "component": [MockFunction] {
-                  "calls": Array [
-                    Array [],
-                  ],
-                  "results": Array [
-                    Object {
-                      "isThrow": false,
-                      "value": undefined,
-                    },
-                  ],
-                },
-                "title": "Title Card",
-              },
-              "wrappingComponentProps": null,
-            },
-            "ref": null,
-            "return": FiberNode {
+            "nextEffect": FiberNode {
               "_debugHookTypes": null,
-              "_debugID": 118,
+              "_debugID": 60,
               "_debugIsCurrentlyTiming": false,
-              "_debugNeedsRemount": false,
               "_debugOwner": null,
               "_debugSource": null,
               "actualDuration": 0,
               "actualStartTime": -1,
               "alternate": FiberNode {
                 "_debugHookTypes": null,
-                "_debugID": 118,
+                "_debugID": 60,
                 "_debugIsCurrentlyTiming": false,
-                "_debugNeedsRemount": false,
                 "_debugOwner": null,
                 "_debugSource": null,
                 "actualDuration": 0,
@@ -1763,7 +2526,7 @@ ReactWrapper {
                 "alternate": [Circular],
                 "child": null,
                 "childExpirationTime": 0,
-                "dependencies": null,
+                "contextDependencies": null,
                 "effectTag": 0,
                 "elementType": null,
                 "expirationTime": 1073741823,
@@ -1780,9 +2543,7 @@ ReactWrapper {
                 "return": null,
                 "selfBaseDuration": 0,
                 "sibling": null,
-                "stateNode": FiberRootNode {
-                  "callbackExpirationTime": 0,
-                  "callbackNode": null,
+                "stateNode": Object {
                   "containerInfo": <div>
                     <div
                       class="dashboard-card class"
@@ -1796,20 +2557,25 @@ ReactWrapper {
                   </div>,
                   "context": Object {},
                   "current": [Circular],
-                  "finishedExpirationTime": 0,
+                  "didError": false,
+                  "earliestPendingTime": 0,
+                  "earliestSuspendedTime": 0,
+                  "expirationTime": 0,
                   "finishedWork": null,
                   "firstBatch": null,
-                  "firstPendingTime": 0,
                   "hydrate": false,
-                  "interactionThreadID": 16,
-                  "lastPendingTime": 0,
+                  "interactionThreadID": 15,
+                  "latestPendingTime": 0,
+                  "latestPingedTime": 0,
+                  "latestSuspendedTime": 0,
                   "memoizedInteractions": Set {},
+                  "nextExpirationTimeToWorkOn": 0,
+                  "nextScheduledRoot": null,
                   "pendingChildren": null,
+                  "pendingCommitExpirationTime": 0,
                   "pendingContext": null,
                   "pendingInteractionMap": Map {},
                   "pingCache": null,
-                  "pingTime": 0,
-                  "tag": 0,
                   "timeoutHandle": -1,
                 },
                 "tag": 3,
@@ -1849,8 +2615,6 @@ ReactWrapper {
                         wrappingComponentProps={null}
                       />,
                     },
-                    "priority": 97,
-                    "suspenseConfig": null,
                     "tag": 0,
                   },
                   "lastCapturedEffect": null,
@@ -1885,16 +2649,14 @@ ReactWrapper {
                         wrappingComponentProps={null}
                       />,
                     },
-                    "priority": 97,
-                    "suspenseConfig": null,
                     "tag": 0,
                   },
                 },
               },
               "child": [Circular],
               "childExpirationTime": 0,
-              "dependencies": null,
-              "effectTag": 0,
+              "contextDependencies": null,
+              "effectTag": 32,
               "elementType": null,
               "expirationTime": 0,
               "firstEffect": [Circular],
@@ -1933,9 +2695,7 @@ ReactWrapper {
               "return": null,
               "selfBaseDuration": 0,
               "sibling": null,
-              "stateNode": FiberRootNode {
-                "callbackExpirationTime": 0,
-                "callbackNode": null,
+              "stateNode": Object {
                 "containerInfo": <div>
                   <div
                     class="dashboard-card class"
@@ -1949,20 +2709,307 @@ ReactWrapper {
                 </div>,
                 "context": Object {},
                 "current": [Circular],
-                "finishedExpirationTime": 0,
+                "didError": false,
+                "earliestPendingTime": 0,
+                "earliestSuspendedTime": 0,
+                "expirationTime": 0,
                 "finishedWork": null,
                 "firstBatch": null,
-                "firstPendingTime": 0,
                 "hydrate": false,
-                "interactionThreadID": 16,
-                "lastPendingTime": 0,
+                "interactionThreadID": 15,
+                "latestPendingTime": 0,
+                "latestPingedTime": 0,
+                "latestSuspendedTime": 0,
                 "memoizedInteractions": Set {},
+                "nextExpirationTimeToWorkOn": 0,
+                "nextScheduledRoot": null,
                 "pendingChildren": null,
+                "pendingCommitExpirationTime": 0,
                 "pendingContext": null,
                 "pendingInteractionMap": Map {},
                 "pingCache": null,
-                "pingTime": 0,
-                "tag": 0,
+                "timeoutHandle": -1,
+              },
+              "tag": 3,
+              "treeBaseDuration": 0,
+              "type": null,
+              "updateQueue": Object {
+                "baseState": Object {
+                  "element": <WrapperComponent
+                    Component={[Function]}
+                    context={null}
+                    props={
+                      Object {
+                        "classes": "class",
+                        "component": [MockFunction] {
+                          "calls": Array [
+                            Array [],
+                          ],
+                          "results": Array [
+                            Object {
+                              "isThrow": false,
+                              "value": undefined,
+                            },
+                          ],
+                        },
+                        "title": "Title Card",
+                      }
+                    }
+                    wrappingComponentProps={null}
+                  />,
+                },
+                "firstCapturedEffect": null,
+                "firstCapturedUpdate": null,
+                "firstEffect": null,
+                "firstUpdate": null,
+                "lastCapturedEffect": null,
+                "lastCapturedUpdate": null,
+                "lastEffect": null,
+                "lastUpdate": null,
+              },
+            },
+            "pendingProps": Object {
+              "Component": [Function],
+              "context": null,
+              "props": Object {
+                "classes": "class",
+                "component": [MockFunction] {
+                  "calls": Array [
+                    Array [],
+                  ],
+                  "results": Array [
+                    Object {
+                      "isThrow": false,
+                      "value": undefined,
+                    },
+                  ],
+                },
+                "title": "Title Card",
+              },
+              "wrappingComponentProps": null,
+            },
+            "ref": null,
+            "return": FiberNode {
+              "_debugHookTypes": null,
+              "_debugID": 60,
+              "_debugIsCurrentlyTiming": false,
+              "_debugOwner": null,
+              "_debugSource": null,
+              "actualDuration": 0,
+              "actualStartTime": -1,
+              "alternate": FiberNode {
+                "_debugHookTypes": null,
+                "_debugID": 60,
+                "_debugIsCurrentlyTiming": false,
+                "_debugOwner": null,
+                "_debugSource": null,
+                "actualDuration": 0,
+                "actualStartTime": -1,
+                "alternate": [Circular],
+                "child": null,
+                "childExpirationTime": 0,
+                "contextDependencies": null,
+                "effectTag": 0,
+                "elementType": null,
+                "expirationTime": 1073741823,
+                "firstEffect": null,
+                "index": 0,
+                "key": null,
+                "lastEffect": null,
+                "memoizedProps": null,
+                "memoizedState": null,
+                "mode": 0,
+                "nextEffect": null,
+                "pendingProps": null,
+                "ref": null,
+                "return": null,
+                "selfBaseDuration": 0,
+                "sibling": null,
+                "stateNode": Object {
+                  "containerInfo": <div>
+                    <div
+                      class="dashboard-card class"
+                    >
+                      <div
+                        class="title"
+                      >
+                        Title Card
+                      </div>
+                    </div>
+                  </div>,
+                  "context": Object {},
+                  "current": [Circular],
+                  "didError": false,
+                  "earliestPendingTime": 0,
+                  "earliestSuspendedTime": 0,
+                  "expirationTime": 0,
+                  "finishedWork": null,
+                  "firstBatch": null,
+                  "hydrate": false,
+                  "interactionThreadID": 15,
+                  "latestPendingTime": 0,
+                  "latestPingedTime": 0,
+                  "latestSuspendedTime": 0,
+                  "memoizedInteractions": Set {},
+                  "nextExpirationTimeToWorkOn": 0,
+                  "nextScheduledRoot": null,
+                  "pendingChildren": null,
+                  "pendingCommitExpirationTime": 0,
+                  "pendingContext": null,
+                  "pendingInteractionMap": Map {},
+                  "pingCache": null,
+                  "timeoutHandle": -1,
+                },
+                "tag": 3,
+                "treeBaseDuration": 0,
+                "type": null,
+                "updateQueue": Object {
+                  "baseState": null,
+                  "firstCapturedEffect": null,
+                  "firstCapturedUpdate": null,
+                  "firstEffect": null,
+                  "firstUpdate": Object {
+                    "callback": null,
+                    "expirationTime": 1073741823,
+                    "next": null,
+                    "nextEffect": null,
+                    "payload": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={
+                          Object {
+                            "classes": "class",
+                            "component": [MockFunction] {
+                              "calls": Array [
+                                Array [],
+                              ],
+                              "results": Array [
+                                Object {
+                                  "isThrow": false,
+                                  "value": undefined,
+                                },
+                              ],
+                            },
+                            "title": "Title Card",
+                          }
+                        }
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "tag": 0,
+                  },
+                  "lastCapturedEffect": null,
+                  "lastCapturedUpdate": null,
+                  "lastEffect": null,
+                  "lastUpdate": Object {
+                    "callback": null,
+                    "expirationTime": 1073741823,
+                    "next": null,
+                    "nextEffect": null,
+                    "payload": Object {
+                      "element": <WrapperComponent
+                        Component={[Function]}
+                        context={null}
+                        props={
+                          Object {
+                            "classes": "class",
+                            "component": [MockFunction] {
+                              "calls": Array [
+                                Array [],
+                              ],
+                              "results": Array [
+                                Object {
+                                  "isThrow": false,
+                                  "value": undefined,
+                                },
+                              ],
+                            },
+                            "title": "Title Card",
+                          }
+                        }
+                        wrappingComponentProps={null}
+                      />,
+                    },
+                    "tag": 0,
+                  },
+                },
+              },
+              "child": [Circular],
+              "childExpirationTime": 0,
+              "contextDependencies": null,
+              "effectTag": 32,
+              "elementType": null,
+              "expirationTime": 0,
+              "firstEffect": [Circular],
+              "index": 0,
+              "key": null,
+              "lastEffect": [Circular],
+              "memoizedProps": null,
+              "memoizedState": Object {
+                "element": <WrapperComponent
+                  Component={[Function]}
+                  context={null}
+                  props={
+                    Object {
+                      "classes": "class",
+                      "component": [MockFunction] {
+                        "calls": Array [
+                          Array [],
+                        ],
+                        "results": Array [
+                          Object {
+                            "isThrow": false,
+                            "value": undefined,
+                          },
+                        ],
+                      },
+                      "title": "Title Card",
+                    }
+                  }
+                  wrappingComponentProps={null}
+                />,
+              },
+              "mode": 0,
+              "nextEffect": null,
+              "pendingProps": null,
+              "ref": null,
+              "return": null,
+              "selfBaseDuration": 0,
+              "sibling": null,
+              "stateNode": Object {
+                "containerInfo": <div>
+                  <div
+                    class="dashboard-card class"
+                  >
+                    <div
+                      class="title"
+                    >
+                      Title Card
+                    </div>
+                  </div>
+                </div>,
+                "context": Object {},
+                "current": [Circular],
+                "didError": false,
+                "earliestPendingTime": 0,
+                "earliestSuspendedTime": 0,
+                "expirationTime": 0,
+                "finishedWork": null,
+                "firstBatch": null,
+                "hydrate": false,
+                "interactionThreadID": 15,
+                "latestPendingTime": 0,
+                "latestPingedTime": 0,
+                "latestSuspendedTime": 0,
+                "memoizedInteractions": Set {},
+                "nextExpirationTimeToWorkOn": 0,
+                "nextScheduledRoot": null,
+                "pendingChildren": null,
+                "pendingCommitExpirationTime": 0,
+                "pendingContext": null,
+                "pendingInteractionMap": Map {},
+                "pingCache": null,
                 "timeoutHandle": -1,
               },
               "tag": 3,
@@ -2188,24 +3235,5 @@ ReactWrapper {
       },
     },
   },
-  Symbol(enzyme.__linkedRoots__): Array [],
-  Symbol(enzyme.__unrendered__): <Card
-    classes="class"
-    component={
-      [MockFunction] {
-        "calls": Array [
-          Array [],
-        ],
-        "results": Array [
-          Object {
-            "isThrow": false,
-            "value": undefined,
-          },
-        ],
-      }
-    }
-    title="Title Card"
-  />,
-  Symbol(enzyme.__updatedBy__): null,
 }
 `;

--- a/src/__tests__/components/Dashboard/activityFeed/__snapshots__/ActivityFeed.test.jsx.snap
+++ b/src/__tests__/components/Dashboard/activityFeed/__snapshots__/ActivityFeed.test.jsx.snap
@@ -802,18 +802,5 @@ ReactWrapper {
       },
     },
   },
-  Symbol(enzyme.__linkedRoots__): Array [],
-  Symbol(enzyme.__unrendered__): <ActivityFeed
-    reportData={
-      Array [
-        Object {
-          "fellowName": "Kitika, Kelvin",
-          "type": "offboarding",
-          "updatedAt": "2019-05-15T13:47:04.608Z",
-        },
-      ]
-    }
-  />,
-  Symbol(enzyme.__updatedBy__): null,
 }
 `;

--- a/src/__tests__/components/FilterComponent/__snapshots__/Snapshots.test.jsx.snap
+++ b/src/__tests__/components/FilterComponent/__snapshots__/Snapshots.test.jsx.snap
@@ -98,9 +98,7 @@ ShallowWrapper {
         },
       },
     },
-    Symbol(enzyme.__providerValues__): undefined,
   },
-  Symbol(enzyme.__providerValues__): Map {},
 }
 `;
 
@@ -166,9 +164,7 @@ ShallowWrapper {
         },
       },
     },
-    Symbol(enzyme.__providerValues__): undefined,
   },
-  Symbol(enzyme.__providerValues__): Map {},
 }
 `;
 
@@ -201,7 +197,7 @@ ShallowWrapper {
       "disabled": false,
       "disabledKeyboardNavigation": false,
       "dropdownMode": "select",
-      "maxDate": "2019-08-28T14:28:06.659Z",
+      "maxDate": "2019-09-13T06:49:17.309Z",
       "monthsShown": 1,
       "nextMonthButtonLabel": "Next month",
       "onBlur": [Function],
@@ -242,7 +238,7 @@ ShallowWrapper {
         "disabled": false,
         "disabledKeyboardNavigation": false,
         "dropdownMode": "select",
-        "maxDate": "2019-08-28T14:28:06.659Z",
+        "maxDate": "2019-09-13T06:49:17.309Z",
         "monthsShown": 1,
         "nextMonthButtonLabel": "Next month",
         "onBlur": [Function],
@@ -294,9 +290,7 @@ ShallowWrapper {
         },
       },
     },
-    Symbol(enzyme.__providerValues__): undefined,
   },
-  Symbol(enzyme.__providerValues__): Map {},
 }
 `;
 
@@ -570,9 +564,7 @@ ShallowWrapper {
         },
       },
     },
-    Symbol(enzyme.__providerValues__): undefined,
   },
-  Symbol(enzyme.__providerValues__): Map {},
   Symbol(enzyme.__childContext__): null,
 }
 `;
@@ -1274,8 +1266,6 @@ ShallowWrapper {
         },
       },
     },
-    Symbol(enzyme.__providerValues__): undefined,
   },
-  Symbol(enzyme.__providerValues__): Map {},
 }
 `;

--- a/src/__tests__/components/ReportNavBar/ReportNavBar.test.jsx
+++ b/src/__tests__/components/ReportNavBar/ReportNavBar.test.jsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import ReportNavBar from '../../../components/ReportNavBar';
-import Dropdown from "../../../components/StatsCard/Dropdown";
+import Dropdown from '../../../components/StatsCard/Dropdown';
 
 const props = {
   renderView: jest.fn,
   isStats: true,
   fetchStat: jest.fn,
+  toggleOpen: jest.fn,
 };
 
 const getComponent = () => shallow(<ReportNavBar  {...props} />);
@@ -17,6 +18,9 @@ describe('ReportNavBar', () => {
 
   it('should render Dropdown component', () => {
     expect(getComponent().find(Dropdown)).toHaveLength(1)
+  });
+  it('should expect toggleOpen to have been called', () => {
+    // expect(getComponent()).find
   });
 
 });

--- a/src/__tests__/components/ReportNavBar/__snapshots__/ReportNavBar.test.jsx.snap
+++ b/src/__tests__/components/ReportNavBar/__snapshots__/ReportNavBar.test.jsx.snap
@@ -7,6 +7,7 @@ ShallowWrapper {
     fetchStat={[Function]}
     isStats={true}
     renderView={[Function]}
+    toggleOpen={[Function]}
     viewMode="cardView"
   />,
   Symbol(enzyme.__renderer__): Object {
@@ -29,6 +30,9 @@ ShallowWrapper {
         <React.Fragment>
           <Dropdown
             fetchStat={[Function]}
+            renderView={[Function]}
+            toggleOpen={[Function]}
+            viewMode="cardView"
           />
         </React.Fragment>
       </div>,
@@ -42,6 +46,9 @@ ShallowWrapper {
         "children": <React.Fragment>
           <Dropdown
             fetchStat={[Function]}
+            renderView={[Function]}
+            toggleOpen={[Function]}
+            viewMode="cardView"
           />
         </React.Fragment>,
         "className": "left-navbar",
@@ -54,6 +61,9 @@ ShallowWrapper {
         "props": Object {
           "children": <Dropdown
             fetchStat={[Function]}
+            renderView={[Function]}
+            toggleOpen={[Function]}
+            viewMode="cardView"
           />,
         },
         "ref": null,
@@ -63,6 +73,9 @@ ShallowWrapper {
           "nodeType": "class",
           "props": Object {
             "fetchStat": [Function],
+            "renderView": [Function],
+            "toggleOpen": [Function],
+            "viewMode": "cardView",
           },
           "ref": null,
           "rendered": null,
@@ -86,6 +99,9 @@ ShallowWrapper {
           <React.Fragment>
             <Dropdown
               fetchStat={[Function]}
+              renderView={[Function]}
+              toggleOpen={[Function]}
+              viewMode="cardView"
             />
           </React.Fragment>
         </div>,
@@ -99,6 +115,9 @@ ShallowWrapper {
           "children": <React.Fragment>
             <Dropdown
               fetchStat={[Function]}
+              renderView={[Function]}
+              toggleOpen={[Function]}
+              viewMode="cardView"
             />
           </React.Fragment>,
           "className": "left-navbar",
@@ -111,6 +130,9 @@ ShallowWrapper {
           "props": Object {
             "children": <Dropdown
               fetchStat={[Function]}
+              renderView={[Function]}
+              toggleOpen={[Function]}
+              viewMode="cardView"
             />,
           },
           "ref": null,
@@ -120,6 +142,9 @@ ShallowWrapper {
             "nodeType": "class",
             "props": Object {
               "fetchStat": [Function],
+              "renderView": [Function],
+              "toggleOpen": [Function],
+              "viewMode": "cardView",
             },
             "ref": null,
             "rendered": null,
@@ -155,8 +180,7 @@ ShallowWrapper {
         },
       },
     },
-    Symbol(enzyme.__providerValues__): undefined,
   },
-  Symbol(enzyme.__providerValues__): Map {},
+  Symbol(enzyme.__childContext__): null,
 }
 `;

--- a/src/__tests__/components/ReportPage.test.jsx
+++ b/src/__tests__/components/ReportPage.test.jsx
@@ -4,7 +4,6 @@ import ReactRouterEnzymeContext from 'react-router-enzyme-context';
 import { ReportPage, mapDispatchToProps, mapStateToProps } from '../../components/ReportPage';
 import { sampleReports, stats } from '../../fixtures/fixtures';
 
-
 describe('ReportPage Component', () => {
   const props = {
     automation: {
@@ -90,7 +89,6 @@ describe('ReportPage Component', () => {
     expect(component.state('pagination').limit).toEqual(25);
     expect(props.fetchAllAutomation).toHaveBeenCalledWith(pagination, filters);
   });
-
   it('updates the current page state when user types in the input box', () => {
     const currentPageInput = component.find('.form-input');
     currentPageInput.simulate('change', { target: { value: 30 } });

--- a/src/__tests__/components/Spinner/__snapshots__/Spinner.test.jsx.snap
+++ b/src/__tests__/components/Spinner/__snapshots__/Spinner.test.jsx.snap
@@ -62,8 +62,6 @@ ShallowWrapper {
         },
       },
     },
-    Symbol(enzyme.__providerValues__): undefined,
   },
-  Symbol(enzyme.__providerValues__): Map {},
 }
 `;

--- a/src/__tests__/components/StatsCard/__snapshots__/Dropdown.test.jsx.snap
+++ b/src/__tests__/components/StatsCard/__snapshots__/Dropdown.test.jsx.snap
@@ -4,14 +4,12 @@ exports[`Dropdown should render as expected 1`] = `
 Dropdown {
   "_reactInternalFiber": FiberNode {
     "_debugHookTypes": null,
-    "_debugID": 123,
+    "_debugID": 63,
     "_debugIsCurrentlyTiming": false,
-    "_debugNeedsRemount": false,
     "_debugOwner": FiberNode {
       "_debugHookTypes": null,
-      "_debugID": 121,
+      "_debugID": 62,
       "_debugIsCurrentlyTiming": false,
-      "_debugNeedsRemount": false,
       "_debugOwner": null,
       "_debugSource": null,
       "actualDuration": 0,
@@ -19,7 +17,7 @@ Dropdown {
       "alternate": null,
       "child": [Circular],
       "childExpirationTime": 0,
-      "dependencies": null,
+      "contextDependencies": null,
       "effectTag": 1,
       "elementType": [Function],
       "expirationTime": 0,
@@ -44,30 +42,18 @@ Dropdown {
         "wrappingComponentProps": null,
       },
       "mode": 0,
-      "nextEffect": null,
-      "pendingProps": Object {
-        "Component": [Function],
-        "context": null,
-        "props": Object {
-          "fetchStat": [MockFunction],
-        },
-        "wrappingComponentProps": null,
-      },
-      "ref": null,
-      "return": FiberNode {
+      "nextEffect": FiberNode {
         "_debugHookTypes": null,
-        "_debugID": 118,
+        "_debugID": 60,
         "_debugIsCurrentlyTiming": false,
-        "_debugNeedsRemount": false,
         "_debugOwner": null,
         "_debugSource": null,
         "actualDuration": 0,
         "actualStartTime": -1,
         "alternate": FiberNode {
           "_debugHookTypes": null,
-          "_debugID": 118,
+          "_debugID": 60,
           "_debugIsCurrentlyTiming": false,
-          "_debugNeedsRemount": false,
           "_debugOwner": null,
           "_debugSource": null,
           "actualDuration": 0,
@@ -75,7 +61,7 @@ Dropdown {
           "alternate": [Circular],
           "child": null,
           "childExpirationTime": 0,
-          "dependencies": null,
+          "contextDependencies": null,
           "effectTag": 0,
           "elementType": null,
           "expirationTime": 1073741823,
@@ -92,9 +78,7 @@ Dropdown {
           "return": null,
           "selfBaseDuration": 0,
           "sibling": null,
-          "stateNode": FiberRootNode {
-            "callbackExpirationTime": 0,
-            "callbackNode": null,
+          "stateNode": Object {
             "containerInfo": <div>
               <div
                 class="stat-dropdown-container"
@@ -113,20 +97,25 @@ Dropdown {
             </div>,
             "context": Object {},
             "current": [Circular],
-            "finishedExpirationTime": 0,
+            "didError": false,
+            "earliestPendingTime": 0,
+            "earliestSuspendedTime": 0,
+            "expirationTime": 0,
             "finishedWork": null,
             "firstBatch": null,
-            "firstPendingTime": 0,
             "hydrate": false,
-            "interactionThreadID": 16,
-            "lastPendingTime": 0,
+            "interactionThreadID": 15,
+            "latestPendingTime": 0,
+            "latestPingedTime": 0,
+            "latestSuspendedTime": 0,
             "memoizedInteractions": Set {},
+            "nextExpirationTimeToWorkOn": 0,
+            "nextScheduledRoot": null,
             "pendingChildren": null,
+            "pendingCommitExpirationTime": 0,
             "pendingContext": null,
             "pendingInteractionMap": Map {},
             "pingCache": null,
-            "pingTime": 0,
-            "tag": 0,
             "timeoutHandle": -1,
           },
           "tag": 3,
@@ -154,8 +143,6 @@ Dropdown {
                   wrappingComponentProps={null}
                 />,
               },
-              "priority": 97,
-              "suspenseConfig": null,
               "tag": 0,
             },
             "lastCapturedEffect": null,
@@ -178,16 +165,14 @@ Dropdown {
                   wrappingComponentProps={null}
                 />,
               },
-              "priority": 97,
-              "suspenseConfig": null,
               "tag": 0,
             },
           },
         },
         "child": [Circular],
         "childExpirationTime": 0,
-        "dependencies": null,
-        "effectTag": 0,
+        "contextDependencies": null,
+        "effectTag": 32,
         "elementType": null,
         "expirationTime": 0,
         "firstEffect": [Circular],
@@ -214,9 +199,7 @@ Dropdown {
         "return": null,
         "selfBaseDuration": 0,
         "sibling": null,
-        "stateNode": FiberRootNode {
-          "callbackExpirationTime": 0,
-          "callbackNode": null,
+        "stateNode": Object {
           "containerInfo": <div>
             <div
               class="stat-dropdown-container"
@@ -235,20 +218,257 @@ Dropdown {
           </div>,
           "context": Object {},
           "current": [Circular],
-          "finishedExpirationTime": 0,
+          "didError": false,
+          "earliestPendingTime": 0,
+          "earliestSuspendedTime": 0,
+          "expirationTime": 0,
           "finishedWork": null,
           "firstBatch": null,
-          "firstPendingTime": 0,
           "hydrate": false,
-          "interactionThreadID": 16,
-          "lastPendingTime": 0,
+          "interactionThreadID": 15,
+          "latestPendingTime": 0,
+          "latestPingedTime": 0,
+          "latestSuspendedTime": 0,
           "memoizedInteractions": Set {},
+          "nextExpirationTimeToWorkOn": 0,
+          "nextScheduledRoot": null,
           "pendingChildren": null,
+          "pendingCommitExpirationTime": 0,
           "pendingContext": null,
           "pendingInteractionMap": Map {},
           "pingCache": null,
-          "pingTime": 0,
-          "tag": 0,
+          "timeoutHandle": -1,
+        },
+        "tag": 3,
+        "treeBaseDuration": 0,
+        "type": null,
+        "updateQueue": Object {
+          "baseState": Object {
+            "element": <WrapperComponent
+              Component={[Function]}
+              context={null}
+              props={
+                Object {
+                  "fetchStat": [MockFunction],
+                }
+              }
+              wrappingComponentProps={null}
+            />,
+          },
+          "firstCapturedEffect": null,
+          "firstCapturedUpdate": null,
+          "firstEffect": null,
+          "firstUpdate": null,
+          "lastCapturedEffect": null,
+          "lastCapturedUpdate": null,
+          "lastEffect": null,
+          "lastUpdate": null,
+        },
+      },
+      "pendingProps": Object {
+        "Component": [Function],
+        "context": null,
+        "props": Object {
+          "fetchStat": [MockFunction],
+        },
+        "wrappingComponentProps": null,
+      },
+      "ref": null,
+      "return": FiberNode {
+        "_debugHookTypes": null,
+        "_debugID": 60,
+        "_debugIsCurrentlyTiming": false,
+        "_debugOwner": null,
+        "_debugSource": null,
+        "actualDuration": 0,
+        "actualStartTime": -1,
+        "alternate": FiberNode {
+          "_debugHookTypes": null,
+          "_debugID": 60,
+          "_debugIsCurrentlyTiming": false,
+          "_debugOwner": null,
+          "_debugSource": null,
+          "actualDuration": 0,
+          "actualStartTime": -1,
+          "alternate": [Circular],
+          "child": null,
+          "childExpirationTime": 0,
+          "contextDependencies": null,
+          "effectTag": 0,
+          "elementType": null,
+          "expirationTime": 1073741823,
+          "firstEffect": null,
+          "index": 0,
+          "key": null,
+          "lastEffect": null,
+          "memoizedProps": null,
+          "memoizedState": null,
+          "mode": 0,
+          "nextEffect": null,
+          "pendingProps": null,
+          "ref": null,
+          "return": null,
+          "selfBaseDuration": 0,
+          "sibling": null,
+          "stateNode": Object {
+            "containerInfo": <div>
+              <div
+                class="stat-dropdown-container"
+              >
+                Automations stats for
+                <span
+                  class="stat-dropdown-caret"
+                >
+                   today
+                  <img
+                    alt="down"
+                    src="/drop-down.png"
+                  />
+                </span>
+              </div>
+            </div>,
+            "context": Object {},
+            "current": [Circular],
+            "didError": false,
+            "earliestPendingTime": 0,
+            "earliestSuspendedTime": 0,
+            "expirationTime": 0,
+            "finishedWork": null,
+            "firstBatch": null,
+            "hydrate": false,
+            "interactionThreadID": 15,
+            "latestPendingTime": 0,
+            "latestPingedTime": 0,
+            "latestSuspendedTime": 0,
+            "memoizedInteractions": Set {},
+            "nextExpirationTimeToWorkOn": 0,
+            "nextScheduledRoot": null,
+            "pendingChildren": null,
+            "pendingCommitExpirationTime": 0,
+            "pendingContext": null,
+            "pendingInteractionMap": Map {},
+            "pingCache": null,
+            "timeoutHandle": -1,
+          },
+          "tag": 3,
+          "treeBaseDuration": 0,
+          "type": null,
+          "updateQueue": Object {
+            "baseState": null,
+            "firstCapturedEffect": null,
+            "firstCapturedUpdate": null,
+            "firstEffect": null,
+            "firstUpdate": Object {
+              "callback": null,
+              "expirationTime": 1073741823,
+              "next": null,
+              "nextEffect": null,
+              "payload": Object {
+                "element": <WrapperComponent
+                  Component={[Function]}
+                  context={null}
+                  props={
+                    Object {
+                      "fetchStat": [MockFunction],
+                    }
+                  }
+                  wrappingComponentProps={null}
+                />,
+              },
+              "tag": 0,
+            },
+            "lastCapturedEffect": null,
+            "lastCapturedUpdate": null,
+            "lastEffect": null,
+            "lastUpdate": Object {
+              "callback": null,
+              "expirationTime": 1073741823,
+              "next": null,
+              "nextEffect": null,
+              "payload": Object {
+                "element": <WrapperComponent
+                  Component={[Function]}
+                  context={null}
+                  props={
+                    Object {
+                      "fetchStat": [MockFunction],
+                    }
+                  }
+                  wrappingComponentProps={null}
+                />,
+              },
+              "tag": 0,
+            },
+          },
+        },
+        "child": [Circular],
+        "childExpirationTime": 0,
+        "contextDependencies": null,
+        "effectTag": 32,
+        "elementType": null,
+        "expirationTime": 0,
+        "firstEffect": [Circular],
+        "index": 0,
+        "key": null,
+        "lastEffect": [Circular],
+        "memoizedProps": null,
+        "memoizedState": Object {
+          "element": <WrapperComponent
+            Component={[Function]}
+            context={null}
+            props={
+              Object {
+                "fetchStat": [MockFunction],
+              }
+            }
+            wrappingComponentProps={null}
+          />,
+        },
+        "mode": 0,
+        "nextEffect": null,
+        "pendingProps": null,
+        "ref": null,
+        "return": null,
+        "selfBaseDuration": 0,
+        "sibling": null,
+        "stateNode": Object {
+          "containerInfo": <div>
+            <div
+              class="stat-dropdown-container"
+            >
+              Automations stats for
+              <span
+                class="stat-dropdown-caret"
+              >
+                 today
+                <img
+                  alt="down"
+                  src="/drop-down.png"
+                />
+              </span>
+            </div>
+          </div>,
+          "context": Object {},
+          "current": [Circular],
+          "didError": false,
+          "earliestPendingTime": 0,
+          "earliestSuspendedTime": 0,
+          "expirationTime": 0,
+          "finishedWork": null,
+          "firstBatch": null,
+          "hydrate": false,
+          "interactionThreadID": 15,
+          "latestPendingTime": 0,
+          "latestPingedTime": 0,
+          "latestSuspendedTime": 0,
+          "memoizedInteractions": Set {},
+          "nextExpirationTimeToWorkOn": 0,
+          "nextScheduledRoot": null,
+          "pendingChildren": null,
+          "pendingCommitExpirationTime": 0,
+          "pendingContext": null,
+          "pendingInteractionMap": Map {},
+          "pingCache": null,
           "timeoutHandle": -1,
         },
         "tag": 3,
@@ -319,12 +539,11 @@ Dropdown {
     "alternate": null,
     "child": FiberNode {
       "_debugHookTypes": null,
-      "_debugID": 125,
+      "_debugID": 64,
       "_debugIsCurrentlyTiming": false,
-      "_debugNeedsRemount": false,
       "_debugOwner": [Circular],
       "_debugSource": Object {
-        "fileName": "/Users/arnold/Andela-Project/bp-esa-frontend/src/components/StatsCard/Dropdown.jsx",
+        "fileName": "/Users/home/Documents/Projects/javascript/Andela/bp-esa/bp-esa-frontend/src/components/StatsCard/Dropdown.jsx",
         "lineNumber": 57,
       },
       "actualDuration": 0,
@@ -332,9 +551,8 @@ Dropdown {
       "alternate": null,
       "child": FiberNode {
         "_debugHookTypes": null,
-        "_debugID": 127,
+        "_debugID": 65,
         "_debugIsCurrentlyTiming": false,
-        "_debugNeedsRemount": false,
         "_debugOwner": null,
         "_debugSource": null,
         "actualDuration": 0,
@@ -342,7 +560,7 @@ Dropdown {
         "alternate": null,
         "child": null,
         "childExpirationTime": 0,
-        "dependencies": null,
+        "contextDependencies": null,
         "effectTag": 0,
         "elementType": null,
         "expirationTime": 0,
@@ -360,12 +578,11 @@ Dropdown {
         "selfBaseDuration": 0,
         "sibling": FiberNode {
           "_debugHookTypes": null,
-          "_debugID": 128,
+          "_debugID": 66,
           "_debugIsCurrentlyTiming": false,
-          "_debugNeedsRemount": false,
           "_debugOwner": [Circular],
           "_debugSource": Object {
-            "fileName": "/Users/arnold/Andela-Project/bp-esa-frontend/src/components/StatsCard/Dropdown.jsx",
+            "fileName": "/Users/home/Documents/Projects/javascript/Andela/bp-esa/bp-esa-frontend/src/components/StatsCard/Dropdown.jsx",
             "lineNumber": 59,
           },
           "actualDuration": 0,
@@ -373,9 +590,8 @@ Dropdown {
           "alternate": null,
           "child": FiberNode {
             "_debugHookTypes": null,
-            "_debugID": 131,
+            "_debugID": 67,
             "_debugIsCurrentlyTiming": false,
-            "_debugNeedsRemount": false,
             "_debugOwner": null,
             "_debugSource": null,
             "actualDuration": 0,
@@ -383,7 +599,7 @@ Dropdown {
             "alternate": null,
             "child": null,
             "childExpirationTime": 0,
-            "dependencies": null,
+            "contextDependencies": null,
             "effectTag": 0,
             "elementType": null,
             "expirationTime": 0,
@@ -401,12 +617,11 @@ Dropdown {
             "selfBaseDuration": 0,
             "sibling": FiberNode {
               "_debugHookTypes": null,
-              "_debugID": 132,
+              "_debugID": 68,
               "_debugIsCurrentlyTiming": false,
-              "_debugNeedsRemount": false,
               "_debugOwner": [Circular],
               "_debugSource": Object {
-                "fileName": "/Users/arnold/Andela-Project/bp-esa-frontend/src/components/StatsCard/Dropdown.jsx",
+                "fileName": "/Users/home/Documents/Projects/javascript/Andela/bp-esa/bp-esa-frontend/src/components/StatsCard/Dropdown.jsx",
                 "lineNumber": 60,
               },
               "actualDuration": 0,
@@ -414,7 +629,7 @@ Dropdown {
               "alternate": null,
               "child": null,
               "childExpirationTime": 0,
-              "dependencies": null,
+              "contextDependencies": null,
               "effectTag": 0,
               "elementType": "img",
               "expirationTime": 0,
@@ -453,7 +668,7 @@ Dropdown {
             "updateQueue": null,
           },
           "childExpirationTime": 0,
-          "dependencies": null,
+          "contextDependencies": null,
           "effectTag": 0,
           "elementType": "span",
           "expirationTime": 0,
@@ -511,7 +726,7 @@ Dropdown {
         "updateQueue": null,
       },
       "childExpirationTime": 0,
-      "dependencies": null,
+      "contextDependencies": null,
       "effectTag": 0,
       "elementType": "div",
       "expirationTime": 0,
@@ -580,7 +795,7 @@ Dropdown {
       "updateQueue": null,
     },
     "childExpirationTime": 0,
-    "dependencies": null,
+    "contextDependencies": null,
     "effectTag": 1,
     "elementType": [Function],
     "expirationTime": 0,
@@ -603,9 +818,8 @@ Dropdown {
     "ref": null,
     "return": FiberNode {
       "_debugHookTypes": null,
-      "_debugID": 121,
+      "_debugID": 62,
       "_debugIsCurrentlyTiming": false,
-      "_debugNeedsRemount": false,
       "_debugOwner": null,
       "_debugSource": null,
       "actualDuration": 0,
@@ -613,7 +827,7 @@ Dropdown {
       "alternate": null,
       "child": [Circular],
       "childExpirationTime": 0,
-      "dependencies": null,
+      "contextDependencies": null,
       "effectTag": 1,
       "elementType": [Function],
       "expirationTime": 0,
@@ -638,30 +852,18 @@ Dropdown {
         "wrappingComponentProps": null,
       },
       "mode": 0,
-      "nextEffect": null,
-      "pendingProps": Object {
-        "Component": [Function],
-        "context": null,
-        "props": Object {
-          "fetchStat": [MockFunction],
-        },
-        "wrappingComponentProps": null,
-      },
-      "ref": null,
-      "return": FiberNode {
+      "nextEffect": FiberNode {
         "_debugHookTypes": null,
-        "_debugID": 118,
+        "_debugID": 60,
         "_debugIsCurrentlyTiming": false,
-        "_debugNeedsRemount": false,
         "_debugOwner": null,
         "_debugSource": null,
         "actualDuration": 0,
         "actualStartTime": -1,
         "alternate": FiberNode {
           "_debugHookTypes": null,
-          "_debugID": 118,
+          "_debugID": 60,
           "_debugIsCurrentlyTiming": false,
-          "_debugNeedsRemount": false,
           "_debugOwner": null,
           "_debugSource": null,
           "actualDuration": 0,
@@ -669,7 +871,7 @@ Dropdown {
           "alternate": [Circular],
           "child": null,
           "childExpirationTime": 0,
-          "dependencies": null,
+          "contextDependencies": null,
           "effectTag": 0,
           "elementType": null,
           "expirationTime": 1073741823,
@@ -686,9 +888,7 @@ Dropdown {
           "return": null,
           "selfBaseDuration": 0,
           "sibling": null,
-          "stateNode": FiberRootNode {
-            "callbackExpirationTime": 0,
-            "callbackNode": null,
+          "stateNode": Object {
             "containerInfo": <div>
               <div
                 class="stat-dropdown-container"
@@ -707,20 +907,25 @@ Dropdown {
             </div>,
             "context": Object {},
             "current": [Circular],
-            "finishedExpirationTime": 0,
+            "didError": false,
+            "earliestPendingTime": 0,
+            "earliestSuspendedTime": 0,
+            "expirationTime": 0,
             "finishedWork": null,
             "firstBatch": null,
-            "firstPendingTime": 0,
             "hydrate": false,
-            "interactionThreadID": 16,
-            "lastPendingTime": 0,
+            "interactionThreadID": 15,
+            "latestPendingTime": 0,
+            "latestPingedTime": 0,
+            "latestSuspendedTime": 0,
             "memoizedInteractions": Set {},
+            "nextExpirationTimeToWorkOn": 0,
+            "nextScheduledRoot": null,
             "pendingChildren": null,
+            "pendingCommitExpirationTime": 0,
             "pendingContext": null,
             "pendingInteractionMap": Map {},
             "pingCache": null,
-            "pingTime": 0,
-            "tag": 0,
             "timeoutHandle": -1,
           },
           "tag": 3,
@@ -748,8 +953,6 @@ Dropdown {
                   wrappingComponentProps={null}
                 />,
               },
-              "priority": 97,
-              "suspenseConfig": null,
               "tag": 0,
             },
             "lastCapturedEffect": null,
@@ -772,16 +975,14 @@ Dropdown {
                   wrappingComponentProps={null}
                 />,
               },
-              "priority": 97,
-              "suspenseConfig": null,
               "tag": 0,
             },
           },
         },
         "child": [Circular],
         "childExpirationTime": 0,
-        "dependencies": null,
-        "effectTag": 0,
+        "contextDependencies": null,
+        "effectTag": 32,
         "elementType": null,
         "expirationTime": 0,
         "firstEffect": [Circular],
@@ -808,9 +1009,7 @@ Dropdown {
         "return": null,
         "selfBaseDuration": 0,
         "sibling": null,
-        "stateNode": FiberRootNode {
-          "callbackExpirationTime": 0,
-          "callbackNode": null,
+        "stateNode": Object {
           "containerInfo": <div>
             <div
               class="stat-dropdown-container"
@@ -829,20 +1028,257 @@ Dropdown {
           </div>,
           "context": Object {},
           "current": [Circular],
-          "finishedExpirationTime": 0,
+          "didError": false,
+          "earliestPendingTime": 0,
+          "earliestSuspendedTime": 0,
+          "expirationTime": 0,
           "finishedWork": null,
           "firstBatch": null,
-          "firstPendingTime": 0,
           "hydrate": false,
-          "interactionThreadID": 16,
-          "lastPendingTime": 0,
+          "interactionThreadID": 15,
+          "latestPendingTime": 0,
+          "latestPingedTime": 0,
+          "latestSuspendedTime": 0,
           "memoizedInteractions": Set {},
+          "nextExpirationTimeToWorkOn": 0,
+          "nextScheduledRoot": null,
           "pendingChildren": null,
+          "pendingCommitExpirationTime": 0,
           "pendingContext": null,
           "pendingInteractionMap": Map {},
           "pingCache": null,
-          "pingTime": 0,
-          "tag": 0,
+          "timeoutHandle": -1,
+        },
+        "tag": 3,
+        "treeBaseDuration": 0,
+        "type": null,
+        "updateQueue": Object {
+          "baseState": Object {
+            "element": <WrapperComponent
+              Component={[Function]}
+              context={null}
+              props={
+                Object {
+                  "fetchStat": [MockFunction],
+                }
+              }
+              wrappingComponentProps={null}
+            />,
+          },
+          "firstCapturedEffect": null,
+          "firstCapturedUpdate": null,
+          "firstEffect": null,
+          "firstUpdate": null,
+          "lastCapturedEffect": null,
+          "lastCapturedUpdate": null,
+          "lastEffect": null,
+          "lastUpdate": null,
+        },
+      },
+      "pendingProps": Object {
+        "Component": [Function],
+        "context": null,
+        "props": Object {
+          "fetchStat": [MockFunction],
+        },
+        "wrappingComponentProps": null,
+      },
+      "ref": null,
+      "return": FiberNode {
+        "_debugHookTypes": null,
+        "_debugID": 60,
+        "_debugIsCurrentlyTiming": false,
+        "_debugOwner": null,
+        "_debugSource": null,
+        "actualDuration": 0,
+        "actualStartTime": -1,
+        "alternate": FiberNode {
+          "_debugHookTypes": null,
+          "_debugID": 60,
+          "_debugIsCurrentlyTiming": false,
+          "_debugOwner": null,
+          "_debugSource": null,
+          "actualDuration": 0,
+          "actualStartTime": -1,
+          "alternate": [Circular],
+          "child": null,
+          "childExpirationTime": 0,
+          "contextDependencies": null,
+          "effectTag": 0,
+          "elementType": null,
+          "expirationTime": 1073741823,
+          "firstEffect": null,
+          "index": 0,
+          "key": null,
+          "lastEffect": null,
+          "memoizedProps": null,
+          "memoizedState": null,
+          "mode": 0,
+          "nextEffect": null,
+          "pendingProps": null,
+          "ref": null,
+          "return": null,
+          "selfBaseDuration": 0,
+          "sibling": null,
+          "stateNode": Object {
+            "containerInfo": <div>
+              <div
+                class="stat-dropdown-container"
+              >
+                Automations stats for
+                <span
+                  class="stat-dropdown-caret"
+                >
+                   today
+                  <img
+                    alt="down"
+                    src="/drop-down.png"
+                  />
+                </span>
+              </div>
+            </div>,
+            "context": Object {},
+            "current": [Circular],
+            "didError": false,
+            "earliestPendingTime": 0,
+            "earliestSuspendedTime": 0,
+            "expirationTime": 0,
+            "finishedWork": null,
+            "firstBatch": null,
+            "hydrate": false,
+            "interactionThreadID": 15,
+            "latestPendingTime": 0,
+            "latestPingedTime": 0,
+            "latestSuspendedTime": 0,
+            "memoizedInteractions": Set {},
+            "nextExpirationTimeToWorkOn": 0,
+            "nextScheduledRoot": null,
+            "pendingChildren": null,
+            "pendingCommitExpirationTime": 0,
+            "pendingContext": null,
+            "pendingInteractionMap": Map {},
+            "pingCache": null,
+            "timeoutHandle": -1,
+          },
+          "tag": 3,
+          "treeBaseDuration": 0,
+          "type": null,
+          "updateQueue": Object {
+            "baseState": null,
+            "firstCapturedEffect": null,
+            "firstCapturedUpdate": null,
+            "firstEffect": null,
+            "firstUpdate": Object {
+              "callback": null,
+              "expirationTime": 1073741823,
+              "next": null,
+              "nextEffect": null,
+              "payload": Object {
+                "element": <WrapperComponent
+                  Component={[Function]}
+                  context={null}
+                  props={
+                    Object {
+                      "fetchStat": [MockFunction],
+                    }
+                  }
+                  wrappingComponentProps={null}
+                />,
+              },
+              "tag": 0,
+            },
+            "lastCapturedEffect": null,
+            "lastCapturedUpdate": null,
+            "lastEffect": null,
+            "lastUpdate": Object {
+              "callback": null,
+              "expirationTime": 1073741823,
+              "next": null,
+              "nextEffect": null,
+              "payload": Object {
+                "element": <WrapperComponent
+                  Component={[Function]}
+                  context={null}
+                  props={
+                    Object {
+                      "fetchStat": [MockFunction],
+                    }
+                  }
+                  wrappingComponentProps={null}
+                />,
+              },
+              "tag": 0,
+            },
+          },
+        },
+        "child": [Circular],
+        "childExpirationTime": 0,
+        "contextDependencies": null,
+        "effectTag": 32,
+        "elementType": null,
+        "expirationTime": 0,
+        "firstEffect": [Circular],
+        "index": 0,
+        "key": null,
+        "lastEffect": [Circular],
+        "memoizedProps": null,
+        "memoizedState": Object {
+          "element": <WrapperComponent
+            Component={[Function]}
+            context={null}
+            props={
+              Object {
+                "fetchStat": [MockFunction],
+              }
+            }
+            wrappingComponentProps={null}
+          />,
+        },
+        "mode": 0,
+        "nextEffect": null,
+        "pendingProps": null,
+        "ref": null,
+        "return": null,
+        "selfBaseDuration": 0,
+        "sibling": null,
+        "stateNode": Object {
+          "containerInfo": <div>
+            <div
+              class="stat-dropdown-container"
+            >
+              Automations stats for
+              <span
+                class="stat-dropdown-caret"
+              >
+                 today
+                <img
+                  alt="down"
+                  src="/drop-down.png"
+                />
+              </span>
+            </div>
+          </div>,
+          "context": Object {},
+          "current": [Circular],
+          "didError": false,
+          "earliestPendingTime": 0,
+          "earliestSuspendedTime": 0,
+          "expirationTime": 0,
+          "finishedWork": null,
+          "firstBatch": null,
+          "hydrate": false,
+          "interactionThreadID": 15,
+          "latestPendingTime": 0,
+          "latestPingedTime": 0,
+          "latestSuspendedTime": 0,
+          "memoizedInteractions": Set {},
+          "nextExpirationTimeToWorkOn": 0,
+          "nextScheduledRoot": null,
+          "pendingChildren": null,
+          "pendingCommitExpirationTime": 0,
+          "pendingContext": null,
+          "pendingInteractionMap": Map {},
+          "pingCache": null,
           "timeoutHandle": -1,
         },
         "tag": 3,

--- a/src/__tests__/components/StatsCard/__snapshots__/StatsCard.test.jsx.snap
+++ b/src/__tests__/components/StatsCard/__snapshots__/StatsCard.test.jsx.snap
@@ -216,9 +216,7 @@ ShallowWrapper {
         },
       },
     },
-    Symbol(enzyme.__providerValues__): undefined,
   },
-  Symbol(enzyme.__providerValues__): Map {},
   Symbol(enzyme.__childContext__): null,
 }
 `;

--- a/src/__tests__/components/__snapshots__/Header.test.jsx.snap
+++ b/src/__tests__/components/__snapshots__/Header.test.jsx.snap
@@ -1373,9 +1373,7 @@ ShallowWrapper {
         },
       },
     },
-    Symbol(enzyme.__providerValues__): undefined,
   },
-  Symbol(enzyme.__providerValues__): Map {},
   Symbol(enzyme.__childContext__): null,
 }
 `;
@@ -2729,9 +2727,7 @@ ShallowWrapper {
         },
       },
     },
-    Symbol(enzyme.__providerValues__): undefined,
   },
-  Symbol(enzyme.__providerValues__): Map {},
   Symbol(enzyme.__childContext__): null,
 }
 `;

--- a/src/__tests__/components/__snapshots__/Pagination.test.jsx.snap
+++ b/src/__tests__/components/__snapshots__/Pagination.test.jsx.snap
@@ -2,6 +2,21 @@
 
 exports[`Pagination Component renders the pagination component 1`] = `
 ReactWrapper {
+  Symbol(enzyme.__unrendered__): <Pagination
+    currentPage={2}
+    handlePagination={[MockFunction]}
+    limit={10}
+    onChangeRowCount={[MockFunction]}
+    onPageChange={[MockFunction]}
+    pageNumber={1}
+    pagination={
+      Object {
+        "currentPage": 1,
+        "numberOfPages": 1120,
+      }
+    }
+    tempCurrentPage={false}
+  />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
     "getNode": [Function],
@@ -1692,22 +1707,5 @@ ReactWrapper {
       },
     },
   },
-  Symbol(enzyme.__linkedRoots__): Array [],
-  Symbol(enzyme.__unrendered__): <Pagination
-    currentPage={2}
-    handlePagination={[MockFunction]}
-    limit={10}
-    onChangeRowCount={[MockFunction]}
-    onPageChange={[MockFunction]}
-    pageNumber={1}
-    pagination={
-      Object {
-        "currentPage": 1,
-        "numberOfPages": 1120,
-      }
-    }
-    tempCurrentPage={false}
-  />,
-  Symbol(enzyme.__updatedBy__): null,
 }
 `;

--- a/src/__tests__/components/__snapshots__/ProgressBar.test.jsx.snap
+++ b/src/__tests__/components/__snapshots__/ProgressBar.test.jsx.snap
@@ -86,9 +86,7 @@ ShallowWrapper {
         },
       },
     },
-    Symbol(enzyme.__providerValues__): undefined,
   },
-  Symbol(enzyme.__providerValues__): Map {},
 }
 `;
 
@@ -178,9 +176,7 @@ ShallowWrapper {
         },
       },
     },
-    Symbol(enzyme.__providerValues__): undefined,
   },
-  Symbol(enzyme.__providerValues__): Map {},
 }
 `;
 
@@ -270,8 +266,6 @@ ShallowWrapper {
         },
       },
     },
-    Symbol(enzyme.__providerValues__): undefined,
   },
-  Symbol(enzyme.__providerValues__): Map {},
 }
 `;

--- a/src/__tests__/components/__snapshots__/UpdateTabe.test.jsx.snap
+++ b/src/__tests__/components/__snapshots__/UpdateTabe.test.jsx.snap
@@ -122,8 +122,6 @@ ShallowWrapper {
         },
       },
     },
-    Symbol(enzyme.__providerValues__): undefined,
   },
-  Symbol(enzyme.__providerValues__): Map {},
 }
 `;

--- a/src/__tests__/components/__snapshots__/login.test.jsx.snap
+++ b/src/__tests__/components/__snapshots__/login.test.jsx.snap
@@ -818,9 +818,7 @@ ShallowWrapper {
         },
       },
     },
-    Symbol(enzyme.__providerValues__): undefined,
   },
-  Symbol(enzyme.__providerValues__): Map {},
   Symbol(enzyme.__childContext__): null,
 }
 `;

--- a/src/components/ReportNavBar/index.jsx
+++ b/src/components/ReportNavBar/index.jsx
@@ -1,70 +1,127 @@
-import * as React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'proptypes';
 import './styles.scss';
 import FilterComponent from '../FilterComponent';
 import Dropdown from '../StatsCard/Dropdown';
 
-const ReportNavBar = ({ isStats, fetchStat, renderView, viewMode, ...props }) => {
-  const activeTableView = viewMode === 'listView' ? '-active' : '';
-  const activeCardView = viewMode === 'cardView' ? '-active' : '';
-  return (
-  <React.Fragment>
-    {
-      isStats ? (
-        <div className="left-navbar">
-          <React.Fragment>
-            <Dropdown {...props} fetchStat={fetchStat} />
-          </React.Fragment>
-        </div>
-      ) : (
-        <div className="report-navbar-container">
-          <div className="report-navbar">
-            <p>View:</p>
-            <svg version="1.1" viewBox="0.0 0.0 960.0 720.0" fill="none" stroke="none" strokeLinecap="square" strokeMiterlimit="10" xmlnsXlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg" id="card-icon" className={`view-button${activeCardView}`} onClick={renderView('card')}>
-              <clipPath id="p.0"><path d="m0 0l960.0 0l0 720.0l-960.0 0l0 -720.0z" clipRule="nonzero" /></clipPath>
-              <g clipPath="url(#p.0)">
-                <path fill="#000000" fillOpacity="0.0" d="m0 0l960.0 0l0 720.0l-960.0 0z" fillRule="evenodd" />
-                <path fill="#000000" d="m243.45009 -0.17608136l-242.82036 0l0 194.1241l242.82036 0z" fillRule="evenodd" />
-                <path stroke="#000000" strokeWidth="1.0" strokeLinejoin="round" strokeLinecap="butt" d="m243.45009 -0.17608136l-242.82036 0l0 194.1241l242.82036 0z" fillRule="evenodd" />
-                <path fill="#000000" d="m601.4111 -0.17608136l-242.82034 0l0 194.1241l242.82034 0z" fillRule="evenodd" />
-                <path stroke="#000000" strokeWidth="1.0" strokeLinejoin="round" strokeLinecap="butt" d="m601.4111 -0.17608136l-242.82034 0l0 194.1241l242.82034 0z" fillRule="evenodd" />
-                <path fill="#000000" d="m959.372 -0.17608136l-242.82031 0l0 194.1241l242.82031 0z" fillRule="evenodd" />
-                <path stroke="#000000" strokeWidth="1.0" strokeLinejoin="round" strokeLinecap="butt" d="m959.372 -0.17608136l-242.82031 0l0 194.1241l242.82031 0z" fillRule="evenodd" />
-                <path fill="#000000" d="m243.45009 262.47488l-242.82036 0l0 194.12408l242.82036 0z" fillRule="evenodd" />
-                <path stroke="#000000" strokeWidth="1.0" strokeLinejoin="round" strokeLinecap="butt" d="m243.45009 262.47488l-242.82036 0l0 194.12408l242.82036 0z" fillRule="evenodd" />
-                <path fill="#000000" d="m601.4111 262.47488l-242.82034 0l0 194.12408l242.82034 0z" fillRule="evenodd" />
-                <path stroke="#000000" strokeWidth="1.0" strokeLinejoin="round" strokeLinecap="butt" d="m601.4111 262.47488l-242.82034 0l0 194.12408l242.82034 0z" fillRule="evenodd" />
-                <path fill="#000000" d="m959.372 262.47488l-242.82031 0l0 194.12408l242.82031 0z" fillRule="evenodd" />
-                <path stroke="#000000" strokeWidth="1.0" strokeLinejoin="round" strokeLinecap="butt" d="m959.372 262.47488l-242.82031 0l0 194.12408l242.82031 0z" fillRule="evenodd" />
-                <path fill="#000000" d="m243.45009 525.12585l-242.82036 0l0 194.12408l242.82036 0z" fillRule="evenodd" />
-                <path stroke="#000000" strokeWidth="1.0" strokeLinejoin="round" strokeLinecap="butt" d="m243.45009 525.12585l-242.82036 0l0 194.12408l242.82036 0z" fillRule="evenodd" />
-                <path fill="#000000" d="m602.9698 525.1262l-242.82031 0l0 196.35175l242.82031 0z" fillRule="evenodd" />
-                <path stroke="#000000" strokeWidth="1.0" strokeLinejoin="round" strokeLinecap="butt" d="m602.9698 525.1262l-242.82031 0l0 196.35175l242.82031 0z" fillRule="evenodd" />
-                <path fill="#000000" d="m959.372 525.12585l-242.82031 0l0 194.12408l242.82031 0z" fillRule="evenodd" />
-                <path stroke="#000000" strokeWidth="1.0" strokeLinejoin="round" strokeLinecap="butt" d="m959.372 525.12585l-242.82031 0l0 194.12408l242.82031 0z" fillRule="evenodd" />
-              </g>
-            </svg>
-            <svg height="512pt" viewBox="0 -52 512.00001 512" width="512pt" xmlns="http://www.w3.org/2000/svg" className={`view-button${activeTableView}`} onClick={renderView('list')} id="list-icon">
-              <path d="m0 113.292969h113.292969v-113.292969h-113.292969zm30.003906-83.289063h53.289063v53.289063h-53.289063zm0 0" />
-              <path d="m149.296875 0v113.292969h362.703125v-113.292969zm332.699219 83.292969h-302.695313v-53.289063h302.695313zm0 0" />
-              <path d="m0 260.300781h113.292969v-113.292969h-113.292969zm30.003906-83.292969h53.289063v53.289063h-53.289063zm0 0" />
-              <path d="m149.296875 260.300781h362.703125v-113.292969h-362.703125zm30.003906-83.292969h302.695313v53.289063h-302.695313zm0 0" />
-              <path d="m0 407.308594h113.292969v-113.296875h-113.292969zm30.003906-83.292969h53.289063v53.289063h-53.289063zm0 0" />
-              <path d="m149.296875 407.308594h362.703125v-113.296875h-362.703125zm30.003906-83.292969h302.695313v53.289063h-302.695313zm0 0" />
-            </svg>
-            <FilterComponent {...props} />
+class ReportNavBar extends Component {
+  state = {
+    isOpen: false,
+  };
+
+  toggleOpen = () => this.setState({ isOpen: !this.state.isOpen });
+
+  renderDownloadButton() {
+    const { isOpen } = this.state;
+    const menuClass = `dropdown-menu${ isOpen ? ' show' : ''}`;
+    const { onClick } = this.props;
+    return (
+        <React.Fragment>
+          <div className="dropdown" onClick={this.toggleOpen}>
+            <button
+                className="btn btn-outline-primary dropdown-toggle"
+                type="button"
+                id="dropdownMenuButton"
+            >
+              Download
+            </button>
+            <div className={menuClass} aria-labelledby="dropdownMenuButton">
+              <button  id="csv" type="submit" name="fileType" className="dropdown-item" value="csv" onClick={onClick}>
+                csv
+              </button>
+              <button type="submit" name="fileType" className="dropdown-item" value="xls" onClick={onClick}>
+                xls
+              </button>
+            </div>
           </div>
-        </div>
-      )
-    }
-  </React.Fragment>
-  );
-};
+        </React.Fragment>
+    );
+  }
+
+  renderListView () {
+    const {renderView, viewMode} = this.props;
+    const activeTableView = viewMode === 'listView' ? '-active' : '';
+    return (
+        <React.Fragment>
+          <svg height="512pt" viewBox="0 -52 512.00001 512" width="512pt" xmlns="http://www.w3.org/2000/svg" className={`view-button${activeTableView}`} onClick={renderView('list')} id="list-icon">
+            <path d="m0 113.292969h113.292969v-113.292969h-113.292969zm30.003906-83.289063h53.289063v53.289063h-53.289063zm0 0" />
+            <path d="m149.296875 0v113.292969h362.703125v-113.292969zm332.699219 83.292969h-302.695313v-53.289063h302.695313zm0 0" />
+            <path d="m0 260.300781h113.292969v-113.292969h-113.292969zm30.003906-83.292969h53.289063v53.289063h-53.289063zm0 0" />
+            <path d="m149.296875 260.300781h362.703125v-113.292969h-362.703125zm30.003906-83.292969h302.695313v53.289063h-302.695313zm0 0" />
+            <path d="m0 407.308594h113.292969v-113.296875h-113.292969zm30.003906-83.292969h53.289063v53.289063h-53.289063zm0 0" />
+            <path d="m149.296875 407.308594h362.703125v-113.296875h-362.703125zm30.003906-83.292969h302.695313v53.289063h-302.695313zm0 0" />
+          </svg>
+        </React.Fragment>
+    )
+  }
+
+  renderCardView () {
+    const {renderView, viewMode} = this.props;
+    const activeCardView = viewMode === 'cardView' ? '-active' : '';
+    return (
+        <React.Fragment>
+          <svg version="1.1" viewBox="0.0 0.0 960.0 720.0" fill="none" stroke="none" strokeLinecap="square" strokeMiterlimit="10" xmlnsXlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg" id="card-icon" className={`view-button${activeCardView}`} onClick={renderView('card')}>
+            <clipPath id="p.0"><path d="m0 0l960.0 0l0 720.0l-960.0 0l0 -720.0z" clipRule="nonzero" /></clipPath>
+            <g clipPath="url(#p.0)">
+              <path fill="#000000" fillOpacity="0.0" d="m0 0l960.0 0l0 720.0l-960.0 0z" fillRule="evenodd" />
+              <path fill="#000000" d="m243.45009 -0.17608136l-242.82036 0l0 194.1241l242.82036 0z" fillRule="evenodd" />
+              <path stroke="#000000" strokeWidth="1.0" strokeLinejoin="round" strokeLinecap="butt" d="m243.45009 -0.17608136l-242.82036 0l0 194.1241l242.82036 0z" fillRule="evenodd" />
+              <path fill="#000000" d="m601.4111 -0.17608136l-242.82034 0l0 194.1241l242.82034 0z" fillRule="evenodd" />
+              <path stroke="#000000" strokeWidth="1.0" strokeLinejoin="round" strokeLinecap="butt" d="m601.4111 -0.17608136l-242.82034 0l0 194.1241l242.82034 0z" fillRule="evenodd" />
+              <path fill="#000000" d="m959.372 -0.17608136l-242.82031 0l0 194.1241l242.82031 0z" fillRule="evenodd" />
+              <path stroke="#000000" strokeWidth="1.0" strokeLinejoin="round" strokeLinecap="butt" d="m959.372 -0.17608136l-242.82031 0l0 194.1241l242.82031 0z" fillRule="evenodd" />
+              <path fill="#000000" d="m243.45009 262.47488l-242.82036 0l0 194.12408l242.82036 0z" fillRule="evenodd" />
+              <path stroke="#000000" strokeWidth="1.0" strokeLinejoin="round" strokeLinecap="butt" d="m243.45009 262.47488l-242.82036 0l0 194.12408l242.82036 0z" fillRule="evenodd" />
+              <path fill="#000000" d="m601.4111 262.47488l-242.82034 0l0 194.12408l242.82034 0z" fillRule="evenodd" />
+              <path stroke="#000000" strokeWidth="1.0" strokeLinejoin="round" strokeLinecap="butt" d="m601.4111 262.47488l-242.82034 0l0 194.12408l242.82034 0z" fillRule="evenodd" />
+              <path fill="#000000" d="m959.372 262.47488l-242.82031 0l0 194.12408l242.82031 0z" fillRule="evenodd" />
+              <path stroke="#000000" strokeWidth="1.0" strokeLinejoin="round" strokeLinecap="butt" d="m959.372 262.47488l-242.82031 0l0 194.12408l242.82031 0z" fillRule="evenodd" />
+              <path fill="#000000" d="m243.45009 525.12585l-242.82036 0l0 194.12408l242.82036 0z" fillRule="evenodd" />
+              <path stroke="#000000" strokeWidth="1.0" strokeLinejoin="round" strokeLinecap="butt" d="m243.45009 525.12585l-242.82036 0l0 194.12408l242.82036 0z" fillRule="evenodd" />
+              <path fill="#000000" d="m602.9698 525.1262l-242.82031 0l0 196.35175l242.82031 0z" fillRule="evenodd" />
+              <path stroke="#000000" strokeWidth="1.0" strokeLinejoin="round" strokeLinecap="butt" d="m602.9698 525.1262l-242.82031 0l0 196.35175l242.82031 0z" fillRule="evenodd" />
+              <path fill="#000000" d="m959.372 525.12585l-242.82031 0l0 194.12408l242.82031 0z" fillRule="evenodd" />
+              <path stroke="#000000" strokeWidth="1.0" strokeLinejoin="round" strokeLinecap="butt" d="m959.372 525.12585l-242.82031 0l0 194.12408l242.82031 0z" fillRule="evenodd" />
+            </g>
+          </svg>
+        </React.Fragment>
+    );
+  }
+
+  render() {
+    const { isStats, fetchStat, ...props } = this.props;
+
+
+    return (
+        <React.Fragment>
+          {isStats ? (
+                <div className="left-navbar">
+                  <React.Fragment>
+                    <Dropdown {...props} fetchStat={fetchStat} />
+                  </React.Fragment>
+                </div>
+            ) : (
+                <div className="report-navbar-container">
+                  <div className="report-navbar">
+                    <p>View:</p>
+                    {this.renderCardView()}
+                    {this.renderListView()}
+                    <FilterComponent {...props} />
+                    {this.renderDownloadButton()}
+                  </div>
+                </div>
+          )
+          }
+        </React.Fragment>
+    );
+  }
+}
 
 ReportNavBar.propTypes = {
   isStats: PropTypes.bool,
   renderView: PropTypes.func,
   viewMode: PropTypes.string,
+  onClick: PropTypes.func.isRequired,
 
 };
 

--- a/src/components/ReportNavBar/styles.scss
+++ b/src/components/ReportNavBar/styles.scss
@@ -50,7 +50,7 @@
   .report-navbar-container {
     font-size: 1rem;
     .report-navbar {
-      grid-template-columns: repeat(3, max-content) 1fr;
+      grid-template-columns: repeat(4, max-content) 1fr;
 
       >p {
         display: block;

--- a/src/fixtures/fixtures.js
+++ b/src/fixtures/fixtures.js
@@ -89,6 +89,12 @@ const sampleReports = {
     dataCount: '13112',
     nextPage: 2,
   },
+  newPagination: {
+    currentPage: 1,
+    numberOfPages: 1,
+    dataCount: '13112',
+    nextPage: 2,
+  },
 };
 
 const stats = {

--- a/src/redux/api/__tests__/automationAPI.test.js
+++ b/src/redux/api/__tests__/automationAPI.test.js
@@ -52,4 +52,26 @@ describe('Automation API', () => {
     await AutomationAPI.retryAutomation();
     done();
   });
+
+  it('should return unpaginated data from the API', async (done) => {
+    const newPagination = { currentPage: 1, limit: -1 };
+    moxios.stubRequest(`${mockUrl}`, {
+      status: 200,
+      response: {
+        message: 'Resource successfully retried',
+      },
+    });
+    await AutomationAPI.getReportURL(newPagination, filterInitialState);
+    done();
+  });
+  it('should return unpaginated data from the API', async (done) => {
+    moxios.stubRequest(`${mockUrl}`, {
+      status: 200,
+      response: {
+        message: 'Resource successfully retried',
+      },
+    });
+    await AutomationAPI.fetchReport();
+    done();
+  });
 });

--- a/src/redux/api/automationAPI.js
+++ b/src/redux/api/automationAPI.js
@@ -3,38 +3,54 @@ import URL from 'url';
 import resolveUrl from '.';
 
 const baseUrl = resolveUrl();
+const parsedAutomationsURL = URL.parse(`${baseUrl}/automations`);
+const parsedDataURL = URL.parse(`${baseUrl}/automations/downloadReport`);
+
+const filteredData = (filters) => {
+  const filterCopy = { ...filters };
+  delete filterCopy.showFilterDropdown;
+  delete filterCopy.date;
+  filterCopy.searchBy = filterCopy['search-by'];
+  filterCopy.type = filterCopy['automation-type'];
+  delete filterCopy['search-by'];
+  delete filterCopy['automation-type'];
+  /* eslint-disable no-mixed-operators */
+  return {
+    ...filterCopy,
+    'date[from]': filters.date.from && filters.date.from.toISOString() || undefined,
+    'date[to]': filters.date.to && filters.date.to.toISOString() || undefined,
+  };
+};
 class AutomationAPI {
   static async getAutomations(pagination, filters) {
-    const filterCopy = { ...filters };
-    delete filterCopy.showFilterDropdown;
-    delete filterCopy.date;
-    filterCopy.searchBy = filterCopy['search-by'];
-    filterCopy.type = filterCopy['automation-type'];
-    delete filterCopy['search-by'];
-    delete filterCopy['automation-type'];
-    /* eslint-disable no-mixed-operators */
-    const filterQuery = {
-      ...filterCopy,
-      'date[from]': (filters.date.from && filters.date.from.toISOString()) || undefined,
-      'date[to]': (filters.date.to && filters.date.to.toISOString()) || undefined,
-    };
-    /* eslint-enable no-mixed-operators */
-
-    const parsedAutomationsURL = URL.parse(`${baseUrl}/automations`);
-
     const filterURL = URL.format({
       ...parsedAutomationsURL,
       query: {
         page: pagination.currentPage,
         limit: pagination.limit,
-        ...filterQuery,
+        ...filteredData(filters),
       },
     });
     return axios.get(filterURL);
   }
 
+  static getReportURL(newPagination, filters) {
+    return URL.format({
+      ...parsedDataURL,
+      query: {
+        page: newPagination.currentPage,
+        limit: newPagination.limit,
+        ...filteredData(filters),
+      },
+    });
+  }
+
   static async retryAutomation(automationId) {
     return axios.get(`${baseUrl}/automations/${automationId}`);
+  }
+
+  static fetchReport() {
+    return axios.get(`${baseUrl}/automations/fetchReport`, { responseType: 'blob' });
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4737,6 +4737,11 @@ file-loader@2.0.0:
     loader-utils "^1.0.2"
     schema-utils "^1.0.0"
 
+file-saver@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/file-saver/-/file-saver-2.0.2.tgz#06d6e728a9ea2df2cce2f8d9e84dfcdc338ec17a"
+  integrity sha512-Wz3c3XQ5xroCxd1G8b7yL0Ehkf0TC9oYC6buPFkNnU9EnaPlifeAFCyCh+iewXTyFRcg0a6j3J7FmJsIhlhBdw==
+
 filename-regex@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/filename-regex/-/filename-regex-2.0.1.tgz#c1c4b9bee3e09725ddb106b75c1e301fe2f18b26"


### PR DESCRIPTION
#### What does this PR do?


#### Description of Task to be completed?


#### How should this be manually tested?
1. On browser, goto url ...



#### Any background context you want to provide?


#### What are the relevant notion stories?
[](https://www.notion.so/Create-Acceptance-Tests-for-Searching-Team-Members-5263206ae50343c996aaec19fe6d62b6)

#### Postman Documentation


#### Screenshots (If applicable)