### PR TITLE
168080865: make partner name clickable

### DIFF
--- a/src/__tests__/components/Dashboard/__snapshots__/Card.test.jsx.snap
+++ b/src/__tests__/components/Dashboard/__snapshots__/Card.test.jsx.snap
@@ -708,7 +708,7 @@ ReactWrapper {
           "_debugIsCurrentlyTiming": false,
           "_debugOwner": [Circular],
           "_debugSource": Object {
-            "fileName": "/Users/davidmuhanguzi/Documents/Andela/D1/bp-esa-frontend/src/components/Dashboard/Card.jsx",
+            "fileName": "/Users/arnold/Andela-Project/bp-esa-frontend/src/components/Dashboard/Card.jsx",
             "lineNumber": 20,
           },
           "actualDuration": 0,
@@ -720,7 +720,7 @@ ReactWrapper {
             "_debugIsCurrentlyTiming": false,
             "_debugOwner": [Circular],
             "_debugSource": Object {
-              "fileName": "/Users/davidmuhanguzi/Documents/Andela/D1/bp-esa-frontend/src/components/Dashboard/Card.jsx",
+              "fileName": "/Users/arnold/Andela-Project/bp-esa-frontend/src/components/Dashboard/Card.jsx",
               "lineNumber": 21,
             },
             "actualDuration": 0,
@@ -2299,7 +2299,7 @@ ReactWrapper {
             "_debugIsCurrentlyTiming": false,
             "_debugOwner": [Circular],
             "_debugSource": Object {
-              "fileName": "/Users/davidmuhanguzi/Documents/Andela/D1/bp-esa-frontend/src/components/Dashboard/Card.jsx",
+              "fileName": "/Users/arnold/Andela-Project/bp-esa-frontend/src/components/Dashboard/Card.jsx",
               "lineNumber": 20,
             },
             "actualDuration": 0,
@@ -2311,7 +2311,7 @@ ReactWrapper {
               "_debugIsCurrentlyTiming": false,
               "_debugOwner": [Circular],
               "_debugSource": Object {
-                "fileName": "/Users/davidmuhanguzi/Documents/Andela/D1/bp-esa-frontend/src/components/Dashboard/Card.jsx",
+                "fileName": "/Users/arnold/Andela-Project/bp-esa-frontend/src/components/Dashboard/Card.jsx",
                 "lineNumber": 21,
               },
               "actualDuration": 0,

--- a/src/__tests__/components/ReportPage.test.jsx
+++ b/src/__tests__/components/ReportPage.test.jsx
@@ -71,6 +71,18 @@ describe('ReportPage Component', () => {
     expect(global.open).toHaveBeenCalled();
   });
 
+  it('should redirect to allocations page when you click partner\'s name', () => {
+    component.setState({ viewMode: 'listView' });
+    const redirectToAllocations = component.find('.table-body')
+      .find('tbody')
+      .find('tr')
+      .find('#partnerName')
+      .at(0);
+    global.open = jest.fn();
+    redirectToAllocations.simulate('click');
+    expect(global.open).toHaveBeenCalled();
+  });
+
   it('updates the page limit', () => {
     const { pagination, filters } = component.state();
     const limitSelection = component.find('.select');

--- a/src/__tests__/components/StatsCard/__snapshots__/Dropdown.test.jsx.snap
+++ b/src/__tests__/components/StatsCard/__snapshots__/Dropdown.test.jsx.snap
@@ -543,7 +543,7 @@ Dropdown {
       "_debugIsCurrentlyTiming": false,
       "_debugOwner": [Circular],
       "_debugSource": Object {
-        "fileName": "/Users/davidmuhanguzi/Documents/Andela/D1/bp-esa-frontend/src/components/StatsCard/Dropdown.jsx",
+        "fileName": "/Users/arnold/Andela-Project/bp-esa-frontend/src/components/StatsCard/Dropdown.jsx",
         "lineNumber": 57,
       },
       "actualDuration": 0,
@@ -582,7 +582,7 @@ Dropdown {
           "_debugIsCurrentlyTiming": false,
           "_debugOwner": [Circular],
           "_debugSource": Object {
-            "fileName": "/Users/davidmuhanguzi/Documents/Andela/D1/bp-esa-frontend/src/components/StatsCard/Dropdown.jsx",
+            "fileName": "/Users/arnold/Andela-Project/bp-esa-frontend/src/components/StatsCard/Dropdown.jsx",
             "lineNumber": 59,
           },
           "actualDuration": 0,
@@ -621,7 +621,7 @@ Dropdown {
               "_debugIsCurrentlyTiming": false,
               "_debugOwner": [Circular],
               "_debugSource": Object {
-                "fileName": "/Users/davidmuhanguzi/Documents/Andela/D1/bp-esa-frontend/src/components/StatsCard/Dropdown.jsx",
+                "fileName": "/Users/arnold/Andela-Project/bp-esa-frontend/src/components/StatsCard/Dropdown.jsx",
                 "lineNumber": 60,
               },
               "actualDuration": 0,

--- a/src/components/FilterComponent/index.jsx
+++ b/src/components/FilterComponent/index.jsx
@@ -117,7 +117,7 @@ class FilterComponent extends React.PureComponent {
 }
 
 FilterComponent.propTypes = {
-  filter: PropTypes.object.isRequired,
+  filter: PropTypes.func.isRequired,
 };
 
 export default FilterComponent;

--- a/src/components/ReportPage/index.jsx
+++ b/src/components/ReportPage/index.jsx
@@ -264,6 +264,7 @@ export class ReportPage extends Component {
         fellowId: developerId,
         fellowName: developerName,
         partnerName,
+        partnerId,
         type,
       } = report;
       return (
@@ -281,7 +282,13 @@ export class ReportPage extends Component {
               <i className="fas fa-external-link-alt" />
             </span>
           </td>
-          <td title={report.partnerName}>{partnerName}</td>
+          <td
+            title={partnerName}
+            id="partnerName"
+            onClick={() => window.open(`https://ais.andela.com/partners/${partnerId}`)}
+          >
+            {partnerName}
+          </td>
           <td>{type}</td>
           <td>{this.renderAutomationStatus(report.slackAutomations.status, report, 'slack')}</td>
           <td>{this.renderAutomationStatus(report.emailAutomations.status, report, 'email')}</td>


### PR DESCRIPTION
#### What does this PR do?
- make partner name clickable in the list view mode

#### Description of Task to be completed?
- A user should be able to click on the partner name in the list view and in response, a new tab should be opened to display the allocations page through which a user is able to search for the given partner name

#### How should this be manually tested?
1. clone the repo, checkout to the `ft-make-partner-name-clickable-168080865` and install all the dependencies.
2. run the server using this command `yarn start`
3. head over to the browser and paste this url `http://localhost:3000/`
4. select dashboard in the navigation bar
5. Then select list view
6. Click any partner name in the list view and a new tab window should open up  

#### Any background context you want to provide?
- N/A
#### What are the relevant pivotal tracker stories?
[168080865](https://www.pivotaltracker.com/story/show/168080865)